### PR TITLE
BVS interfaces are not being cleaned up -- see BSC-2454

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
@@ -1472,8 +1472,6 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
                         d = deviceMap.get(d.getDeviceKey());
                         if (null != d)
                             continue;
-                        else
-                            break;
                     }
                 } else {
                     deviceUpdates.add(new DeviceUpdate(d, DELETE, null));
@@ -1484,8 +1482,6 @@ IFlowReconcileListener, IInfoProvider, IHAListener {
                         d = deviceMap.get(d.getDeviceKey());
                         if (null != d)
                             continue;
-                        else
-                            break;
                 }
                 processUpdates(deviceUpdates);
                 break;

--- a/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImplTest.java
+++ b/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImplTest.java
@@ -869,6 +869,10 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
     }
 
     public void doTestDeviceExpiration() throws Exception {
+        IDeviceListener mockListener =
+                createStrictMock(IDeviceListener.class);
+        mockListener.deviceRemoved(isA(IDevice.class));
+        
         Calendar c = Calendar.getInstance();
         c.add(Calendar.MILLISECOND, -DeviceManagerImpl.ENTITY_TIMEOUT-1);
         Entity entity1 = new Entity(1L, null, 1, 1L, 1, c.getTime());
@@ -897,6 +901,8 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
         d = deviceManager.learnDeviceByEntity(entity1);
         assertArrayEquals(new Integer[] { 1, 2 }, d.getIPv4Addresses());
 
+        deviceManager.addListener(mockListener);
+        replay(mockListener);
         deviceManager.entityCleanupTask.reschedule(0, null);
 
         IDevice r = deviceManager.getDevice(d.getDeviceKey());
@@ -907,6 +913,8 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 
         r = deviceManager.findDevice(1L, null, null, null, null);
         assertNull(r);
+        
+        verify(mockListener);
     }
     
     /*


### PR DESCRIPTION
- event processing in cleanupEntities was exiting prematurely, some device delete
  updates were not being processed
- updated unittest to verify device deletion
- See BSC-2454
