### PR TITLE
refactoring Guava ListenableFuture to Java 8 CompletableFuture

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -44,8 +44,8 @@
     <property name="floodlight-test-jar" location="${target}/floodlight-test.jar"/>
     <property name="thrift.dir" value="${basedir}/src/main/thrift"/>
     <property name="thrift.out.dir" value="lib/gen-java"/>
-    <property name="ant.build.javac.source" value="1.7"/>
-    <property name="ant.build.javac.target" value="1.7"/>
+    <property name="ant.build.javac.source" value="1.8"/>
+    <property name="ant.build.javac.target" value="1.8"/>
     <property name="findbugs.home" value="../build/findbugs-2.0.2"/>
     <property name="findbugs.results" value="findbugs-results" />
     <property name="lib" location="lib"/>
@@ -324,7 +324,7 @@
             noindex="false"
             nonavbar="false"
             notree="false"
-            source="1.7"
+            source="1.8"
             sourcepath="${source}"
             splitindex="true"
             use="true"

--- a/src/main/java/net/floodlightcontroller/core/DeliverableListenableFuture.java
+++ b/src/main/java/net/floodlightcontroller/core/DeliverableListenableFuture.java
@@ -1,6 +1,6 @@
 package net.floodlightcontroller.core;
 
-import com.google.common.util.concurrent.AbstractFuture;
+import java.util.concurrent.CompletableFuture;
 
 /** Implementation of a ListenableFuture that provides a Deliverable interface to
  *  the provider.
@@ -9,14 +9,14 @@ import com.google.common.util.concurrent.AbstractFuture;
  * @see Deliverable
  * @param <T>
  */
-public class DeliverableListenableFuture<T> extends AbstractFuture<T> implements Deliverable<T> {
+public class DeliverableListenableFuture<T> extends CompletableFuture<T> implements Deliverable<T> {
     @Override
     public void deliver(final T result) {
-        set(result);
+        complete(result);
     }
 
     @Override
     public void deliverError(final Throwable cause) {
-        setException(cause);
+    	completeExceptionally(cause);
     }
 }

--- a/src/main/java/net/floodlightcontroller/core/IOFMessageWriter.java
+++ b/src/main/java/net/floodlightcontroller/core/IOFMessageWriter.java
@@ -18,6 +18,7 @@
 package net.floodlightcontroller.core;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import org.projectfloodlight.openflow.protocol.OFMessage;
 import org.projectfloodlight.openflow.protocol.OFRequest;
@@ -63,7 +64,7 @@ public interface IOFMessageWriter{
      *         If the connection is not currently connected, will
      *         return a Future that immediately fails with a @link{SwitchDisconnectedException}.
      */
-    <R extends OFMessage> ListenableFuture<R> writeRequest(OFRequest<R> request);
+    <R extends OFMessage> CompletableFuture<R> writeRequest(OFRequest<R> request);
 
     /** write a Stats (Multipart-) request, register for all corresponding reply messages.
      * Returns a Future object that can be used to retrieve the List of asynchronous
@@ -74,6 +75,6 @@ public interface IOFMessageWriter{
      *         If the connection is not currently connected, will
      *         return a Future that immediately fails with a @link{SwitchDisconnectedException}.
      */
-    <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(
+    <REPLY extends OFStatsReply> CompletableFuture<List<REPLY>> writeStatsRequest(
             OFStatsRequest<REPLY> request);
 }

--- a/src/main/java/net/floodlightcontroller/core/IOFSwitch.java
+++ b/src/main/java/net/floodlightcontroller/core/IOFSwitch.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Date;
+import java.util.concurrent.CompletableFuture;
 
 import org.projectfloodlight.openflow.protocol.OFActionType;
 import org.projectfloodlight.openflow.protocol.OFCapabilities;
@@ -36,7 +37,6 @@ import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFPort;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.ListenableFuture;
 import net.floodlightcontroller.core.web.serializers.IOFSwitchSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 /**
@@ -322,7 +322,7 @@ public interface IOFSwitch extends IOFMessageWriter {
      *         If the connection is not currently connected, will
      *         return a Future that immediately fails with a @link{SwitchDisconnectedException}.
      */
-    <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request, LogicalOFMessageCategory category);
+    <REPLY extends OFStatsReply> CompletableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request, LogicalOFMessageCategory category);
 
     /** write an OpenFlow Request message, register for a single corresponding reply message
      *  or error message.
@@ -335,5 +335,5 @@ public interface IOFSwitch extends IOFMessageWriter {
      *         If the connection is not currently connected, will
      *         return a Future that immediately fails with a @link{SwitchDisconnectedException}.
      */
