### PR TITLE
Fixing race condition/null pointer exception in DeviceManagerImpl

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
@@ -1595,6 +1595,16 @@ public class DeviceManagerImpl implements IDeviceManagerService, IOFMessageListe
     		return;
     	}
     	topoChangedEvent = true;
+    	
+    	//solve race condition where deviceUpdateTask can still be null 
+        while (deviceUpdateTask == null) { 
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException ie) {
+                //intentionally blank
+            }
+        }
+
         deviceUpdateTask.reschedule(10, TimeUnit.MILLISECONDS);
     }
 


### PR DESCRIPTION
Occurs when the TopologyManager can call back into DeviceManagerImpl before the deviceUpdateTask is initialized. Could be fixed by adding DeviceManagerImpl to the TopologyManager's listeners after initializing deviceUpdateTask, but this is more general and it seems like the right behavior is to have any externally-visible function ready to be called after init() returns.
