### PR TITLE
topology ui bugfix: don't assume hosts have ips

### DIFF
--- a/src/main/resources/web/js/views/topology.js
+++ b/src/main/resources/web/js/views/topology.js
@@ -43,7 +43,11 @@ window.TopologyView = Backbone.View.extend({
 
           for (var i = 0; i < this.hosts.length; i++) {
             host = this.hosts[i];
-            host.name = host.attributes['network-addresses'][0]['ip'] + "\n" + host.id;
+            if ('ip' in host.attributes['network-addresses'][0]) {
+                host.name = host.attributes['network-addresses'][0]['ip'] + "\n" + host.id;
+            } else {
+                host.name = host.id;
+            }
             host.group = 2;
             console.log(host);
           }


### PR DESCRIPTION
topology viewer was dying if floodlight had not yet discovered
an IP address for every host.
