### PR TITLE
Assignment of prevCluster is changed to reflect the L2 domain ID of the prev entity. It was possible for cur and prev to be swapped when duplicate attachment points were detected, where the prevCluster could have the wrong assignment.

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
@@ -311,7 +311,7 @@ public class Device implements IDevice {
             }
 
             prev = clentities[clEntIndex] = cur;
-            prevCluster = curCluster;
+            prevCluster = topology.getL2DomainId(prev.getSwitchDPID());
 
             long prevLastSeen =
                     deviceManager.apComparator.


### PR DESCRIPTION
...f the prev entity.  It was possible for cur and prev to be swapped when duplicate attachment points were detected, where the prevCluster could have the wrong assignment.
