### PR TITLE
portEnabled(short) should return false if a port is not present.  TopologyManager checks for "Special" ports and port status as part of "isAttachmentPointPort".  The checking of this logic in devicemanager is removed.

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitchImpl.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitchImpl.java
@@ -290,6 +290,7 @@ public class OFSwitchImpl implements IOFSwitch {
     }
 
     public synchronized boolean portEnabled(short portNumber) {
+        if (ports.get(portNumber) == null) return false;
         return portEnabled(ports.get(portNumber));
     }
     

--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
@@ -75,7 +75,6 @@ DeviceManagerImpl.DeviceUpdate.Change.*;
 import org.openflow.protocol.OFMatchWithSwDpid;
 import org.openflow.protocol.OFMessage;
 import org.openflow.protocol.OFPacketIn;
-import org.openflow.protocol.OFPhysicalPort;
 import org.openflow.protocol.OFType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -748,17 +747,7 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
      */
     protected boolean isValidAttachmentPoint(long switchDPID,
                                              int switchPort) {
-        //IOFSwitch sw = floodlightProvider.getSwitches().get(switchDPID);
-        //if (sw == null) return false;
-        //OFPhysicalPort port = sw.getPort((short)switchPort);
-        //if (port == null || !sw.portEnabled(port)) return false;
         if (topology.isAttachmentPointPort(switchDPID, (short)switchPort) == false)
-            return false;
-
-        // Check whether the port is a physical port. We should not learn
-        // attachment points on "special" ports.
-        if (((switchPort & 0xff00) == 0xff00) &&
-                (switchPort != (short)0xfffe))
             return false;
 
         if (suppressAPs.contains(new SwitchPort(switchDPID, switchPort)))

--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -166,9 +166,22 @@ public class TopologyManager implements
     public boolean isAttachmentPointPort(long switchid, short port, 
                                          boolean tunnelEnabled) {
         TopologyInstance ti = getCurrentInstance(tunnelEnabled);
-        return ti.isAttachmentPointPort(switchid, port);
+
+        // if the port is not attachment point port according to
+        // topology instance, then return false
+        if (ti.isAttachmentPointPort(switchid, port) == false)
+                return false;
+
+        // Check whether the port is a physical port. We should not learn
+        // attachment points on "special" ports.
+        if ((port & 0xff00) == 0xff00 && port != (short)0xfffe) return false;
+
+        // Make sure that the port is enabled.
+        IOFSwitch sw = floodlightProvider.getSwitches().get(switchid);
+        if (sw == null) return false;
+        return (sw.portEnabled(port));
     }
-    
+
     public long getOpenflowDomainId(long switchId) {
         return getOpenflowDomainId(switchId, true);
     }


### PR DESCRIPTION
...gyManager checks for "Special" ports and port status as part of "isAttachmentPointPort".  The checking of this logic in devicemanager is remoed.
