### PR TITLE
debian packaging: fix lintian warnings

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,6 @@ Vcs-Browser: https://github.com/floodlight/floodlight
 Package: floodlight
 Architecture: all
 Depends: ${java:Depends}, ${misc:Depends}
-Description: An Apache licensed, Java based OpenFlow controller
-  Floodlight is a Java based OpenFlow controller originally written by David Erickson at Stanford
-  University. It is available under the Apache 2.0 license.
+Description: Java based OpenFlow controller
+ Floodlight is a Java based OpenFlow controller originally written by David
+ Erickson at Stanford University.

--- a/debian/copyright
+++ b/debian/copyright
@@ -25,6 +25,3 @@ License: Apache-2.0
  .
  On Debian systems, the complete text of the Apache version 2.0 license
  can be found in "/usr/share/common-licenses/Apache-2.0".
-
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.

--- a/debian/docs
+++ b/debian/docs
@@ -1,4 +1,2 @@
-LICENSE.txt
 NOTICE.txt
-README.txt
 README.txt

--- a/debian/init.d
+++ b/debian/init.d
@@ -1,8 +1,8 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          floodlight
-# Required-Start:    $network $local_fs
-# Required-Stop:
+# Required-Start:    $network $local_fs $remote_fs
+# Required-Stop:     $remote_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: An Apache licensed, Java based OpenFlow controller


### PR DESCRIPTION
Fixes these issues:
E: floodlight: copyright-contains-dh_make-todo-boilerplate
W: floodlight: description-synopsis-starts-with-article
W: floodlight: description-starts-with-leading-spaces
W: floodlight: extended-description-line-too-long
W: floodlight: extra-license-file usr/share/doc/floodlight/LICENSE.txt.gz
E: floodlight: init.d-script-missing-dependency-on-remote_fs etc/init.d/floodlight: required-start
E: floodlight: init.d-script-missing-dependency-on-remote_fs etc/init.d/floodlight: required-stop
