### PR TITLE
Getting rid of warnings in generated thrift code.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -82,14 +82,14 @@
     <path id="classpath-cobertura">
         <fileset dir="${lib}">
             <patternset refid="lib-cobertura"/>
-	</fileset>
+    </fileset>
     </path>
 
     <patternset id="lib-test">
         <include name="junit-4.8.2.jar"/>
         <include name="org.easymock-3.1.jar"/>
-		<include name="objenesis-1.2.jar"/>  <!-- required by easymock to mock classes -->
-		<include name="cglib-nodep-2.2.2.jar"/>    <!-- required by easymock to mock classes -->
+        <include name="objenesis-1.2.jar"/>  <!-- required by easymock to mock classes -->
+        <include name="cglib-nodep-2.2.2.jar"/>    <!-- required by easymock to mock classes -->
     </patternset>
     <path id="classpath-test">
         <fileset dir="${lib}">
@@ -109,21 +109,21 @@
 
     <target name="compile" depends="init">
         <javac includeAntRuntime="false" 
-	       classpathref="classpath" 
-	       debug="true" 
-	       srcdir="${source}:${thrift.out.dir}"
-	       destdir="${build}">
+           classpathref="classpath" 
+           debug="true" 
+           srcdir="${source}:${thrift.out.dir}"
+           destdir="${build}">
         </javac>
     </target>
 
     <target name="compile-tests" depends="compile-test"/>
     <target name="compile-test" depends="compile">
-    	<fileset dir="${resources}"/>
+        <fileset dir="${resources}"/>
         <javac includeAntRuntime="false" debug="true" 
-	       srcdir="${source-test}"
-	       classpath="${build}"
-	       classpathref="classpath-test"
-	       destdir="${build-test}"/>
+           srcdir="${source-test}"
+           classpath="${build}"
+           classpathref="classpath-test"
+           destdir="${build-test}"/>
     </target>
 
     <!-- Thrift build based on http://www.flester.com/blog/2009/04/26/using-thrift-from-ant -->
@@ -139,6 +139,15 @@
         <exec executable="thrift" dir="${basedir}" failonerror="true">
             <arg line="--strict -v --gen java -o ${thrift.out.dir}/.. ${thrift.file.list}"/>
         </exec>
+        <!-- Get rid of annoying warnings in thrift java: at annotations -->
+        <echo message="Adding @SuppressWarning annotations"/>
+        <replaceregexp byline="true">
+            <regexp pattern="^public "/>
+            <substitution expression='@SuppressWarnings("all") public '/>
+            <fileset id="thrift.output.files" dir="${thrift.out.dir}/..">
+                <include name="**/*.java"/>
+            </fileset>
+        </replaceregexp>
     </target>
 
     <target name="clean">
@@ -156,10 +165,10 @@
     <target name="tests" depends="test"/>
     <target name="test" depends="compile-test">
         <junit fork="true" forkmode="once"
-	       failureproperty="junit.failure"
-	       printsummary="on">
-  	    <sysproperty key="net.sourceforge.cobertura.datafile"
-			 file="${target}/cobertura.ser" />
+           failureproperty="junit.failure"
+           printsummary="on">
+        <sysproperty key="net.sourceforge.cobertura.datafile"
+             file="${target}/cobertura.ser" />
             <classpath>
                 <pathelement location="${build-coverage}"/>
                 <pathelement location="${build}"/>
@@ -185,22 +194,22 @@
     </target>
     <target name="instrument" depends="compile,compile-test,clean-instrument">
       <cobertura-instrument datafile="${target}/cobertura.ser"
-			    todir="${build-coverage}"
-			    classpathref="classpath-cobertura">
-	<fileset dir="${build}">
-	  <include name="**/*.class"/>
-	</fileset>
+                todir="${build-coverage}"
+                classpathref="classpath-cobertura">
+    <fileset dir="${build}">
+      <include name="**/*.class"/>
+    </fileset>
       </cobertura-instrument>
     </target>
     <target name="coverage-report">
         <cobertura-report format="html"