-    <R extends OFMessage> ListenableFuture<R> writeRequest(OFRequest<R> request, LogicalOFMessageCategory category);
+    <R extends OFMessage> CompletableFuture<R> writeRequest(OFRequest<R> request, LogicalOFMessageCategory category);
 }

--- a/src/main/java/net/floodlightcontroller/core/NullConnection.java
+++ b/src/main/java/net/floodlightcontroller/core/NullConnection.java
@@ -4,6 +4,7 @@ import java.net.SocketAddress;
 import java.util.List;
 
 import java.util.Date;
+import java.util.concurrent.CompletableFuture;
 import net.floodlightcontroller.core.internal.IOFConnectionListener;
 import org.projectfloodlight.openflow.protocol.OFFactories;
 import org.projectfloodlight.openflow.protocol.OFFactory;
@@ -16,9 +17,6 @@ import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFAuxId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 
 public class NullConnection implements IOFConnectionBackend, IOFMessageWriter {
     private static final Logger logger = LoggerFactory.getLogger(NullConnection.class);
@@ -63,9 +61,11 @@ public class NullConnection implements IOFConnectionBackend, IOFMessageWriter {
     }
 
     @Override
-    public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(
+    public <REPLY extends OFStatsReply> CompletableFuture<List<REPLY>> writeStatsRequest(
             OFStatsRequest<REPLY> request) {
-        return Futures.immediateFailedFuture(new SwitchDisconnectedException(getDatapathId()));
+        CompletableFuture<List<REPLY>> future = new CompletableFuture<>();
+        future.completeExceptionally(new SwitchDisconnectedException(getDatapathId()));
+        return future;
     }
 
     @Override
@@ -79,8 +79,10 @@ public class NullConnection implements IOFConnectionBackend, IOFMessageWriter {
     }
 
     @Override
-    public <R extends OFMessage> ListenableFuture<R> writeRequest(OFRequest<R> request) {
-        return Futures.immediateFailedFuture(new SwitchDisconnectedException(getDatapathId()));
+    public <R extends OFMessage> CompletableFuture<R> writeRequest(OFRequest<R> request) {
+        CompletableFuture<R> future = new CompletableFuture<>();
+        future.completeExceptionally(new SwitchDisconnectedException(getDatapathId()));
+        return future;
     }
 
     @Override

--- a/src/main/java/net/floodlightcontroller/core/OFSwitch.java
+++ b/src/main/java/net/floodlightcontroller/core/OFSwitch.java
@@ -33,6 +33,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.annotation.Nonnull;
@@ -74,7 +75,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.ListenableFuture;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -743,12 +743,12 @@ public class OFSwitch implements IOFSwitchBackend {
     }
 
     @Override
-    public <R extends OFMessage> ListenableFuture<R> writeRequest(OFRequest<R> request, LogicalOFMessageCategory category) {
+    public <R extends OFMessage> CompletableFuture<R> writeRequest(OFRequest<R> request, LogicalOFMessageCategory category) {
         return getConnection(category).writeRequest(request);
     }
 
     @Override
-    public <R extends OFMessage> ListenableFuture<R> writeRequest(OFRequest<R> request) {
+    public <R extends OFMessage> CompletableFuture<R> writeRequest(OFRequest<R> request) {
         return connections.get(OFAuxId.MAIN).writeRequest(request);
     }
 
@@ -902,12 +902,12 @@ public class OFSwitch implements IOFSwitchBackend {
     }
 
     @Override
-    public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request) {
+    public <REPLY extends OFStatsReply> CompletableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request) {
         return connections.get(OFAuxId.MAIN).writeStatsRequest(request);
     }
 
     @Override
-    public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request, LogicalOFMessageCategory category) {
+    public <REPLY extends OFStatsReply> CompletableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request, LogicalOFMessageCategory category) {
         return getConnection(category).writeStatsRequest(request);
     }
 

--- a/src/main/java/net/floodlightcontroller/core/web/SwitchResourceBase.java
+++ b/src/main/java/net/floodlightcontroller/core/web/SwitchResourceBase.java
@@ -18,6 +18,7 @@
 package net.floodlightcontroller.core.web;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -42,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.primitives.UnsignedLong;
-import com.google.common.util.concurrent.ListenableFuture;
 
 /**
  * Base class for server resources related to switches
@@ -82,7 +82,7 @@ public class SwitchResourceBase extends ServerResource {
 		IOFSwitchService switchService = (IOFSwitchService) getContext().getAttributes().get(IOFSwitchService.class.getCanonicalName());
 
 		IOFSwitch sw = switchService.getSwitch(switchId);
-		ListenableFuture<?> future;
+		CompletableFuture<?> future;
 		List<OFStatsReply> values = null;
 		Match match;
 		if (sw != null) {

--- a/src/test/java/net/floodlightcontroller/core/OFConnectionTest.java
+++ b/src/test/java/net/floodlightcontroller/core/OFConnectionTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.easymock.Capture;
@@ -52,7 +53,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.ListenableFuture;
 
 public class OFConnectionTest {
     private static final Logger logger = LoggerFactory.getLogger(OFConnectionTest.class);
@@ -80,7 +80,7 @@ public class OFConnectionTest {
         Capture<List<OFMessage>> cMsgList = prepareChannelForWriteList();
 
         OFEchoRequest echoRequest = factory.echoRequest(new byte[] {});
-        ListenableFuture<OFEchoReply> future = conn.writeRequest(echoRequest);
+        CompletableFuture<OFEchoReply> future = conn.writeRequest(echoRequest);
         assertThat("Connection should have 1 pending request",
                 conn.getPendingRequestIds().size(), equalTo(1));
 
@@ -108,7 +108,7 @@ public class OFConnectionTest {
         Capture<List<OFMessage>> cMsgList = prepareChannelForWriteList();
 
         OFFlowStatsRequest flowStatsRequest = factory.buildFlowStatsRequest().build();
-        ListenableFuture<List<OFFlowStatsReply>> future = conn.writeStatsRequest(flowStatsRequest);
+        CompletableFuture<List<OFFlowStatsReply>> future = conn.writeStatsRequest(flowStatsRequest);
         assertThat("Connection should have 1 pending request",
                 conn.getPendingRequestIds().size(), equalTo(1));
 
@@ -155,7 +155,7 @@ public class OFConnectionTest {
         Capture<List<OFMessage>> cMsgList = prepareChannelForWriteList();
 
         OFRoleRequest roleRequest = factory.buildRoleRequest().setRole(OFControllerRole.ROLE_MASTER).build();
-        ListenableFuture<OFRoleReply> future = conn.writeRequest(roleRequest);
+        CompletableFuture<OFRoleReply> future = conn.writeRequest(roleRequest);
         assertThat("Connection should have 1 pending request",
                 conn.getPendingRequestIds().size(), equalTo(1));
 
@@ -185,7 +185,7 @@ public class OFConnectionTest {
         replay(channel);
 
         OFEchoRequest echoRequest = factory.echoRequest(new byte[] {});
-        ListenableFuture<OFEchoReply> future = conn.writeRequest(echoRequest);
+        CompletableFuture<OFEchoReply> future = conn.writeRequest(echoRequest);
 
         SwitchDisconnectedException e =
                 FutureTestUtils.assertFutureFailedWithException(future,
@@ -200,7 +200,7 @@ public class OFConnectionTest {
         prepareChannelForWriteList();
 
         OFEchoRequest echoRequest = factory.echoRequest(new byte[] {});
-        ListenableFuture<OFEchoReply> future = conn.writeRequest(echoRequest);
+        CompletableFuture<OFEchoReply> future = conn.writeRequest(echoRequest);
 
         assertThat("Connection should have 1 pending request", conn.getPendingRequestIds().size(),
                 equalTo(1));

--- a/src/test/java/net/floodlightcontroller/core/internal/MockOFConnection.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/MockOFConnection.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import java.util.Date;
+import java.util.concurrent.CompletableFuture;
 import net.floodlightcontroller.core.IOFConnectionBackend;
 import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFMessage;
@@ -19,8 +20,6 @@ import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFAuxId;
 
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 
 public class MockOFConnection implements IOFConnectionBackend {
 
@@ -81,25 +80,25 @@ public class MockOFConnection implements IOFConnectionBackend {
 
     static class RequestAndFuture<R extends OFMessage> {
         final OFRequest<R> request;
-        final SettableFuture<R> replyFuture;
+        final CompletableFuture<R> replyFuture;
 
         public RequestAndFuture(OFRequest<R> request) {
             this.request = request;
-            this.replyFuture = SettableFuture.create();
+            this.replyFuture = new CompletableFuture<>();
         }
 
         public OFRequest<R> getRequest() {
             return request;
         }
 
-        public SettableFuture<R> getReplyFuture() {
+        public CompletableFuture<R> getReplyFuture() {
             return replyFuture;
         }
 
     }
 
     @Override
-    public <R extends OFMessage> ListenableFuture<R>
+    public <R extends OFMessage> CompletableFuture<R>
             writeRequest(OFRequest<R> request) {
         RequestAndFuture<R> raf = new RequestAndFuture<>(request);
         messages.add(request);
@@ -108,7 +107,7 @@ public class MockOFConnection implements IOFConnectionBackend {
     }
 
     @Override
-    public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>>
+    public <REPLY extends OFStatsReply> CompletableFuture<List<REPLY>>
             writeStatsRequest(OFStatsRequest<REPLY> request) {
         return null;
     }

--- a/src/test/java/net/floodlightcontroller/core/internal/MockOFSwitchImpl.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/MockOFSwitchImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
 
 import org.easymock.EasyMock;
 import net.floodlightcontroller.core.OFSwitch;
@@ -14,8 +15,6 @@ import org.projectfloodlight.openflow.protocol.OFStatsReply;
 import org.projectfloodlight.openflow.protocol.OFStatsRequest;
 import org.projectfloodlight.openflow.protocol.OFStatsType;
 import org.projectfloodlight.openflow.protocol.OFVersion;
-
-import com.google.common.util.concurrent.ListenableFuture;
 
 /**
  * A sublcass of OFSwitchImpl that contains extra setters.
@@ -47,9 +46,9 @@ public class MockOFSwitchImpl extends OFSwitch {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request) {
-        ListenableFuture<List<REPLY>> ofStatsFuture =
-                EasyMock.createNiceMock(ListenableFuture.class);
+    public <REPLY extends OFStatsReply> CompletableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request) {
+    CompletableFuture<List<REPLY>> ofStatsFuture =
+                EasyMock.createNiceMock(CompletableFuture.class);
 
         // We create a mock future and return info from the map
         try {

--- a/src/test/java/net/floodlightcontroller/util/OFMessageDamperMockSwitch.java
+++ b/src/test/java/net/floodlightcontroller/util/OFMessageDamperMockSwitch.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import net.floodlightcontroller.core.IOFConnection;
 import net.floodlightcontroller.core.IOFSwitch;
@@ -210,14 +211,14 @@ public class OFMessageDamperMockSwitch implements IOFSwitch {
 	}
 
 	@Override
-	public <R extends OFMessage> ListenableFuture<R> writeRequest(
+	public <R extends OFMessage> CompletableFuture<R> writeRequest(
 			OFRequest<R> request) {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
-	public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(
+	public <REPLY extends OFStatsReply> CompletableFuture<List<REPLY>> writeStatsRequest(
 			OFStatsRequest<REPLY> request) {
 		// TODO Auto-generated method stub
 		return null;
@@ -298,14 +299,14 @@ public class OFMessageDamperMockSwitch implements IOFSwitch {
 	}
 
 	@Override
-	public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(
+	public <REPLY extends OFStatsReply> CompletableFuture<List<REPLY>> writeStatsRequest(
 			OFStatsRequest<REPLY> request, LogicalOFMessageCategory category) {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
-	public <R extends OFMessage> ListenableFuture<R> writeRequest(
+	public <R extends OFMessage> CompletableFuture<R> writeRequest(
 			OFRequest<R> request, LogicalOFMessageCategory category) {
 		// TODO Auto-generated method stub
 		return null;


### PR DESCRIPTION
Hi, I'm doing research on new concurrent constructs in Java 8. I found `CompletableFuture` in Java 8 has the same functionality as Guava `ListenableFuture`. But `CompletableFuture` is much nicer because it comes together with Lambda expression in Java 8, and it is monadic, which makes the code more readable and cleaner. Also, it provides more ways to compose different async tasks. Therefore, using `CompletableFuture` instead of `ListenableFuture` is better for future extension and maintenance of the code.

I tried to refactoring Guava `ListenableFuture` to Java 8 `CompletableFuture` in `Floodlight`, so you can see the difference in the code. I'm just wondering your opinion on this kind of refactoring (or migrating the code from Java 7 to Java 8). Do you think the refactoring is useful? Do you have any plan to use Java 8?