### PR TITLE
Support for cbench via command-line switch

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/CmdLineSettings.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/CmdLineSettings.java
@@ -3,16 +3,21 @@ package net.floodlightcontroller.core.internal;
 import org.kohsuke.args4j.Option;
 
 /**
- * Expresses the port settings of OpenFlow controller.
+ * Expresses the command line settings of the OpenFlow controller.
  */
-public class PortSettings {
+public class CmdLineSettings {
     private final int DEFAULT_OPENFLOW_PORT = 6633;
     private final int DEFAULT_REST_PORT = 8080;
+    private final boolean DEFAULT_CBENCH_SUPPORT = false;
 
     @Option(name="-ofp", aliases="--openFlowPort",metaVar="PORT", usage="Port number for OpenFlow")
     private int openFlowPort = DEFAULT_OPENFLOW_PORT;
+    
     @Option(name="-rp", aliases="--restPort", metaVar="PORT", usage="Port number for REST API")
     private int restPort = DEFAULT_REST_PORT;
+    
+    @Option(name="-cbench", aliases="--cbenchSupport", usage="Support for cbench (dummy) switch")
+    private boolean cbenchSupported = DEFAULT_CBENCH_SUPPORT;
     
     public int getOpenFlowPort() {
         return openFlowPort;
@@ -20,5 +25,9 @@ public class PortSettings {
 
     public int getRestPort() {
         return restPort;
+    }
+    
+    public boolean isCbenchSupported() {
+    	return cbenchSupported;
     }
 }

--- a/src/main/java/net/floodlightcontroller/core/internal/Controller.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/Controller.java
@@ -177,6 +177,7 @@ public class Controller
 
     protected int restPort;
     protected int openFlowPort;
+    protected boolean cbenchSupported;
 
     protected static final String CONTROLLER_TABLE_NAME = "controller_controller";
     protected static final String CONTROLLER_ID = "id";
@@ -218,10 +219,10 @@ public class Controller
     }
 
     public Controller() {
-        this(new PortSettings());
+        this(new CmdLineSettings());
     }
 
-    public Controller(PortSettings settings) {
+    public Controller(CmdLineSettings settings) {
         this.messageListeners =
             new ConcurrentHashMap<OFType, 
                                   ListenerDispatcher<OFType, 
@@ -231,6 +232,7 @@ public class Controller
         this.restlets = new ArrayList<RestletRoutable>();
         this.restPort = settings.getRestPort();
         this.openFlowPort = settings.getOpenFlowPort();
+        this.cbenchSupported = settings.isCbenchSupported();
     }
     
     // **********************
@@ -488,9 +490,12 @@ public class Controller
                         sw.setFeaturesReply((OFFeaturesReply) m);
                         sendFeatureReplyConfiguration();
                         state.hsState = HandshakeState.FEATURES_REPLY;
-                        // uncomment to enable "dumb" switches like cbench
-                        // state.hsState = HandshakeState.READY;
-                        // addSwitch(sw);
+                        
+                        if (cbenchSupported) {
+	                        // enables "dumb" switches like cbench
+	                        state.hsState = HandshakeState.READY;
+	                        addSwitch(sw);
+                        }
                     } else {
                         String em = "Unexpected FEATURES_REPLY from " + sw;
                         throw new SwitchStateException(em);
@@ -1509,7 +1514,7 @@ public class Controller
         System.setProperty("org.restlet.engine.loggerFacadeClass", 
                            "org.restlet.ext.slf4j.Slf4jLoggerFacade");
 
-        PortSettings settings = new PortSettings();
+        CmdLineSettings settings = new CmdLineSettings();
         CmdLineParser parser = new CmdLineParser(settings);
         try {
             parser.parseArgument(args);


### PR DESCRIPTION
Added -cbench / --cbenchSupport command-line parameters for Floodlight,
making it work with cbench (a dumb OpenFlow switch) without requiring
changes in the code. By default, cbench is not supported.

Class PortSettings was renamed to CmdLineSettings, as it nows handles
not only (openflow and rest) port settings, but rather any command-line
arguments.
