### PR TITLE
Remove host address configurations from properties file.

### DIFF
--- a/src/main/resources/floodlightdefault.properties
+++ b/src/main/resources/floodlightdefault.properties
@@ -16,9 +16,7 @@ net.floodlightcontroller.debugcounter.DebugCounter,\
 net.floodlightcontroller.perfmon.PktInProcessingTime,\
 net.floodlightcontroller.ui.web.StaticWebRoutable,\
 net.floodlightcontroller.loadbalancer.LoadBalancer
-net.floodlightcontroller.restserver.RestApiServer.host = 192.168.56.2
 net.floodlightcontroller.restserver.RestApiServer.port = 8080
-net.floodlightcontroller.core.FloodlightProvider.openflowhost = 192.168.56.1
 net.floodlightcontroller.core.FloodlightProvider.openflowport = 6633
 net.floodlightcontroller.jython.JythonDebugInterface.port = 6655
 net.floodlightcontroller.forwarding.Forwarding.idletimeout = 5


### PR DESCRIPTION
These configurations are optional, and at its current form, erronous.
