### PR TITLE
Added option to remove debug counters from the hierarchy if it's been ad...

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitchManager.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitchManager.java
@@ -640,7 +640,6 @@ public class OFSwitchManager implements IOFSwitchManager, INewOFConnectionListen
 
 		this.switchListeners = new CopyOnWriteArraySet<IOFSwitchListener>();
 
-		this.counters = new SwitchManagerCounters(debugCounterService);
 		/* TODO @Ryan
 		try {
 			this.storeClient = this.syncService.getStoreClient(

--- a/src/main/java/net/floodlightcontroller/debugcounter/IDebugCounterService.java
+++ b/src/main/java/net/floodlightcontroller/debugcounter/IDebugCounterService.java
@@ -79,6 +79,18 @@ public interface IDebugCounterService extends IFloodlightService {
      * @return false if the given module name does not exists
      */
     public boolean resetAllModuleCounters(String moduleName);
+    
+    /**
+     * Removes/deletes the counter hierarchy AND ALL LEVELS BELOW it in the hierarchy.
+     * For example: If a hierarchy exists like "00:00:00:00:01:02:03:04/pktin/drops"
+     *              specifying a remove hierarchy: "00:00:00:00:01:02:03:04"
+     *              will remove all counters for the switch dpid specified;
+     *              while specifying a remove hierarchy: ""00:00:00:00:01:02:03:04/pktin"
+     *              will remove the pktin counter and all levels below it (like drops)
+     *              for the switch dpid specified.
+     * @return false if the given moduleName, counterHierarchy does not exist
+     */
+    public boolean removeCounterHierarchy(String moduleName, String counterHierarchy);
 
 
     /**

--- a/src/main/java/net/floodlightcontroller/debugcounter/MockDebugCounterService.java
+++ b/src/main/java/net/floodlightcontroller/debugcounter/MockDebugCounterService.java
@@ -112,4 +112,10 @@ public class MockDebugCounterService implements IFloodlightModule, IDebugCounter
         }
     }
 
+	@Override
+	public boolean removeCounterHierarchy(String moduleName,
+			String counterHierarchy) {
+		return true;
+	}
+
 }


### PR DESCRIPTION
@capveg Added option to remove debug counters from the hierarchy if it's been added; useful for keeping track of switch or device counters, which might not stick around forever. Fixed bug in CounterNode where non-null was returned regardless of whether a counter was already present or was a new counter. DebugCounterServiceImpl prints a debug message if non-null is returned, mistakenly indicating you're adding a counter that you already had registerd (generated TONS of annoying incorrect debug messages at startup). Next bug... I accidentally initialized counters twice in the OFSwitchManager; now only done once.
