### PR TITLE
Rewrite of attachment point logic in device manager.  Attachment points are maintained independent of entities.

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/AttachmentPoint.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/AttachmentPoint.java
@@ -1,0 +1,89 @@
+/**
+ *    Copyright 2011,2012 Big Switch Networks, Inc.
+ *    Originally created by David Erickson, Stanford University
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ **/
+
+/**
+ * @author Srini
+ */
+
+package net.floodlightcontroller.devicemanager.internal;
+
+public class AttachmentPoint {
+    long sw;
+    short port;
+    long lastSeen;
+
+    // Timeout for moving attachment points from OF/broadcast
+    // domain to another.
+    protected static long NBD_TO_BD_TIMEDIFF_MS = 300000; // 5 minutes
+    public static final long OPENFLOW_TO_EXTERNAL_TIMEOUT = 5000;  // 5 seconds
+    public static final long EXTERNAL_TO_EXTERNAL_TIMEOUT = 5000;  // 5 seconds
+    public static final long CONSISTENT_TIMEOUT = 5000;            // 5 seconds
+
+    public AttachmentPoint(long sw, short port, long lastSeen) {
+        super();
+        this.sw = sw;
+        this.port = port;
+        this.lastSeen = lastSeen;
+    }
+
+    public long getSw() {
+        return sw;
+    }
+    public void setSw(long sw) {
+        this.sw = sw;
+    }
+    public short getPort() {
+        return port;
+    }
+    public void setPort(short port) {
+        this.port = port;
+    }
+    public long getLastSeen() {
+        return lastSeen;
+    }
+    public void setLastSeen(long lastSeen) {
+        this.lastSeen = lastSeen;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + port;
+        result = prime * result + (int) (sw ^ (sw >>> 32));
+        return result;
+    }
+
+    /**
+     * Compares only the switch and port.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AttachmentPoint other = (AttachmentPoint) obj;
+        if (port != other.port)
+            return false;
+        if (sw != other.sw)
+            return false;
+        return true;
+    }
+}

--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
@@ -20,9 +20,13 @@ package net.floodlightcontroller.devicemanager.internal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.TreeSet;
 
 import org.codehaus.jackson.map.annotate.JsonSerialize;
@@ -32,7 +36,6 @@ import net.floodlightcontroller.devicemanager.web.DeviceSerializer;
 import net.floodlightcontroller.devicemanager.IDevice;
 import net.floodlightcontroller.devicemanager.IEntityClass;
 import net.floodlightcontroller.devicemanager.SwitchPort;
-import static net.floodlightcontroller.devicemanager.SwitchPort.ErrorStatus.*;
 import net.floodlightcontroller.packet.Ethernet;
 import net.floodlightcontroller.topology.ITopologyService;
 
@@ -50,6 +53,7 @@ public class Device implements IDevice {
 
     protected String macAddressString;
 
+    protected List<AttachmentPoint> attachmentPoints;
     // ************
     // Constructors
     // ************
@@ -72,6 +76,142 @@ public class Device implements IDevice {
                 HexString.toHexString(entity.getMacAddress(), 6);
         this.entityClass = entityClass;
         Arrays.sort(this.entities);
+        this.attachmentPoints = null;
+
+        if (entity.getSwitchDPID() != null &&
+                entity.getSwitchPort() != null){
+            long sw = entity.getSwitchDPID();
+            short port = entity.getSwitchPort().shortValue();
+
+            if (deviceManager.isValidAttachmentPoint(sw, port)) {
+
+                AttachmentPoint ap = 
+                        new AttachmentPoint(sw, port,
+                                            entity.getLastSeenTimestamp().getTime());
+                this.attachmentPoints = new ArrayList<AttachmentPoint>();
+                this.attachmentPoints.add(ap);
+            }
+        }
+    }
+
+    private Map<Long, AttachmentPoint> getAPMap() {
+
+        if (attachmentPoints == null) return null;
+        ITopologyService topology = deviceManager.topology;
+
+        // Get the old attachment points and sort them.
+        List<AttachmentPoint>oldAP =
+                new ArrayList<AttachmentPoint>(attachmentPoints);
+
+        Collections.sort(oldAP, deviceManager.apComparator);
+
+        // Map of attachment point by L2 domain Id.
+        Map<Long, AttachmentPoint> apMap = new HashMap<Long, AttachmentPoint>();
+
+        for(int i=0; i<oldAP.size(); ++i) {
+            AttachmentPoint ap = oldAP.get(i);
+            // if this is not a valid attachment point, continue
+            if (!deviceManager.isValidAttachmentPoint(ap.getSw(),
+                                                     ap.getPort()))
+                continue;
+
+            long id = topology.getL2DomainId(ap.getSw());
+            AttachmentPoint possibleDuplicate = apMap.put(id, ap);
+            if (possibleDuplicate == null) continue;
+
+            // Add logic to check for duplicate device.
+        }
+
+        if (apMap.isEmpty()) return null;
+        return apMap;
+    }
+
+    protected boolean updateAttachmentPoint(long sw, short port, long lastSeen){
+        ITopologyService topology = deviceManager.topology;
+
+        // 
+        if (!deviceManager.isValidAttachmentPoint(sw, port)) return false;
+
+        AttachmentPoint newAP = new AttachmentPoint(sw, port, lastSeen);
+        Map<Long, AttachmentPoint> apMap = getAPMap();
+
+        if (apMap == null || apMap.isEmpty()) {
+            // Device just got added.
+            List<AttachmentPoint> apList = new ArrayList<AttachmentPoint>();
+            apList.add(newAP);
+            this.attachmentPoints = apList;
+            return true;  // device added
+        }
+
+        long id = topology.getL2DomainId(sw);
+        AttachmentPoint oldAP = apMap.get(id);
+
+        if (oldAP == null) // No attachment on this L2 domain.
+        {
+            List<AttachmentPoint> apList = new ArrayList<AttachmentPoint>();
+            apList.addAll(apMap.values());
+            apList.add(newAP);
+            this.attachmentPoints = apList;
+            return true; // new AP found on an L2 island.
+        }
+
+        // There is already a known attachment point on the same L2 island.
+        // we need to compare oldAP and newAP.
+        if (oldAP.equals(newAP)) {
+            // nothing to do here. just the last seen has to be changed.
+            if (newAP.lastSeen > oldAP.lastSeen)
+                apMap.put(id, newAP);
+            this.attachmentPoints =
+                    new ArrayList<AttachmentPoint>(apMap.values());
+            return false; // nothing to do here.
+        }
+
+        int x = deviceManager.apComparator.compare(oldAP, newAP);
+        if (x > 0) {
+            // newAP replaces oldAP.
+            apMap.put(id, newAP);
+            this.attachmentPoints =
+                    new ArrayList<AttachmentPoint>(apMap.values());
+            return true; // attachment point changed.
+        }
+
+        return false; // something weird.
+    }
+
+    public boolean deleteAttachmentPoint(long sw, short port) {
+        AttachmentPoint ap = new AttachmentPoint(sw, port, 0);
+
+        if (this.attachmentPoints == null) return false;
+
+        ArrayList<AttachmentPoint> apList = new ArrayList<AttachmentPoint>();
+        apList.addAll(this.attachmentPoints);
+        int index = apList.indexOf(ap);
+        if (index < 0) return false;
+
+        apList.remove(index);
+        this.attachmentPoints = apList;
+        return true;
+    }
+
+    @Override
+    public SwitchPort[] getAttachmentPoints() {
+        return getAttachmentPoints(false);
+    }
+
+    @Override
+    public SwitchPort[] getAttachmentPoints(boolean includeError) {
+
+        Map<Long, AttachmentPoint> apMap = getAPMap();
+        if (apMap == null) return null;
+        if (apMap.isEmpty()) return null;
+
+        List<SwitchPort> sp = new ArrayList<SwitchPort>();
+        for(AttachmentPoint ap: apMap.values()) {
+            SwitchPort swport = new SwitchPort(ap.getSw(),
+                                               ap.getPort());
+            sp.add(swport);
+        }
+        return sp.toArray(new SwitchPort[sp.size()]);
     }
 
     /**
@@ -83,11 +223,18 @@ public class Device implements IDevice {
      */
     public Device(DeviceManagerImpl deviceManager,
                   Long deviceKey,
+                  Collection<AttachmentPoint> attachmentPoints,
                   Collection<Entity> entities,
                   IEntityClass entityClass) {
         this.deviceManager = deviceManager;
         this.deviceKey = deviceKey;
         this.entities = entities.toArray(new Entity[entities.size()]);
+        if (attachmentPoints == null) {
+            this.attachmentPoints = null;
+        } else {
+            this.attachmentPoints =
+                    new ArrayList<AttachmentPoint>(attachmentPoints);
+        }
         this.macAddressString =
                 HexString.toHexString(this.entities[0].getMacAddress(), 6);
         this.entityClass = entityClass;
@@ -109,6 +256,12 @@ public class Device implements IDevice {
                                               device.entities.length + 1);
         this.entities[this.entities.length - 1] = newEntity;
         Arrays.sort(this.entities);
+
+        if (device.attachmentPoints != null) {
+            this.attachmentPoints =
+                    new ArrayList<AttachmentPoint>(device.attachmentPoints);
+        } else 
+            this.attachmentPoints = null;
 
         this.macAddressString =
                 HexString.toHexString(this.entities[0].getMacAddress(), 6);
@@ -166,7 +319,7 @@ public class Device implements IDevice {
         TreeSet<Integer> vals = new TreeSet<Integer>();
         for (Entity e : entities) {
             if (e.getIpv4Address() == null) continue;
-            
+
             // We have an IP address only if among the devices within the class
             // we have the most recent entity with that IP.
             boolean validIP = true;
@@ -197,153 +350,6 @@ public class Device implements IDevice {
         return vals.toArray(new Integer[vals.size()]);
     }
 
-    @Override
-    public SwitchPort[] getAttachmentPoints() {
-        return getAttachmentPoints(false);
-    }
-
-    @Override
-    public SwitchPort[] getAttachmentPoints(boolean includeError) {
-        // XXX - TODO we can cache this result.  Let's find out if this
-        // is really a performance bottleneck first though.
-
-        if (entities.length == 1) {
-            Long dpid = entities[0].getSwitchDPID();
-            Integer port = entities[0].getSwitchPort();
-            if (dpid != null && port != null &&
-                    deviceManager.isValidAttachmentPoint(dpid, port)) {
-                SwitchPort sp = new SwitchPort(dpid, port);
-                return new SwitchPort[] { sp };
-            } else {
-                return new SwitchPort[0];
-            }
-        }
-
-        // Find the most recent attachment point for each cluster
-        Entity[] clentities = Arrays.<Entity>copyOf(entities, entities.length);
-        Arrays.sort(clentities, deviceManager.apComparator);
-        ArrayList<SwitchPort> blocked = null;
-        ArrayList<SwitchPort> clusterBlocked = null;
-        if (includeError) {
-            blocked = new ArrayList<SwitchPort>();
-            clusterBlocked = new ArrayList<SwitchPort>();
-        }
-
-        ITopologyService topology = deviceManager.topology;
-        long prevCluster = 0;
-        int clEntIndex = -1;
-        Entity prev = null;
-        long latestLastSeen = 0;
-        for (int i = 0; i < clentities.length; i++) {
-            Entity cur = clentities[i];
-            Long dpid = cur.getSwitchDPID();
-            Integer port = cur.getSwitchPort();
-            if (dpid == null || port == null ||
-                    !deviceManager.isValidAttachmentPoint(dpid, port) ||
-                    (prev != null &&
-                    topology.isConsistent(prev.getSwitchDPID().longValue(),
-                                          prev.getSwitchPort().shortValue(),
-                                          dpid.longValue(),
-                                          port.shortValue()))
-                    )
-                continue;
-            long curCluster =
-                    topology.getL2DomainId(cur.getSwitchDPID());
-            if (prevCluster != curCluster) {
-                prev = null;
-                latestLastSeen = 0;
-                clEntIndex += 1;
-                if (includeError) {
-                    blocked.addAll(clusterBlocked);
-                    clusterBlocked.clear();
-                }
-            }
-
-            if (prev != null &&
-                    !(dpid.equals(prev.getSwitchDPID()) &&
-                            port.equals(prev.getSwitchPort())) &&
-                            !topology.isInSameBroadcastDomain(dpid.longValue(),
-                                                              port.shortValue(),
-                                                              prev.getSwitchDPID().longValue(),
-                                                              prev.getSwitchPort().shortValue()) &&
-                                                              !topology.isConsistent(prev.getSwitchDPID().longValue(),
-                                                                                     prev.getSwitchPort().shortValue(),
-                                                                                     dpid.longValue(), port.shortValue())) {
-                long curActive =
-                        deviceManager.apComparator.
-                        getEffTS(cur, cur.getActiveSince());
-                if (latestLastSeen > 0 &&
-                        curActive > 0 &&
-                        0 < Long.valueOf(latestLastSeen).compareTo(curActive)) {
-                    // If the previous and current are both active at the same
-                    // time (i.e. the last seen timestamp of previous is
-                    // greater than active timestamp of current item, we want
-                    // to suppress rapid flapping between the two points. We
-                    // choose arbitrarily based on criteria other than
-                    // timestamp; the compareTo for entity should fit the bill.
-                    Entity block = prev;
-                    if (0 < prev.compareTo(cur)) {
-                        block = cur;
-                        cur = prev;
-                    }
-                    if (includeError) {
-                        boolean alreadyBlocked = false;
-                        for (SwitchPort bl : clusterBlocked) {
-                            if (dpid.equals(bl.getSwitchDPID()) &&
-                                    port.equals(bl.getPort())) {
-                                alreadyBlocked = true;
-                                break;
-                            }
-                        }
-                        if (!alreadyBlocked) {
-                            SwitchPort blap =
-                                    new SwitchPort(block.getSwitchDPID(),
-                                                   block.getSwitchPort(),
-                                                   DUPLICATE_DEVICE);
-                            clusterBlocked.add(blap);
-                        }
-                    }
-                } else {
-                    if (includeError) {
-                        clusterBlocked.clear();
-                    }
-                    latestLastSeen = 0;
-                }
-            }
-
-            prev = clentities[clEntIndex] = cur;
-            prevCluster = topology.getL2DomainId(prev.getSwitchDPID());
-
-            long prevLastSeen =
-                    deviceManager.apComparator.
-                    getEffTS(prev,
-                             prev.getLastSeenTimestamp());
-            if (latestLastSeen < prevLastSeen)
-                latestLastSeen = prevLastSeen;
-        }
-
-        if (clEntIndex < 0) {
-            return new SwitchPort[0];
-        }
-
-        ArrayList<SwitchPort> vals = new ArrayList<SwitchPort>(clEntIndex + 1);
-        for (int i = 0; i <= clEntIndex; i++) {
-            Entity e = clentities[i];
-            if (e.getSwitchDPID() != null &&
-                    e.getSwitchPort() != null) {
-                SwitchPort sp = new SwitchPort(e.getSwitchDPID(),
-                                               e.getSwitchPort());
-                vals.add(sp);
-            }
-        }
-        if (includeError) {
-            vals.addAll(blocked);
-            vals.addAll(clusterBlocked);
-        }
-
-        return vals.toArray(new SwitchPort[vals.size()]);
-    }
-    
     @Override
     public Short[] getSwitchPortVlanIds(SwitchPort swp) {
         TreeSet<Short> vals = new TreeSet<Short>();

--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -108,14 +109,6 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
      * Time in seconds between cleaning up old entities/devices
      */
     protected static final int ENTITY_CLEANUP_INTERVAL = 60*60;
-
-    /**
-     * Attachment points on a broadcast domain will have lower priority
-     * than attachment points in openflow domains.  This is the timeout
-     * for switching from a non-broadcast domain to a broadcast domain
-     * attachment point.
-     */
-    protected static long NBD_TO_BD_TIMEDIFF_MS = 300000; // 5 minutes
 
     /**
      * This is the master device map that maps device IDs to {@link Device}
@@ -236,59 +229,82 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
     }
 
     /**
-     * Comparator for finding the correct attachment point to use based on
-     * the set of entities
+     * AttachmentPointComparator
+     * 
+     * Compares two attachment points and returns the latest one.
+     * It is assumed that the two attachment points are in the same
+     * L2 domain.
+     * 
+     * @author srini
      */
     protected class AttachmentPointComparator
-    implements Comparator<Entity> {
-
-
+    implements Comparator<AttachmentPoint> {
         public AttachmentPointComparator() {
             super();
         }
 
-        protected long getEffTS(Entity e, Date ts) {
-            if (ts == null)
-                return 0;
-            long et = ts.getTime();
-            Long dpid = e.getSwitchDPID();
-            Integer port = e.getSwitchPort();
-            if (dpid != null && port != null &&
-                    topology.isBroadcastDomainPort(dpid, port.shortValue())) {
-                return et - NBD_TO_BD_TIMEDIFF_MS;
-            }
-            return et;
-        }
-
         @Override
-        public int compare(Entity e1, Entity e2) {
-            int r = 0;
+        public int compare(AttachmentPoint oldAP, AttachmentPoint newAP) {
 
-            Long swdpid1 = e1.getSwitchDPID();
-            Long swdpid2 = e2.getSwitchDPID();
-            if (swdpid1 == null)
-                r = swdpid2 == null ? 0 : -1;
-            else if (swdpid2 == null)
-                r = 1;
-            else {
-                Long d1ClusterId =
-                        topology.getL2DomainId(swdpid1);
-                Long d2ClusterId =
-                        topology.getL2DomainId(swdpid2);
-                r = d1ClusterId.compareTo(d2ClusterId);
-            }
-            if (r != 0) return r;
+            //First compare based on L2 domain ID; 
+            long oldSw = oldAP.getSw();
+            short oldPort = oldAP.getPort();
+            long newSw = newAP.getSw();
+            short newPort = newAP.getPort();
 
-            // the ordering of active times is a more
-            // representative of the causal relationship
-            // than lastSeen time.
-            long e1ts = getEffTS(e1, e1.getActiveSince());
-            long e2ts = getEffTS(e2, e2.getActiveSince());
-            return Long.valueOf(e1ts).compareTo(e2ts);
+            long oldDomain = topology.getL2DomainId(oldSw);
+            long newDomain = topology.getL2DomainId(newSw);
+
+            if (oldDomain < newDomain) return -1;
+            else if (oldDomain > newDomain) return 1;
+
+            // We expect that the last seen of the new AP is higher than
+            // old AP, if it is not, just reverse and send the negative
+            // of the result.
+            if (oldAP.getLastSeen() > newAP.getLastSeen())
+                return -compare(newAP, oldAP);
+
+
+            // If newAP is inconsistent with the oldAP
+            // and the newAP is not a broadcast domain.
+            if (!topology.isConsistent(oldSw, oldPort, newSw, newPort) &&
+                    !topology.isBroadcastDomainPort(newSw, newPort))
+                return 1;
+
+            // If newAP is inconsistent with the oldAP and
+            // oldAP belongs to broadcast domain and
+            // newAP belongs to broadcast domain and
+            // newLastSeen > oldLastSeen + EXT_TO_EXT_TIMEOUT
+            if (!topology.isConsistent(oldSw, oldPort, newSw, newPort) &&
+                    topology.isBroadcastDomainPort(oldSw, oldPort) &&
+                    topology.isBroadcastDomainPort(newSw, newPort) &&
+                    newAP.getLastSeen() > oldAP.getLastSeen() + 
+                        AttachmentPoint.EXTERNAL_TO_EXTERNAL_TIMEOUT)
+                return 1;
+
+            // If newAP is inconsistent with the oldAP and
+            // oldAP does not to broadcast domain and
+            // newAP belongs to broadcast domain and
+            // newLastSeen > oldLastSeen + EXT_TO_EXT_TIMEOUT
+            if (!topology.isConsistent(oldSw, oldPort, newSw, newPort) &&
+                    !topology.isBroadcastDomainPort(oldSw, oldPort) &&
+                    topology.isBroadcastDomainPort(newSw, newPort) &&
+                    newAP.getLastSeen() > oldAP.getLastSeen() + 
+                        AttachmentPoint.OPENFLOW_TO_EXTERNAL_TIMEOUT)
+                return 1;
+
+            // If newAP is inconsistent with the oldAP and
+            // oldAP does not to broadcast domain and
+            // newAP belongs to broadcast domain and
+            // newLastSeen > oldLastSeen + EXT_TO_EXT_TIMEOUT
+            if (topology.isConsistent(oldSw, oldPort, newSw, newPort) &&
+                    newAP.getLastSeen() > oldAP.getLastSeen() +
+                        AttachmentPoint.CONSISTENT_TIMEOUT)
+                return 1;
+
+            return -1;
         }
-
     }
-
     /**
      * Comparator for sorting by cluster ID
      */
@@ -732,10 +748,10 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
      */
     protected boolean isValidAttachmentPoint(long switchDPID,
                                              int switchPort) {
-        IOFSwitch sw = floodlightProvider.getSwitches().get(switchDPID);
-        if (sw == null) return false;
-        OFPhysicalPort port = sw.getPort((short)switchPort);
-        if (port == null || !sw.portEnabled(port)) return false;
+        //IOFSwitch sw = floodlightProvider.getSwitches().get(switchDPID);
+        //if (sw == null) return false;
+        //OFPhysicalPort port = sw.getPort((short)switchPort);
+        //if (port == null || !sw.portEnabled(port)) return false;
         if (topology.isAttachmentPointPort(switchDPID, (short)switchPort) == false)
             return false;
 
@@ -1057,9 +1073,20 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
                 Date lastSeen = entity.getLastSeenTimestamp();
                 if (lastSeen == null) lastSeen = new Date();
                 device.entities[entityindex].setLastSeenTimestamp(lastSeen);
+                if (device.entities[entityindex].getSwitchDPID() != null &&
+                        device.entities[entityindex].getSwitchPort() != null) {
+                    long sw = device.entities[entityindex].getSwitchDPID();
+                    short port = device.entities[entityindex].getSwitchPort().shortValue();
+                    device.updateAttachmentPoint(sw, port, lastSeen.getTime());
+                }
                 break;
             } else {
                 Device newDevice = allocateDevice(device, entity);
+                if (entity.getSwitchDPID() != null && entity.getSwitchPort() != null) {
+                    newDevice.updateAttachmentPoint(entity.getSwitchDPID(),
+                                                    entity.getSwitchPort().shortValue(),
+                                                    entity.getLastSeenTimestamp().getTime());
+                }
 
                 // generate updates
                 EnumSet<DeviceField> changedFields =
@@ -1369,6 +1396,7 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
 
                 if (toKeep.size() > 0) {
                     Device newDevice = allocateDevice(d.getDeviceKey(),
+                                                      d.attachmentPoints,
                                                       toKeep,
                                                       d.entityClass);
 
@@ -1453,10 +1481,12 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
         return new Device(this, deviceKey, entity, entityClass);
     }
 
+    // TODO: FIX THIS.
     protected Device allocateDevice(Long deviceKey,
+                                    List<AttachmentPoint> aps,
                                     Collection<Entity> entities,
                                     IEntityClass entityClass) {
-        return new Device(this, deviceKey, entities, entityClass);
+        return new Device(this, deviceKey, aps, entities, entityClass);
     }
 
     protected Device allocateDevice(Device device,

--- a/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
@@ -284,8 +284,8 @@ IFloodlightModule, IInfoProvider, IHAListener {
                                            linkDiscoveryAware});
                 }
                 try {
-                for (ILinkDiscoveryListener lda : linkDiscoveryAware) { // order maintained
-                    lda.linkDiscoveryUpdate(update);
+                    for (ILinkDiscoveryListener lda : linkDiscoveryAware) { // order maintained
+                        lda.linkDiscoveryUpdate(update);
                     }
                 }
                 catch (Exception e) {
@@ -374,7 +374,6 @@ IFloodlightModule, IInfoProvider, IHAListener {
                       sw, port);
         }
         LLDP lldp;
-
         Ethernet ethernet;
 
         if (isStandard) {

--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -611,7 +611,7 @@ public class TopologyManager implements
         ScheduledExecutorService ses = threadPool.getScheduledExecutor();
         newInstanceTask = new SingletonTask(ses, new NewInstanceWorker());
         linkDiscovery.addListener(this);
-        newInstanceTask.reschedule(1, TimeUnit.MILLISECONDS);
+        newInstanceTask.reschedule(1, TimeUnit.MICROSECONDS);
         floodlightProvider.addOFMessageListener(OFType.PACKET_IN, this);
         floodlightProvider.addHAListener(this);
         addRestletRoutable();

--- a/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceUniqueIndexTest.java
+++ b/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceUniqueIndexTest.java
@@ -51,7 +51,7 @@ public class DeviceUniqueIndexTest extends TestCase {
         List<Entity> d1Entities = new ArrayList<Entity>(2);
         d1Entities.add(e1a);
         d1Entities.add(e1b);
-        d1 = new Device(null, Long.valueOf(1), d1Entities, null);
+        d1 = new Device(null, Long.valueOf(1), null, d1Entities, null);
         
         // e2 and e2 alt match in MAC and VLAN
         e2 = new Entity(2L, (short)2, 2, 2L, 2, new Date());
@@ -145,7 +145,7 @@ public class DeviceUniqueIndexTest extends TestCase {
         // all key fields are null
         idx2.updateIndex(e4, 4L);
         assertEquals(null, idx2.findByEntity(e4));
-        Device d4 = new Device(null, 4L, Collections.<Entity>singleton(e4), null);
+        Device d4 = new Device(null, 4L, null, Collections.<Entity>singleton(e4), null);
         idx2.updateIndex(d4, 4L);
         assertEquals(null, idx2.findByEntity(e4));
         

--- a/src/test/java/net/floodlightcontroller/devicemanager/test/MockDevice.java
+++ b/src/test/java/net/floodlightcontroller/devicemanager/test/MockDevice.java
@@ -19,10 +19,12 @@ package net.floodlightcontroller.devicemanager.test;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.TreeSet;
 
 import net.floodlightcontroller.devicemanager.IEntityClass;
 import net.floodlightcontroller.devicemanager.SwitchPort;
+import net.floodlightcontroller.devicemanager.internal.AttachmentPoint;
 import net.floodlightcontroller.devicemanager.internal.Device;
 import net.floodlightcontroller.devicemanager.internal.DeviceManagerImpl;
 import net.floodlightcontroller.devicemanager.internal.Entity;
@@ -45,9 +47,10 @@ public class MockDevice extends Device {
     }
     
     public MockDevice(DeviceManagerImpl deviceManager, Long deviceKey,
+                      List<AttachmentPoint> aps,
                       Collection<Entity> entities,
                       IEntityClass entityClass) {
-        super(deviceManager, deviceKey, entities, entityClass);
+        super(deviceManager, deviceKey, aps, entities, entityClass);
     }
 
     @Override

--- a/src/test/java/net/floodlightcontroller/devicemanager/test/MockDeviceManager.java
+++ b/src/test/java/net/floodlightcontroller/devicemanager/test/MockDeviceManager.java
@@ -2,12 +2,15 @@ package net.floodlightcontroller.devicemanager.test;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 import net.floodlightcontroller.devicemanager.IDevice;
 import net.floodlightcontroller.devicemanager.IDeviceListener;
 import net.floodlightcontroller.devicemanager.IEntityClass;
 import net.floodlightcontroller.devicemanager.IEntityClassifierService;
+import net.floodlightcontroller.devicemanager.internal.AttachmentPoint;
 import net.floodlightcontroller.devicemanager.internal.Device;
 import net.floodlightcontroller.devicemanager.internal.DeviceManagerImpl;
 import net.floodlightcontroller.devicemanager.internal.Entity;
@@ -55,7 +58,7 @@ public class MockDeviceManager extends DeviceManagerImpl {
             ipv4Address = null;
         IDevice res =  learnDeviceByEntity(new Entity(macAddress, vlan, 
                                                       ipv4Address, switchDPID, 
-                                                      switchPort, null));
+                                                      switchPort, new Date()));
         deviceListeners = listeners;
         return res;
     }
@@ -85,9 +88,10 @@ public class MockDeviceManager extends DeviceManagerImpl {
     
     @Override
     protected Device allocateDevice(Long deviceKey,
-                                    Collection<Entity> entities, 
+                                    List<AttachmentPoint> aps,
+                                    Collection<Entity> entities,
                                     IEntityClass entityClass) {
-        return new MockDevice(this, deviceKey, entities, entityClass);
+        return new MockDevice(this, deviceKey, aps, entities, entityClass);
     }
     
     @Override


### PR DESCRIPTION
...ependent of entities.  Update test cases.  Duplicate Mac test is disabled for the time being.
