### PR TITLE
Improve handling of directories with spaces

### DIFF
--- a/setup-eclipse.sh
+++ b/setup-eclipse.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-
-d=$(dirname $0)
+d=$(dirname "$0")
 MAIN_CLASS=$1
 LIBRARIES=$2
 [ "${MAIN_CLASS}" ] || { echo "Run 'ant eclipse' to generate Eclipse project files"; exit 1; }
 
 
-cat >$d/.project <<EOF
+cat >"$d/.project" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
 	<name>floodlight</name>
@@ -27,7 +26,7 @@ cat >$d/.project <<EOF
 EOF
 
 
-cat >$d/.classpath <<EOF
+cat >"$d/.classpath" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/main/java" output="target/bin"/>
@@ -43,7 +42,7 @@ cat >>$d/.classpath <<EOF
 EOF
 done
 )
-cat >>$d/.classpath <<EOF
+cat >>"$d/.classpath" <<EOF
 	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="target/bin"/>
 </classpath>


### PR DESCRIPTION
hi,

this patch allows 'ant eclipse' to work when the git repo is checked-out into a directory with spaces in the path.

thanks!
Andrew
