### PR TITLE
Remove bogus return in LinkDiscoveryManager

### DIFF
--- a/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
@@ -629,7 +629,6 @@ public class LinkDiscoveryManager implements IOFMessageListener,
         if (log.isTraceEnabled()) {
             log.trace("Sending LLDP packet out of swich: {}, port: {}",
                       HexString.toHexString(sw), port);
-            return null;
         }
 
         // using "nearest customer bridge" MAC address for broadest possible


### PR DESCRIPTION
Remove a bogus return statement at the end of a `isTraceEnabled` block in `LinkDiscoveryManager`.
