### PR TITLE
Updates to attachment point learning and udpating.  DeviceManager listens to topologyChanged() events.   Whenever a port goes down or a switch is removed, attachment points are updated.  Cleanup of link discovery manager updates; cleanup also includes por

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
@@ -129,7 +129,6 @@ public class Device implements IDevice {
     protected boolean updateAttachmentPoint(long sw, short port, long lastSeen){
         ITopologyService topology = deviceManager.topology;
 
-        // 
         if (!deviceManager.isValidAttachmentPoint(sw, port)) return false;
 
         AttachmentPoint newAP = new AttachmentPoint(sw, port, lastSeen);
@@ -193,6 +192,31 @@ public class Device implements IDevice {
         return true;
     }
 
+    public boolean deleteAttachmentPoint(long sw) {
+        boolean deletedFlag = false;
+        if (this.attachmentPoints == null) return false;
+
+        ArrayList<AttachmentPoint> apList = new ArrayList<AttachmentPoint>();
+        apList.addAll(this.attachmentPoints);
+        ArrayList<AttachmentPoint> modifiedList = new ArrayList<AttachmentPoint>();
+
+        for(AttachmentPoint ap: apList) {
+            if (ap.getSw() == sw) {
+                deletedFlag = true;
+                continue;
+            }
+            modifiedList.add(ap);
+        }
+
+        if (deletedFlag) {
+            this.attachmentPoints = modifiedList;
+            return true;
+        }
+
+        return false;
+    }
+
+
     @Override
     public SwitchPort[] getAttachmentPoints() {
         return getAttachmentPoints(false);
@@ -200,10 +224,11 @@ public class Device implements IDevice {
 
     @Override
     public SwitchPort[] getAttachmentPoints(boolean includeError) {
+        SwitchPort [] returnSwitchPorts = new SwitchPort[] {};
 
         Map<Long, AttachmentPoint> apMap = getAPMap();
-        if (apMap == null) return null;
-        if (apMap.isEmpty()) return null;
+        if (apMap == null) return returnSwitchPorts;
+        if (apMap.isEmpty()) return returnSwitchPorts;
 
         List<SwitchPort> sp = new ArrayList<SwitchPort>();
         for(AttachmentPoint ap: apMap.values()) {

--- a/src/main/java/net/floodlightcontroller/linkdiscovery/ILinkDiscovery.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/ILinkDiscovery.java
@@ -2,29 +2,25 @@ package net.floodlightcontroller.linkdiscovery;
 
 public interface ILinkDiscovery {
 
-    public static enum UpdateOperation {ADD_OR_UPDATE, REMOVE, SWITCH_UPDATED};
+    public static enum UpdateOperation {LINK_UPDATED, LINK_REMOVED, SWITCH_UPDATED, SWITCH_REMOVED, PORT_UP, PORT_DOWN};
 
     public class LDUpdate {
         protected long src;
         protected short srcPort;
-        protected int srcPortState;
         protected long dst;
         protected short dstPort;
-        protected int dstPortState;
         protected SwitchType srcType;
         protected LinkType type;
         protected UpdateOperation operation;
 
-        public LDUpdate(long src, short srcPort, int srcPortState,
-                      long dst, short dstPort, int dstPortState,
+        public LDUpdate(long src, short srcPort,
+                      long dst, short dstPort,
                       ILinkDiscovery.LinkType type,
                       UpdateOperation operation) {
             this.src = src;
             this.srcPort = srcPort;
-            this.srcPortState = srcPortState;
             this.dst = dst;
             this.dstPort = dstPort;
-            this.dstPortState = dstPortState;
             this.type = type;
             this.operation = operation;
         }
@@ -32,20 +28,25 @@ public interface ILinkDiscovery {
         public LDUpdate(LDUpdate old) {
             this.src = old.src;
             this.srcPort = old.srcPort;
-            this.srcPortState = old.srcPortState;
             this.dst = old.dst;
             this.dstPort = old.dstPort;
-            this.dstPortState = old.dstPortState;
             this.srcType = old.srcType;
             this.type = old.type;
             this.operation = old.operation;
         }
 
         // For updtedSwitch(sw)
-        public LDUpdate(long switchId, SwitchType stype) {
-            this.operation = UpdateOperation.SWITCH_UPDATED;
+        public LDUpdate(long switchId, SwitchType stype, UpdateOperation oper ){
+            this.operation = oper;
             this.src = switchId;
             this.srcType = stype;
+        }
+
+        // For port up or port down.
+        public LDUpdate(long sw, short port, UpdateOperation operation) {
+            this.src = sw;
+            this.srcPort = port;
+            this.operation = operation;
         }
 
         public long getSrc() {
@@ -56,20 +57,12 @@ public interface ILinkDiscovery {
             return srcPort;
         }
 
-        public int getSrcPortState() {
-            return srcPortState;
-        }
-
         public long getDst() {
             return dst;
         }
 
         public short getDstPort() {
             return dstPort;
-        }
-
-        public int getDstPortState() {
-            return dstPortState;
         }
 
         public SwitchType getSrcType() {
@@ -91,8 +84,7 @@ public interface ILinkDiscovery {
         @Override
         public String toString() {
             return "LDUpdate [src=" + src + ", srcPort=" + srcPort
-                   + ", srcPortState=" + srcPortState + ", dst=" + dst
-                   + ", dstPort=" + dstPort + ", dstPortState=" + dstPortState
+                   + ", dst=" + dst + ", dstPort=" + dstPort
                    + ", srcType=" + srcType + ", type=" + type + ", operation="
                    + operation + "]";
         }

--- a/src/main/java/net/floodlightcontroller/topology/ITopologyService.java
+++ b/src/main/java/net/floodlightcontroller/topology/ITopologyService.java
@@ -1,6 +1,7 @@
 package net.floodlightcontroller.topology;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 import net.floodlightcontroller.core.module.IFloodlightService;
@@ -188,5 +189,5 @@ public interface ITopologyService extends IFloodlightService  {
      * This method returns the delta in the linkUpdates between the current and the previous topology instance.
      * @return
      */
-    public Set<LDUpdate> getLastLinkUpdates();
+    public List<LDUpdate> getLastLinkUpdates();
 }

--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -40,7 +40,6 @@ import org.openflow.protocol.OFMessage;
 import org.openflow.protocol.OFPacketIn;
 import org.openflow.protocol.OFPacketOut;
 import org.openflow.protocol.OFPort;
-import org.openflow.protocol.OFPhysicalPort.OFPortState;
 import org.openflow.protocol.action.OFAction;
 import org.openflow.protocol.action.OFActionOutput;
 import org.openflow.protocol.OFType;
@@ -90,7 +89,7 @@ public class TopologyManager implements
     protected ArrayList<ITopologyListener> topologyAware;
 
     protected BlockingQueue<LDUpdate> ldUpdates;
-    protected Set<LDUpdate> appliedUpdates;
+    protected List<LDUpdate> appliedUpdates;
     
     // These must be accessed using getCurrentInstance(), not directly
     protected TopologyInstance currentInstance;
@@ -107,10 +106,13 @@ public class TopologyManager implements
         @Override 
         public void run() {
             try {
-	            applyUpdates();
-	            createNewInstance();
-	            lastUpdateTime = new Date();
-	            informListeners();
+                boolean recomputeFlag = false;
+                recomputeFlag = applyUpdates();
+                if (recomputeFlag) {
+                    createNewInstance();
+                }
+                lastUpdateTime = new Date();
+                informListeners();
             }
             catch (Exception e) {
                 log.error("Error in topology instance task thread", e);
@@ -452,7 +454,7 @@ public class TopologyManager implements
     }
 
     @Override
-    public Set<LDUpdate> getLastLinkUpdates() {
+    public List<LDUpdate> getLastLinkUpdates() {
     	return appliedUpdates;
     }
     ////////////////////////////////////////////////////////////////////////
@@ -614,8 +616,7 @@ public class TopologyManager implements
         tunnelLinks = new HashMap<NodePortTuple, Set<Link>>();
         topologyAware = new ArrayList<ITopologyListener>();
         ldUpdates = new LinkedBlockingQueue<LDUpdate>();
-        appliedUpdates = new HashSet<LDUpdate>();
-
+        appliedUpdates = new ArrayList<LDUpdate>();
         clearCurrentTopology();
     }
 
@@ -797,52 +798,41 @@ public class TopologyManager implements
     }
 
 
-    public void applyUpdates() {
-    	appliedUpdates.clear();
+    public boolean applyUpdates() {
+
+        boolean topologyRecomputeRequired = false;
+        appliedUpdates.clear();
         LDUpdate update = null;
         while (ldUpdates.peek() != null) {
-        	boolean updateApplied = false;
-        	LDUpdate newUpdate = null;
             try {
                 update = ldUpdates.take();
-                newUpdate = new LDUpdate(update);
             } catch (Exception e) {
                 log.error("Error reading link discovery update.", e);
             }
             if (log.isTraceEnabled()) {
                 log.trace("Applying update: {}", update);
             }
-            if (update.getOperation() == UpdateOperation.ADD_OR_UPDATE) {
-                boolean added = 
-                        (((update.getSrcPortState() & 
-                           OFPortState.OFPPS_STP_MASK.getValue()) != 
-                           OFPortState.OFPPS_STP_BLOCK.getValue()) &&
-                        ((update.getDstPortState() & 
-                          OFPortState.OFPPS_STP_MASK.getValue()) != 
-                          OFPortState.OFPPS_STP_BLOCK.getValue()));
-                if (added) {
-                    addOrUpdateLink(update.getSrc(), update.getSrcPort(), 
-                                    update.getDst(), update.getDstPort(), 
-                                    update.getType());
-                    updateApplied = true;
-                } else  {
-                    removeLink(update.getSrc(), update.getSrcPort(), 
-                               update.getDst(), update.getDstPort());
-                    newUpdate = new LDUpdate(update);
-                    // set the update operation to remove
-                    newUpdate.setOperation(UpdateOperation.REMOVE);
-                    updateApplied = true;
-                }
-            } else if (update.getOperation() == UpdateOperation.REMOVE) {
+            if (update.getOperation() == UpdateOperation.LINK_UPDATED) {
+                addOrUpdateLink(update.getSrc(), update.getSrcPort(),
+                                update.getDst(), update.getDstPort(),
+                                update.getType());
+                topologyRecomputeRequired = true;
+            } else if (update.getOperation() == UpdateOperation.LINK_REMOVED){
                 removeLink(update.getSrc(), update.getSrcPort(), 
                            update.getDst(), update.getDstPort());
-                updateApplied = true;
+                topologyRecomputeRequired = true;
+            } else if (update.getOperation() == UpdateOperation.SWITCH_REMOVED) {
+                topologyRecomputeRequired = removeSwitch(update.getSrc());
+            } else if (update.getOperation() == UpdateOperation.PORT_DOWN) {
+                topologyRecomputeRequired = removeSwitchPort(update.getSrc(),
+                                                             update.getSrcPort());
             }
 
-            if (updateApplied) {
-            	appliedUpdates.add(newUpdate);
-            }
+            // Add to the list of applied updates.
+            appliedUpdates.add(update);
         }
+
+        return topologyRecomputeRequired;
     }
 
     /**
@@ -903,10 +893,23 @@ public class TopologyManager implements
         switchPorts.get(s).add(p);
     }
 
-    public void removeSwitch(long sid) {
+    public boolean removeSwitchPort(long sw, short port) {
+
+        Set<Link> linksToRemove = new HashSet<Link>();
+        NodePortTuple npt = new NodePortTuple(sw, port);
+        if (switchPortLinks.containsKey(npt) == false) return false;
+
+        linksToRemove.addAll(switchPortLinks.get(npt));
+        for(Link link: linksToRemove) {
+            removeLink(link);
+        }
+        return true;
+    }
+
+    public boolean removeSwitch(long sid) {
         // Delete all the links in the switch, switch and all 
         // associated data should be deleted.
-        if (switchPorts.containsKey(sid) == false) return;
+        if (switchPorts.containsKey(sid) == false) return false;
 
         Set<Link> linksToRemove = new HashSet<Link>();
         for(Short p: switchPorts.get(sid)) {
@@ -914,9 +917,12 @@ public class TopologyManager implements
             linksToRemove.addAll(switchPortLinks.get(n1));
         }
 
+        if (linksToRemove.isEmpty()) return false;
+
         for(Link link: linksToRemove) {
             removeLink(link);
         }
+        return true;
     }
 
     private boolean addLinkToStructure(Map<NodePortTuple, 


### PR DESCRIPTION
...s to topologyChanged() events.  Whenever a port goes down or a switch is removed, attachment points are updated.  Cleanup of link discovery manager updates; cleanup also includes port up/down switch update/removed messages.
