### PR TITLE
Refactored firewall REST api.  Allow POST for firewall enable/disable.

### DIFF
--- a/src/main/java/net/floodlightcontroller/firewall/FirewallDisableResource.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallDisableResource.java
@@ -1,0 +1,52 @@
+/**
+ *    Copyright 2011, Big Switch Networks, Inc.
+ *    Originally created by Amer Tahir
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ **/
+
+package net.floodlightcontroller.firewall;
+
+import org.restlet.resource.Post;
+import org.restlet.resource.Get;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/*
+ * Rest API endpoint to disable the firewall
+ *
+ * Contrary to best practices it changes the state on both GET and POST
+ * We should disable this behavior for GET as soon as we can be sure
+ * that no clients depend on this behavior.
+ */
+public class FirewallDisableResource extends FirewallResourceBase {
+    private static final Logger log = LoggerFactory.getLogger(FirewallDisableResource.class);
+
+    @Get("json")
+    public Object handleRequest() {
+	log.warn("REST call to FirewallDisableResource with method GET is depreciated. Use POST: ");
+	
+	return handlePost();
+    }
+
+    @Post("json")
+    public Object handlePost() {
+        IFirewallService firewall = getFirewallService();
+
+	firewall.enableFirewall(false);
+
+	return "{\"status\" : \"success\", \"details\" : \"firewall stopped\"}";
+    }
+}

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallDisableResource.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallDisableResource.java
@@ -17,8 +17,9 @@
 
 package net.floodlightcontroller.firewall;
 
-import org.restlet.resource.Post;
 import org.restlet.resource.Get;