-			  datafile="${target}/cobertura.ser"
-			  destdir="${coverage-output}"
-			  srcdir="${source}"/>
+              datafile="${target}/cobertura.ser"
+              destdir="${coverage-output}"
+              srcdir="${source}"/>
         <cobertura-report format="xml"
-			  datafile="${target}/cobertura.ser"
-			  destdir="${coverage-output}"
-			  srcdir="${source}"/>
+              datafile="${target}/cobertura.ser"
+              destdir="${coverage-output}"
+              srcdir="${source}"/>
     </target>
     <target name="coverage" depends="instrument,test,coverage-report"/>
 
@@ -211,7 +220,7 @@
                 <attribute name="Class-Path" value="."/>
             </manifest>
             <fileset dir="${build}"/>
-        	<fileset dir="${resources}"/>
+            <fileset dir="${resources}"/>
             <fileset dir="${python-src}">
                 <include name="**/*.py"/>
             </fileset>
@@ -224,7 +233,7 @@
                 <attribute name="Class-Path" value="."/>
             </manifest>
             <fileset dir="${build-test}"/>
-        	<fileset dir="${resources}"/>
+            <fileset dir="${resources}"/>
             <zipgroupfileset dir="${lib}">
                 <patternset refid="lib-test"/>
                 <patternset refid="lib-cobertura"/>

--- a/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/Constants.java
+++ b/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/Constants.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Constants {
+@SuppressWarnings("all") public class Constants {
 
   public static final String VERSION = "0.1.0";
 

--- a/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/Message.java
+++ b/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/Message.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Message implements org.apache.thrift.TBase<Message, Message._Fields>, java.io.Serializable, Cloneable {
+@SuppressWarnings("all") public class Message implements org.apache.thrift.TBase<Message, Message._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("Message");
 
   private static final org.apache.thrift.protocol.TField SESSION_IDS_FIELD_DESC = new org.apache.thrift.protocol.TField("sessionIDs", org.apache.thrift.protocol.TType.LIST, (short)1);

--- a/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/OFMessageType.java
+++ b/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/OFMessageType.java
@@ -14,7 +14,7 @@ import org.apache.thrift.TEnum;
  * OFMessage type
  * 
  */
-public enum OFMessageType implements org.apache.thrift.TEnum {
+@SuppressWarnings("all") public enum OFMessageType implements org.apache.thrift.TEnum {
   HELLO(0),
   ERROR(1),
   ECHO_REQUEST(2),

--- a/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/Packet.java
+++ b/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/Packet.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Packet implements org.apache.thrift.TBase<Packet, Packet._Fields>, java.io.Serializable, Cloneable {
+@SuppressWarnings("all") public class Packet implements org.apache.thrift.TBase<Packet, Packet._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("Packet");
 
   private static final org.apache.thrift.protocol.TField MESSAGE_TYPE_FIELD_DESC = new org.apache.thrift.protocol.TField("messageType", org.apache.thrift.protocol.TType.I32, (short)1);

--- a/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/PacketStreamer.java
+++ b/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/PacketStreamer.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PacketStreamer {
+@SuppressWarnings("all") public class PacketStreamer {
 
   /**
    * Packetstreamer API
@@ -1618,6 +1618,8 @@ public class PacketStreamer {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bit_vector = new BitSet(1);
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);

--- a/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/SwitchPortTuple.java
+++ b/lib/gen-java/net/floodlightcontroller/packetstreamer/thrift/SwitchPortTuple.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A struct that defines switch port tuple
  */
-public class SwitchPortTuple implements org.apache.thrift.TBase<SwitchPortTuple, SwitchPortTuple._Fields>, java.io.Serializable, Cloneable {
+@SuppressWarnings("all") public class SwitchPortTuple implements org.apache.thrift.TBase<SwitchPortTuple, SwitchPortTuple._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("SwitchPortTuple");
 
   private static final org.apache.thrift.protocol.TField DPID_FIELD_DESC = new org.apache.thrift.protocol.TField("dpid", org.apache.thrift.protocol.TType.I64, (short)1);


### PR DESCRIPTION
Workaroudn to get rid of warnings in generated thrift code.
Modify gen-thrift ant target to add a SupressWarnings("all") to all
generated java file (we do a regex replace.)

Also retab'ed build.xml file
