### PR TITLE
Remove the undefined property in build.xml.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -122,7 +122,7 @@
     </target>
 
     <target name="run" depends="dist">
-        <java fork="true" jar="${floodlight-jar}" classpath="${jar}" classpathref="classpath">
+        <java fork="true" jar="${floodlight-jar}" classpathref="classpath">
             <jvmarg value="-server"/>
             <jvmarg value="-Xms1024M"/>
             <jvmarg value="-Xmx1024M"/>


### PR DESCRIPTION
Dear Floodlight developers, 

The property "jar" was used as the classpath attribute in the target "run" of build.xml, but the property is not defined in the file. Then, I removed the classpath attribute.

Regards.
