### PR TITLE
Update attachmentpoint whenever topologyChanged() notification is received.  It is not necessary to process every event; just one update call per topologyChanged() should take care of fixing all attachment point changes.

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
@@ -126,6 +126,29 @@ public class Device implements IDevice {
         return apMap;
     }
 
+    protected boolean updateAttachmentPoint() {
+        if (this.attachmentPoints == null) return false;
+
+        List<AttachmentPoint> oldAPList =
+                new ArrayList<AttachmentPoint>(this.attachmentPoints);
+        Map<Long, AttachmentPoint> apMap = getAPMap();
+
+        if (apMap == null) {
+            this.attachmentPoints = null;
+            return true;
+        }
+
+        List<AttachmentPoint> newAPList =
+                new ArrayList<AttachmentPoint>(apMap.values());
+
+        // Since we did not add any new attachment points, it is sufficient
+        // to compare only the lengths.
+        if (oldAPList.size() == newAPList.size()) return false;
+
+        this.attachmentPoints = newAPList;
+        return true;
+    }
+
     protected boolean updateAttachmentPoint(long sw, short port, long lastSeen){
         ITopologyService topology = deviceManager.topology;
 
@@ -234,7 +257,8 @@ public class Device implements IDevice {
         for(AttachmentPoint ap: apMap.values()) {
             SwitchPort swport = new SwitchPort(ap.getSw(),
                                                ap.getPort());
-            sp.add(swport);
+            if (deviceManager.isValidAttachmentPoint(ap.getSw(), ap.getPort()))
+                sp.add(swport);
         }
         return sp.toArray(new SwitchPort[sp.size()]);
     }

--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
@@ -58,8 +58,6 @@ import net.floodlightcontroller.devicemanager.web.DeviceRoutable;
 import net.floodlightcontroller.flowcache.IFlowReconcileListener;
 import net.floodlightcontroller.flowcache.IFlowReconcileService;
 import net.floodlightcontroller.flowcache.OFMatchReconcile;
-import net.floodlightcontroller.linkdiscovery.ILinkDiscovery.LDUpdate;
-import net.floodlightcontroller.linkdiscovery.ILinkDiscovery.UpdateOperation;
 import net.floodlightcontroller.packet.ARP;
 import net.floodlightcontroller.packet.DHCP;
 import net.floodlightcontroller.packet.Ethernet;
@@ -1511,33 +1509,10 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
      */
     @Override
     public void topologyChanged() {
-        List<LDUpdate> updateList = topology.getLastLinkUpdates();
-        for(LDUpdate u: updateList) {
-            if (u.getOperation() == UpdateOperation.SWITCH_REMOVED) {
-                processSwitchRemoved(u.getSrc());
-            } else if (u.getOperation() == UpdateOperation.PORT_DOWN) {
-                processPortDown(u.getSrc(), u.getSrcPort());
-            }
-        }
-    }
-
-    private void processSwitchRemoved(long sw) {
         Iterator<Device> diter = deviceMap.values().iterator();
         while (diter.hasNext()) {
             Device d = diter.next();
-            if (d.deleteAttachmentPoint(sw)) {
-                // update device attachment point changed.
-                sendDeviceMovedNotification(d);
-            }
-        }
-    }
-
-    private void processPortDown(long sw, short port) {
-        Iterator<Device> diter = deviceMap.values().iterator();
-        while (diter.hasNext()) {
-            Device d = diter.next();
-            if (d.deleteAttachmentPoint(sw, port)) {
-                // update device attachment point changed.
+            if (d.updateAttachmentPoint()) {
                 sendDeviceMovedNotification(d);
             }
         }
@@ -1552,5 +1527,4 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
             listener.deviceMoved(d);
         }
     }
-
 }


### PR DESCRIPTION
...ed.  It is not necessary to process every event; just one update call per topologyChanged() should take care of fixing all attachment point changes.
