### PR TITLE
Fixed a typo in a javadoc comment.

### DIFF
--- a/src/main/java/net/floodlightcontroller/packet/ICMP.java
+++ b/src/main/java/net/floodlightcontroller/packet/ICMP.java
@@ -51,7 +51,7 @@ public class ICMP extends BasePacket {
     }
 
     /**
-     * @param icmp code to set
+     * @param icmpCode code to set
      */
     public ICMP setIcmpCode(byte icmpCode) {
         this.icmpCode = icmpCode;


### PR DESCRIPTION
I found a kind of typo in a javadoc comment in ICMP class and fixed it. 
