### PR TITLE
Fix restPort hard coding

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/Main.java
+++ b/src/main/java/net/floodlightcontroller/core/Main.java
@@ -36,7 +36,7 @@ public class Main {
         FloodlightModuleLoader fml = new FloodlightModuleLoader();
         IFloodlightModuleContext moduleContext = fml.loadModulesFromConfig(settings.getModuleFile());
         IRestApiService restApi = moduleContext.getServiceImpl(IRestApiService.class);
-        restApi.run();
+        restApi.run(settings.getRestPort());
         IFloodlightProviderService controller =
                 moduleContext.getServiceImpl(IFloodlightProviderService.class);
         controller.setCmdLineOptions(settings);

--- a/src/main/java/net/floodlightcontroller/restserver/IRestApiService.java
+++ b/src/main/java/net/floodlightcontroller/restserver/IRestApiService.java
@@ -12,5 +12,5 @@ public interface IRestApiService extends IFloodlightService {
     /**
      * Runs the REST API server
      */
-    public void run();
+    public void run(int restPort);
 }

--- a/src/main/java/net/floodlightcontroller/restserver/RestApiServer.java
+++ b/src/main/java/net/floodlightcontroller/restserver/RestApiServer.java
@@ -30,7 +30,6 @@ public class RestApiServer
     implements IFloodlightModule, IRestApiService {
     protected static Logger logger = LoggerFactory.getLogger(RestApiServer.class);
     protected List<RestletRoutable> restlets;
-    protected int restPort = 8080;
     protected FloodlightModuleContext fmlContext;
     
     // ***********
@@ -72,7 +71,7 @@ public class RestApiServer
             return slashFilter;
         }
         
-        public void run(FloodlightModuleContext fmlContext) {
+        public void run(FloodlightModuleContext fmlContext, int restPort) {
             // Add everything in the module context to the rest
             for (Class<? extends IFloodlightService> s : fmlContext.getAllServices()) {
                 context.getAttributes().put(s.getCanonicalName(), 
@@ -108,9 +107,9 @@ public class RestApiServer
     }
     
     @Override
-    public void run() {
+    public void run(int restPort) {
         RestApplication restApp = new RestApplication();
-        restApp.run(fmlContext);
+        restApp.run(fmlContext, restPort);
     }
     
     // *****************


### PR DESCRIPTION
Floodlight currently ignores the rest port value passed to it from the command line or configuration file, and uses a hard coded value of 8080 in RestApiServer.java. Here's a quick fix.
