### PR TITLE
OF packet queues are always at least min size

### DIFF
--- a/src/main/java/org/openflow/protocol/OFPacketQueue.java
+++ b/src/main/java/org/openflow/protocol/OFPacketQueue.java
@@ -35,7 +35,7 @@ public class OFPacketQueue {
 
     public OFPacketQueue() {
         this.queueId = -1;
-        this.length = -1;
+        this.length = U16.t(MINIMUM_LENGTH);
     }
 
     public OFPacketQueue(int queueId) {


### PR DESCRIPTION
hi,

this is a small bug fix to the just-added support for OF packet queues. it was exposed while testing support for the OpenFlow 1.0 slicing extensions.

thanks!
Andrew
