### PR TITLE
Make the module loader more resilient to configuration errors.

### DIFF
--- a/src/main/java/net/floodlightcontroller/storage/IStorageSourceService.java
+++ b/src/main/java/net/floodlightcontroller/storage/IStorageSourceService.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.concurrent.Future;
 
 import net.floodlightcontroller.core.module.IFloodlightService;
-import net.floodlightcontroller.perfmon.IPktInProcessingTimeService;
 
 public interface IStorageSourceService extends IFloodlightService {
 


### PR DESCRIPTION
1 - Handle the case where you specify more than one module that provides the same service in the config. Print out an error message saying which ones are conflicting.
2 - If a service has more than one implementation and none are specified in the configuration file print out which modules can be used in the error message.
