### PR TITLE
fix matching problems of IP wildcarding

### DIFF
--- a/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
@@ -919,7 +919,7 @@ public class LoadBalancer implements IFloodlightModule,
         SubActionStruct sa = null;
         Matcher n;
         
-        n = Pattern.compile("output=(?:((?:0x)?\\d+)|(all)|(controller)|(local)|(ingress-port)|(normal)|(flood))").matcher(subaction);
+        n = Pattern.compile("output=(?:((?:0x)?\\d+)|(all)|(controller)|(local)|(ingress-port)|(normal)|(flood)|(table))").matcher(subaction);
         if (n.matches()) {
             OFActionOutput action = new OFActionOutput();
             action.setMaxLength(Short.MAX_VALUE);
@@ -945,6 +945,8 @@ public class LoadBalancer implements IFloodlightModule,
                 port = OFPort.OFPP_NORMAL.getValue();
             else if (n.group(7) != null)
                 port = OFPort.OFPP_FLOOD.getValue();
+            else if (n.group(8) != null)
+                port = OFPort.OFPP_TABLE.getValue();
             action.setPort(port);
             log.debug("action {}", action);
             

--- a/src/main/java/org/openflow/protocol/OFMatch.java
+++ b/src/main/java/org/openflow/protocol/OFMatch.java
@@ -776,8 +776,8 @@ public class OFMatch implements Cloneable, Serializable {
             return false;
         if (srcmasklen >= 32 && networkSource != toCompare.getNetworkSource())
             return false;
-        int dstmask = ~((1 << (32 - dstmasklen)) - 1);
-        int srcmask = ~((1 << (32 - srcmasklen)) - 1);
+        int dstmask = dstmasklen == 0 ? 0 : ~((1 << (32 - dstmasklen)) - 1);
+        int srcmask = srcmasklen == 0 ? 0 : ~((1 << (32 - srcmasklen)) - 1);
         if (dstmasklen < 32 &&
                 (networkDestination & dstmask) != (toCompare.getNetworkDestination() & dstmask))
             return false;


### PR DESCRIPTION
* fix problems same as [#462](https://github.com/floodlight/floodlight/pull/462) in LoadBalancer.java
* fix match comparison function:  
Two OFMatch instances (says A, B) are compared to check if one of either can be matched by the other one.
If dstmasklen is "0" (networkDestination should be "0" as well), it means dst-ip of A is a wildcard field. That is, any dst-ip matched by B should be matched by A.  
However, "(1 << (32 - dstmasklen))" would be "1", not "0" and make dstmask be "-1".
(The reason is that an int variable shifted by 32 bits will return the same value. [See.](http://stackoverflow.com/questions/14817639/java-bit-operations-shift))
<pre><code>int dstmask = ~((1 << (32 - dstmasklen)) - 1);</pre></code>
Finally, it may fail to pass the comparison if "toCompare.getNetworkDestination()" is not 0.
<pre><code>if (dstmasklen < 32 &&
           (networkDestination & dstmask) != (toCompare.getNetworkDestination() & dstmask))
        return false;</pre></code>
