### PR TITLE
Bug fix in the attachment point learning, where previously known AP was incorrectly added to the oldAP list.

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
@@ -292,9 +292,6 @@ entity.getLastSeenTimestamp().getTime());
     protected boolean updateAttachmentPoint() {
         boolean moved = false;
 
-        List<AttachmentPoint> oldAPList = new ArrayList<AttachmentPoint>();
-        if (oldAPs != null) oldAPList.addAll(oldAPs);
-
         List<AttachmentPoint> apList = new ArrayList<AttachmentPoint>();
         if (attachmentPoints != null) apList.addAll(attachmentPoints);
         Map<Long, AttachmentPoint> newMap = getAPMap(apList);
@@ -309,6 +306,8 @@ entity.getLastSeenTimestamp().getTime());
                     new ArrayList<AttachmentPoint>();
             if (newMap != null) newAPList.addAll(newMap.values());
             this.attachmentPoints = newAPList;
+            log.debug("DEVICE_MOVE: Old AttachmentPoints: {}," +
+                    "New AttachmentPoints: {}", apList, newAPList);
         }
 
         // Set the oldAPs to null.
@@ -347,6 +346,7 @@ entity.getLastSeenTimestamp().getTime());
             newAP = oldAPList.remove(index);
             newAP.setLastSeen(lastSeen);
             this.oldAPs = oldAPList;
+            log.debug("DEVICE_MOVE: OldAPs changed for device: {}", oldAPList);
         }
 
         // newAP now contains the new attachment point.
@@ -356,6 +356,7 @@ entity.getLastSeenTimestamp().getTime());
         if (apMap == null || apMap.isEmpty()) {
             apList.add(newAP);
             attachmentPoints = apList;
+            log.debug("DEVICE_MOVE: First attachmentpoint point for device: {}", apList);
             return true;
         }
 
@@ -368,6 +369,8 @@ entity.getLastSeenTimestamp().getTime());
             apList.addAll(apMap.values());
             apList.add(newAP);
             this.attachmentPoints = apList;
+            log.debug("DEVICE_MOVE: First access point in L2 domain. {}",
+                      apList);
             return true; // new AP found on an L2 island.
         }
 
@@ -388,6 +391,8 @@ entity.getLastSeenTimestamp().getTime());
             apMap.put(id, newAP);
             this.attachmentPoints =
                     new ArrayList<AttachmentPoint>(apMap.values());
+            log.debug("DEVICE_MOVED: Attachment point changed to: {}," +
+                    "putting previous in oldAP: {}", newAP, oldAP);
 
             oldAPList = new ArrayList<AttachmentPoint>();
             if (oldAPs != null) oldAPList.addAll(oldAPs);
@@ -395,9 +400,13 @@ entity.getLastSeenTimestamp().getTime());
             this.oldAPs = oldAPList;
             return true; // attachment point changed.
         } else {
+            // retain oldAP  as is.  Put the newAP in oldAPs for flagging
+            // possible duplicates.
             oldAPList = new ArrayList<AttachmentPoint>();
             if (oldAPs != null) oldAPList.addAll(oldAPs);
-            oldAPList.add(oldAP);
+            oldAPList.add(newAP);
+            log.debug("DEVICE_MOVED: New attachment point {} does not" +
+                    " replace already existing one {}.", newAP, oldAP);
             this.oldAPs = oldAPList;
         }
 
@@ -516,6 +525,8 @@ entity.getLastSeenTimestamp().getTime());
         if (!includeError)
             return sp.toArray(new SwitchPort[sp.size()]);
 
+        log.debug("DEVICE_APS: Getting all attachment points: APs: {}, oldAPs: {}",
+                  this.attachmentPoints, this.oldAPs);
 
         List<AttachmentPoint> oldAPList;
         oldAPList = new ArrayList<AttachmentPoint>();
@@ -535,6 +546,7 @@ entity.getLastSeenTimestamp().getTime());
                     sp.add(swport);
             }
         }
+        log.debug("DEVICE_APS: Duplicate APs: {}", sp);
         return sp.toArray(new SwitchPort[sp.size()]);
     }
 


### PR DESCRIPTION
...e the already known attachment point (oldAP), then we need to put newAP in the oldAPlist for possibly flagging it as duplicate in the future.  Earlier, we were adding the already known attachment point in the list.
