### PR TITLE
Attachment point move suppresion when moving from non-broadcast domain port to broadcast domain port wasn't working. Fixed.

### DIFF
--- a/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImplTest.java
+++ b/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImplTest.java
@@ -444,6 +444,12 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
                            .andReturn(false).atLeastOnce();
         expect(mockTopology.isInternal(1L, (short)2))
                            .andReturn(false).atLeastOnce();
+        expect(mockTopology.getSwitchClusterId(1L))
+                           .andReturn(1L).atLeastOnce();
+        expect(mockTopology.isBroadcastDomainPort(1L, (short)1))
+                           .andReturn(false).atLeastOnce();
+        expect(mockTopology.isBroadcastDomainPort(1L, (short)2))
+                           .andReturn(false).atLeastOnce();
         deviceManager.setTopology(mockTopology);
 
         // Start recording the replay on the mocks
@@ -531,6 +537,12 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
         expect(mockTopology.isInternal(1L, (short)1))
                            .andReturn(false).atLeastOnce();
         expect(mockTopology.isInternal(1L, (short)2))
+                           .andReturn(false).atLeastOnce();
+        expect(mockTopology.getSwitchClusterId(1L))
+                           .andReturn(1L).atLeastOnce();
+        expect(mockTopology.isBroadcastDomainPort(1L, (short)1))
+                           .andReturn(false).atLeastOnce();
+        expect(mockTopology.isBroadcastDomainPort(1L, (short)2))
                            .andReturn(false).atLeastOnce();
         deviceManager.setTopology(mockTopology);
 


### PR DESCRIPTION
Attachment point move suppresion when moving from non-broadcast domain port to broadcast domain port wasn't working. Fixed.
