### PR TITLE
added exception handling for the device curl call in the circuitpusher app.

### DIFF
--- a/apps/circuitpusher/circuitpusher.py
+++ b/apps/circuitpusher/circuitpusher.py
@@ -94,14 +94,26 @@ if args.action=='add':
     result = os.popen(command).read()
     parsedResult = json.loads(result)
     print command+"\n"
-    sourceSwitch = parsedResult[0]['attachmentPoint'][0]['switchDPID']
+    
+    try:
+    	sourceSwitch = parsedResult[0]['attachmentPoint'][0]['switchDPID']
+    except IndexError:
+	print "ERROR : the specified end point (%s) must already been known to the controller (i.e., already have sent packets on the network, easy way to assure this is to do a ping (to any target) from the two hosts." % (args.srcAddress)
+	sys.exit()
+
     sourcePort = parsedResult[0]['attachmentPoint'][0]['port']
     
     command = "curl -s http://%s/wm/device/?ipv4=%s" % (args.controllerRestIp, args.dstAddress)
     result = os.popen(command).read()
     parsedResult = json.loads(result)
     print command+"\n"
-    destSwitch = parsedResult[0]['attachmentPoint'][0]['switchDPID']
+
+    try:
+        destSwitch = parsedResult[0]['attachmentPoint'][0]['switchDPID']
+    except IndexError:
+        print "ERROR : the specified end point (%s) must already been known to the controller (i.e., already have sent packets on the network, easy way to assure this is to do a ping (to any target) from the two hosts." % (args.dstAddress) 
+        sys.exit()
+ 
     destPort = parsedResult[0]['attachmentPoint'][0]['port']
     
     print "Creating circuit:"


### PR DESCRIPTION
If host din't involve in the network communication, then if we try to add the circuit for that host then it generates the following exception.

```
mininet@mininet-vm:~/floodlight/apps/circuitpusher\> ./circuitpusher.py --controller 127.0.0.1:8080 --type ip --src 10.0.0.1 --dst 10.0.0.3 --add --name cirtuit2
Namespace(action='add', circuitName='cirtuit2', controllerRestIp='127.0.0.1:8080', dstAddress='10.0.0.3', srcAddress='10.0.0.1', type='ip')
curl -s http://127.0.0.1:8080/wm/device/?ipv4=10.0.0.1

Traceback (most recent call last):
  File "./circuitpusher.py", line 97, in <module>
    sourceSwitch = parsedResult[0]['attachmentPoint'][0]['switchDPID']
IndexError: list index out of range
```

So in PR, I have added lines for the exception handling.
Please suggest for any improvement.

Thanks,
