### PR TITLE
Fix mismatches of parameter names in Javadoc.

### DIFF
--- a/src/main/java/net/floodlightcontroller/counter/CountSeries.java
+++ b/src/main/java/net/floodlightcontroller/counter/CountSeries.java
@@ -63,7 +63,6 @@ public class CountSeries {
   /**
    * Return a long that is the number of milliseconds in a ds (second/minute/hour/day/week).  (Utility method.)
    * 
-   * @param d
    * @param ds
    * @return
    */

--- a/src/main/java/net/floodlightcontroller/counter/CounterStore.java
+++ b/src/main/java/net/floodlightcontroller/counter/CounterStore.java
@@ -139,7 +139,8 @@ public class CounterStore {
      * Create a new ICounter and set the title.  Note that the title must be unique, otherwise this will
      * throw an IllegalArgumentException.
      * 
-     * @param title
+     * @param key
+     * @param type
      * @return
      */
     public ICounter createCounter(String key, CounterValue.CounterType type) {

--- a/src/main/java/net/floodlightcontroller/counter/ICounter.java
+++ b/src/main/java/net/floodlightcontroller/counter/ICounter.java
@@ -63,7 +63,7 @@ public interface ICounter {
    * Returns a CountSeries that is a snapshot of the counter's values for the given dateSpan.  (Further changes
    * to this counter won't be reflected in the CountSeries that comes  back.)
    * 
-   * @param startDate
+   * @param dateSpan
    * @return
    */
   public CountSeries snapshot(DateSpan dateSpan);

--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
@@ -1285,7 +1285,7 @@ public class DeviceManagerImpl implements IDeviceManager, IOFMessageListener,
      * Puts an update in queue to indicate the Device moved.  Must be called
      * from within the write lock.
      * @param device The device that has moved.
-     * @param oldPort The old switchport
+     * @param oldSwPort The old switchport
      * @param newDap The new attachment point
      */
     protected void updateMoved(Device device, SwitchPortTuple oldSwPort, 
@@ -1341,7 +1341,7 @@ public class DeviceManagerImpl implements IDeviceManager, IOFMessageListener,
     /**
      * Removes any attachment points that are in the same 
      * {@link net.floodlightcontroller.topology.SwitchCluster SwitchCluster} 
-     * @param The device to update the attachment points
+     * @param d The device to update the attachment points
      */
     public void cleanupAttachmentPoints(Device d) {
         // The long here is the SwitchCluster ID


### PR DESCRIPTION
I found mismatches of parameter names between, and fixed them.
