### PR TITLE
Fix for static flows pusher

### DIFF
--- a/src/main/java/net/floodlightcontroller/staticflowentry/StaticFlowEntryPusher.java
+++ b/src/main/java/net/floodlightcontroller/staticflowentry/StaticFlowEntryPusher.java
@@ -643,13 +643,6 @@ public class StaticFlowEntryPusher
     @Override
     public void addFlow(String name, OFFlowMod fm, String swDpid) {
         Map<String, Object> fmMap = StaticFlowEntries.flowModToStorageEntry(fm, swDpid, name);
-        entry2dpid.put(name, swDpid);
-        Map<String, OFFlowMod> switchEntries = entriesFromStorage.get(swDpid);
-        if (switchEntries == null) {
-            switchEntries = new HashMap<String, OFFlowMod>();
-            entriesFromStorage.put(swDpid, switchEntries);
-        }
-        switchEntries.put(name, fm);
         storageSource.insertRowAsync(TABLE_NAME, fmMap);
     }
 


### PR DESCRIPTION
The removed piece of code is supposed to sync static flow cache, but it is already done in rowsModified(...) method. It even leads to false 'delete' commands in rowsModified(...) method
