### PR TITLE
Fix for IOFSwitch leak in thread-local msg buffer.

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/OFSwitchBase.java
+++ b/src/main/java/net/floodlightcontroller/core/OFSwitchBase.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
@@ -158,7 +159,7 @@ public abstract class OFSwitchBase implements IOFSwitch {
             new ThreadLocal<Map<IOFSwitch,List<OFMessage>>>() {
         @Override
         protected Map<IOFSwitch,List<OFMessage>> initialValue() {
-            return new HashMap<IOFSwitch,List<OFMessage>>();
+            return new WeakHashMap<IOFSwitch,List<OFMessage>>();
         }
     };
 


### PR DESCRIPTION
#### Symptom
Number of `OFSwitchImpl` instances keeps increasing, when switches are repeatedly connected/disconnected.

#### Problem
- When a switch is disconnected, entries in `OFSwitchBase#local_msg_buffer`
  (Map from IOFSwitch to List of OFMessage) is not removed.

Map entry for an `IOFSwitch` is initially inserted around [OFSwitchBase.java#L774-L778] (
https://github.com/y-higuchi/floodlight/blob/8369bb33d3707a9393fd662683e1da314666e92f/src/main/java/net/floodlightcontroller/core/OFSwitchBase.java#L774-L778), but is never removed.
Mapped value is cleared on [#write()](https://github.com/y-higuchi/floodlight/blob/8369bb33d3707a9393fd662683e1da314666e92f/src/main/java/net/floodlightcontroller/core/OFSwitchBase.java#L787) and [#flush()](https://github.com/y-higuchi/floodlight/blob/8369bb33d3707a9393fd662683e1da314666e92f/src/main/java/net/floodlightcontroller/core/OFSwitchBase.java#L1193), etc., but Map entry itself for IOFSwitch is never removed.
Since `local_msg_buffer` is class static `ThreadLocal` object, strong reference to `OFSwitchBase` remains as long as the thread is reused in the thread pool.

This patch attempts to fix the issue by changing the Map implementation used for `local_msg_buffer` to WeakHashMap, so that the reference to disconnected IOFSwitch will be automatically released, when no other strong reference remain in the process.


#### Steps to reproduce the issue
1. Start an instance of floodlight
2. Run a script such as below to repeat connecting and disconnecting switches.
    ```bash
    while true; do
      sudo mn --controller=remote,ip=127.0.0.1,port=6633 --topo linear,10 --test none;
      sleep 1;
    done
    ```

3. Attach jvisualvm to floodlight process and start Memory sample.
4. Filter the Heap histogram by `OFSwitchImpl` to observe that number of instances keeps increasing, even after manually performing GC through jvisualvm, etc.