+import org.restlet.resource.Put;
+import org.restlet.data.Status;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,26 +27,25 @@ import org.slf4j.LoggerFactory;
 
 /*
  * Rest API endpoint to disable the firewall
- *
- * Contrary to best practices it changes the state on both GET and POST
- * We should disable this behavior for GET as soon as we can be sure
- * that no clients depend on this behavior.
  */
 public class FirewallDisableResource extends FirewallResourceBase {
     private static final Logger log = LoggerFactory.getLogger(FirewallDisableResource.class);
 
     @Get("json")
     public Object handleRequest() {
-	log.warn("REST call to FirewallDisableResource with method GET is depreciated. Use POST: ");
-	
-	return handlePost();
+        log.warn("call to FirewallDisableResource with method GET is not allowed. Use PUT: ");
+        
+        setStatus(Status.CLIENT_ERROR_METHOD_NOT_ALLOWED);
+	return "{\"status\" : \"failure\", \"details\" : \"Use PUT to disable firewall\"}";
     }
 
-    @Post("json")
-    public Object handlePost() {
+    @Put("json")
+    public Object handlePut() {
         IFirewallService firewall = getFirewallService();
 
 	firewall.enableFirewall(false);
+
+        setStatus(Status.SUCCESS_OK);
 
 	return "{\"status\" : \"success\", \"details\" : \"firewall stopped\"}";
     }

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallEnableResource.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallEnableResource.java
@@ -1,0 +1,53 @@
+/**
+ *    Copyright 2011, Big Switch Networks, Inc.
+ *    Originally created by Amer Tahir
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ **/
+
+package net.floodlightcontroller.firewall;
+
+import org.restlet.resource.Post;
+import org.restlet.resource.Get;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/*
+ * Rest API endpoint to enable the firewall
+ *
+ * Contrary to best practices it changes the state on both GET and POST
+ * We should disable this behavior for GET as soon as we can be sure
+ * that no clients depend on this behavior.
+ */
+public class FirewallEnableResource extends FirewallResourceBase {
+    private static final Logger log = LoggerFactory.getLogger(FirewallEnableResource.class);
+
+    @Get("json")
+    public Object handleRequest() {
+	log.warn("REST call to FirewallEnableResource with method GET is depreciated.  Use POST: ");
+	
+	return handlePost();
+    }
+
+    @Post("json")
+    public Object handlePost() {
+        IFirewallService firewall = getFirewallService();
+
+	firewall.enableFirewall(true);
+
+	return "{\"status\" : \"success\", \"details\" : \"firewall running\"}";
+    }
+}
+

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallEnableResource.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallEnableResource.java
@@ -17,8 +17,9 @@
 
 package net.floodlightcontroller.firewall;
 
-import org.restlet.resource.Post;
 import org.restlet.resource.Get;
+import org.restlet.resource.Put;
+import org.restlet.data.Status;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,26 +27,25 @@ import org.slf4j.LoggerFactory;
 
 /*
  * Rest API endpoint to enable the firewall
- *
- * Contrary to best practices it changes the state on both GET and POST
- * We should disable this behavior for GET as soon as we can be sure
- * that no clients depend on this behavior.
  */
 public class FirewallEnableResource extends FirewallResourceBase {
     private static final Logger log = LoggerFactory.getLogger(FirewallEnableResource.class);
 
     @Get("json")
     public Object handleRequest() {
-	log.warn("REST call to FirewallEnableResource with method GET is depreciated.  Use POST: ");
-	
-	return handlePost();
+        log.warn("call to FirewallDisableResource with method GET is not allowed. Use PUT: ");
+        
+        setStatus(Status.CLIENT_ERROR_METHOD_NOT_ALLOWED);
+	return "{\"status\" : \"failure\", \"details\" : \"Use PUT to enable firewall\"}";
     }
 
-    @Post("json")
-    public Object handlePost() {
+    @Put("json")
+    public Object handlePut() {
         IFirewallService firewall = getFirewallService();
 
 	firewall.enableFirewall(true);
+
+        setStatus(Status.SUCCESS_OK);
 
 	return "{\"status\" : \"success\", \"details\" : \"firewall running\"}";
     }

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallResourceBase.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallResourceBase.java
@@ -1,0 +1,32 @@
+/**
+ *    Copyright 2011, Big Switch Networks, Inc.
+ *    Originally created by Amer Tahir
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ **/
+
+package net.floodlightcontroller.firewall;
+
+import org.restlet.resource.ServerResource;
+
+
+/*
+ * Base class for Firewall REST API endpoints.
+ * Provides a convenience method to retrieve the firewall service
+ */
+class FirewallResourceBase extends ServerResource {
+    IFirewallService getFirewallService() {
+	return (IFirewallService)getContext().getAttributes().
+	        get(IFirewallService.class.getCanonicalName());
+    }
+}

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallStatusResource.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallStatusResource.java
@@ -1,0 +1,36 @@
+/**
+ *    Copyright 2011, Big Switch Networks, Inc.
+ *    Originally created by Amer Tahir
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ **/
+
+package net.floodlightcontroller.firewall;
+
+import org.restlet.resource.Get;
+
+
+/*
+ * REST API for retrieving the status of the firewall
+ */
+public class FirewallStatusResource extends FirewallResourceBase {
+    @Get("json")
+    public Object handleRequest() {
+        IFirewallService firewall = this.getFirewallService();
+
+	if (firewall.isEnabled())
+	    return "{\"result\" : \"firewall enabled\"}";
+	else
+	    return "{\"result\" : \"firewall disabled\"}";
+    }
+}

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallStorageRulesResource.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallStorageRulesResource.java
@@ -1,0 +1,38 @@
+/**
+ *    Copyright 2011, Big Switch Networks, Inc.
+ *    Originally created by Amer Tahir
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ **/
+
+package net.floodlightcontroller.firewall;
+
+import java.io.IOException;
+
+import org.restlet.resource.Get;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class FirewallStorageRulesResource extends FirewallResourceBase {
+    // REST API for retrieving rules from storage
+
+    private static final Logger log = LoggerFactory.getLogger(FirewallStorageRulesResource.class);
+
+    @Get("json")
+    public Object handleRequest() {
+        IFirewallService firewall = getFirewallService();
+
+	return firewall.getStorageRules();
+    }
+}

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallSubnetMaskResource.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallSubnetMaskResource.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 import org.restlet.resource.Post;
 import org.restlet.resource.Get;
 import org.restlet.resource.ServerResource;
+import org.restlet.data.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,9 +54,14 @@ public class FirewallSubnetMaskResource extends FirewallResourceBase {
             newMask = jsonExtractSubnetMask(fmJson);
         } catch (IOException e) {
             log.error("Error parsing new subnet mask: " + fmJson, e);
+            setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
             return "{\"status\" : \"Error! Could not parse new subnet mask, see log for details.\"}";
         }
+
         firewall.setSubnetMask(newMask);
+
+        setStatus(Status.SUCCESS_OK);
+
         return ("{\"status\" : \"subnet mask set\"}");
     }
 

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallSubnetMaskResource.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallSubnetMaskResource.java
@@ -29,63 +29,24 @@ import org.restlet.resource.ServerResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FirewallResource extends ServerResource {
-    protected static Logger log = LoggerFactory.getLogger(FirewallResource.class);
+
+public class FirewallSubnetMaskResource extends FirewallResourceBase {
+    // REST API to get or set local subnet mask -- this only makes sense for one subnet
+    // will remove later
+
+    private static final Logger log = LoggerFactory.getLogger(FirewallSubnetMaskResource.class);
 
     @Get("json")
     public Object handleRequest() {
-        IFirewallService firewall =
-                (IFirewallService)getContext().getAttributes().
-                get(IFirewallService.class.getCanonicalName());
+        IFirewallService firewall = getFirewallService();
 
-        String op = (String) getRequestAttributes().get("op");
-
-        // REST API check status
-        if (op.equalsIgnoreCase("status")) {
-            if (firewall.isEnabled())
-                return "{\"result\" : \"firewall enabled\"}";
-            else
-                return "{\"result\" : \"firewall disabled\"}";
-        }
-
-        // REST API enable firewall
-        if (op.equalsIgnoreCase("enable")) {
-            firewall.enableFirewall(true);
-            return "{\"status\" : \"success\", \"details\" : \"firewall running\"}";
-        }
-
-        // REST API disable firewall
-        if (op.equalsIgnoreCase("disable")) {
-            firewall.enableFirewall(false);
-            return "{\"status\" : \"success\", \"details\" : \"firewall stopped\"}";
-        }
-
-        // REST API retrieving rules from storage
-        // currently equivalent to /wm/firewall/rules/json
-        if (op.equalsIgnoreCase("storageRules")) {
-            return firewall.getStorageRules();
-        }
-
-        // REST API set local subnet mask -- this only makes sense for one subnet
-        // will remove later
-        if (op.equalsIgnoreCase("subnet-mask")) {
-            return "{\"subnet-mask\":\"" + firewall.getSubnetMask() + "\"}";
-        }
-
-        // no known options found
-        return "{\"status\" : \"failure\", \"details\" : \"invalid operation\"}";
+	return "{\"subnet-mask\":\"" + firewall.getSubnetMask() + "\"}";
     }
 
-    /**
-     * Allows setting of subnet mask
-     * @param fmJson The Subnet Mask in JSON format.
-     * @return A string status message
-     */
+
     @Post
     public String handlePost(String fmJson) {
-        IFirewallService firewall =
-                (IFirewallService)getContext().getAttributes().
-                get(IFirewallService.class.getCanonicalName());
+        IFirewallService firewall = getFirewallService();
 
         String newMask;
         try {

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallWebRoutable.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallWebRoutable.java
@@ -28,8 +28,14 @@ public class FirewallWebRoutable implements RestletRoutable {
     @Override
     public Router getRestlet(Context context) {
         Router router = new Router(context);
-        router.attach("/module/{op}/json", FirewallResource.class);
-        router.attach("/rules/json", FirewallRulesResource.class);
+        router.attach("/module/status/json",       FirewallStatusResource.class);
+        router.attach("/module/enable/json",       FirewallEnableResource.class);
+        router.attach("/module/disable/json",      FirewallDisableResource.class);
+        router.attach("/module/subnet-mask/json",  FirewallSubnetMaskResource.class);
+        router.attach("/module/storageRules/json", FirewallStorageRulesResource.class);
+
+        router.attach("/rules/json",               FirewallRulesResource.class);
+
         return router;
     }
 


### PR DESCRIPTION
 This patch solves the first half of issue [https://github.com/floodlight/floodlight/issues/488]

The existing REST API for enabling and disabling the firewall relies on GET requests.
Best practices dictate that GET requests should not change the state of the system.

This patch disables the GET semantics and replaces it with a PUT based endpoint to enable/disable the firewall.

Also refactored the FirewallResource class into multiple smaller classes to make URL routing clearer.
