### PR TITLE
Fix Device Manager entity handling code [BSC-2046]

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
@@ -527,8 +527,8 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
             if (srcEntity == null)
                 return Command.STOP;
 
-            // Learn/lookup device information
-            Device srcDevice = learnDeviceByEntity(srcEntity);
+            // Find the device by source entity
+            Device srcDevice = findDeviceByEntity(srcEntity);
             if (srcDevice == null)
                 return Command.STOP;
 


### PR DESCRIPTION
During flow reconciliation, device manager should not call learnDeviceByEntity, which would incorrectly update timestamps of entities existing in flow cache. It should call findDeviceByEntity instead.
