### PR TITLE
handleLLDP() uses incorrect variable when getting status of packet-in port. Fixed.

### DIFF
--- a/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
@@ -522,7 +522,7 @@ public class LinkDiscoveryManager
 
         OFPhysicalPort physicalPort = remoteSwitch.getPort(remotePort);
         int srcPortState = (physicalPort != null) ? physicalPort.getState() : 0;
-        physicalPort = sw.getPort(remotePort);
+        physicalPort = sw.getPort(pi.getInPort());
         int dstPortState = (physicalPort != null) ? physicalPort.getState() : 0;
 
         // Store the time of update to this link, and push it out to routingEngine


### PR DESCRIPTION
...he state of the packet-in port.
