### PR TITLE
OFSwitchBase write() Consolidation

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/OFSwitchBase.java
+++ b/src/main/java/net/floodlightcontroller/core/OFSwitchBase.java
@@ -230,6 +230,8 @@ public abstract class OFSwitchBase implements IOFSwitch {
                       FloodlightContext bc) throws IOException {
         for (OFMessage m : msglist)
         	this.write(m, bc);
+        
+        flush ();
     }
 
     private void write(List<OFMessage> msglist) throws IOException {


### PR DESCRIPTION
Consolidated `write(OFMessage, FloodlightContext)` and `write(List<OFMessage>, FloodlightContext)`; the latter now invokes the former.
