### PR TITLE
Misc patches

### DIFF
--- a/src/main/java/net/floodlightcontroller/debugcounter/CounterNode.java
+++ b/src/main/java/net/floodlightcontroller/debugcounter/CounterNode.java
@@ -11,6 +11,9 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
@@ -27,6 +30,7 @@ import com.google.common.collect.ImmutableList;
  */
 class CounterNode implements Iterable<DebugCounterImpl> {
     private static final String QUOTED_SEP = Pattern.quote("/");
+    private static final Logger log = LoggerFactory.getLogger(CounterNode.class);
 
     /** path/hierarchy of this counter without leading /. An empty string
      * represents the root. A string without a / is a module name
@@ -168,6 +172,14 @@ class CounterNode implements Iterable<DebugCounterImpl> {
          * We're directly reusing the shrunken hierarchyElements List and
          * keyToRemove String, which IMHO is pretty cool how it works out.
          */
+        
+        /*
+         * Make sure it's possible to remove something.
+         */
+        if (hierarchyElements.isEmpty()) {
+        	log.error("Cannot remove a CounterNode from an empty list of hierarchy elements. Returning null.");
+        	return null;
+        } 
         String keyToRemove = hierarchyElements.remove(hierarchyElements.size() - 1); 
         for (String element: hierarchyElements) {
             cur = cur.children.get(element);

--- a/src/main/java/net/floodlightcontroller/testmodule/TestModule.java
+++ b/src/main/java/net/floodlightcontroller/testmodule/TestModule.java
@@ -43,6 +43,7 @@ import org.projectfloodlight.openflow.protocol.meterband.OFMeterBand;
 import org.projectfloodlight.openflow.protocol.meterband.OFMeterBandDrop;
 import org.projectfloodlight.openflow.protocol.oxm.OFOxm;
 import org.projectfloodlight.openflow.protocol.oxm.OFOxmEthSrc;
+import org.projectfloodlight.openflow.protocol.ver13.OFMeterModCommandSerializerVer13;
 import org.projectfloodlight.openflow.types.ArpOpcode;
 import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.EthType;
@@ -125,7 +126,6 @@ public class TestModule implements IFloodlightModule, IOFSwitchListener {
 	@Override
 	public void switchAdded(DatapathId switchId) {
 		OFFactory factory = switchService.getSwitch(switchId).getOFFactory();
-		
 		/*
 		 * An attempt at meters, but they aren't supported anywhere, yet... 
 		 * OFMeterBand mb = factory.meterBands().buildDrop()
@@ -134,12 +134,13 @@ public class TestModule implements IFloodlightModule, IOFSwitchListener {
 				.build();
 		ArrayList<OFMeterBand> mbl = new ArrayList<OFMeterBand>();
 		mbl.add(mb);
-		
+				
 		OFMeterMod mm = factory.buildMeterMod()
 				.setMeters(mbl)
 				.setMeterId(1)
-				.setCommand(0)
-				.build(); */
+				.setCommand(OFMeterModCommandSerializerVer13.ADD_VAL) 
+				.build(); 
+		// This is a bug. You should be able to directly do OFMeterModCommand.ADD */
 		
 		/*HashSet<OFTableConfig> tblCfg = new HashSet<OFTableConfig>();
 		tblCfg.add(OFTableConfig.TABLE_MISS_CONTROLLER);

--- a/src/main/resources/floodlightdefault.properties
+++ b/src/main/resources/floodlightdefault.properties
@@ -19,4 +19,5 @@ org.sdnplatform.sync.internal.SyncManager.authScheme=CHALLENGE_RESPONSE
 org.sdnplatform.sync.internal.SyncManager.keyStorePath=/etc/floodlight/auth_credentials.jceks
 org.sdnplatform.sync.internal.SyncManager.dbPath=/var/lib/floodlight/
 org.sdnplatform.sync.internal.SyncManager.port=6642
+net.floodlightcontroller.core.internal.FloodlightProvider.openflowPort=6653
 net.floodlightcontroller.core.internal.FloodlightProvider.role=ACTIVE

--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -18,7 +18,7 @@
   <logger name="net.floodlightcontroller.packet" level="INFO"></logger>
   <logger name="net.floodlightcontroller.forwarding" level="INFO"></logger>
   <logger name="net.floodlightcontroller.routing" level="INFO"></logger>
-  <logger name="net.floodlightcontroller.core" level="INFO"></logger>
+  <logger name="net.floodlightcontroller.core.internal" level="INFO"></logger>
   <logger level="DEBUG" name="net.floodlightcontroller.firewall"></logger>
   <logger level="INFO" name="net.floodlightcontroller.staticflowentry"></logger>
 </configuration>

--- a/src/test/java/net/floodlightcontroller/staticflowentry/StaticFlowTests.java
+++ b/src/test/java/net/floodlightcontroller/staticflowentry/StaticFlowTests.java
@@ -17,6 +17,7 @@
 package net.floodlightcontroller.staticflowentry;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -30,6 +31,7 @@ import org.junit.Test;
 import org.projectfloodlight.openflow.protocol.OFFactories;
 import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFFlowMod;
+import org.projectfloodlight.openflow.protocol.OFFlowModFlags;
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.OFMessage;
@@ -61,310 +63,313 @@ import static org.junit.Assert.*;
 
 public class StaticFlowTests extends FloodlightTestCase {
 
-    static String TestSwitch1DPID = "00:00:00:00:00:00:00:01";
-    static int TotalTestRules = 3;
-    
-    static OFFactory factory = OFFactories.getFactory(OFVersion.OF_13);
+	static String TestSwitch1DPID = "00:00:00:00:00:00:00:01";
+	static int TotalTestRules = 3;
 
-    /***
-     * Create TestRuleXXX and the corresponding FlowModXXX
-     * for X = 1..3
-     */
-    static Map<String,Object> TestRule1;
-    static OFFlowMod FlowMod1;
-    static {
-        FlowMod1 = factory.buildFlowModify().build();
-        TestRule1 = new HashMap<String,Object>();
-        TestRule1.put(COLUMN_NAME, "TestRule1");
-        TestRule1.put(COLUMN_SWITCH, TestSwitch1DPID);
-        // setup match
-        Match match;
-        TestRule1.put(COLUMN_DL_DST, "00:20:30:40:50:60");
-        match = MatchUtils.fromString("eth_dst=00:20:30:40:50:60", factory.getVersion());
-        // setup actions
-        List<OFAction> actions = new LinkedList<OFAction>();
-        TestRule1.put(COLUMN_ACTIONS, "output=1");
-        actions.add(factory.actions().output(OFPort.of(1), Integer.MAX_VALUE));
-        // done
-        FlowMod1 = FlowMod1.createBuilder().setMatch(match)
-        .setActions(actions)
-        .setBufferId(OFBufferId.NO_BUFFER)
-        .setOutPort(OFPort.ANY)
-        .setPriority(Integer.MAX_VALUE)
-        .setXid(4)
-        .build();
-    }
+	static OFFactory factory = OFFactories.getFactory(OFVersion.OF_13);
 
-    static Map<String,Object> TestRule2;
-    static OFFlowMod FlowMod2;
+	/***
+	 * Create TestRuleXXX and the corresponding FlowModXXX
+	 * for X = 1..3
+	 */
+	static Map<String,Object> TestRule1;
+	static OFFlowMod FlowMod1;
+	static {
+		FlowMod1 = factory.buildFlowModify().build();
+		TestRule1 = new HashMap<String,Object>();
+		TestRule1.put(COLUMN_NAME, "TestRule1");
+		TestRule1.put(COLUMN_SWITCH, TestSwitch1DPID);
+		// setup match
+		Match match;
+		TestRule1.put(COLUMN_DL_DST, "00:20:30:40:50:60");
+		match = MatchUtils.fromString("eth_dst=00:20:30:40:50:60", factory.getVersion());
+		// setup actions
+		List<OFAction> actions = new LinkedList<OFAction>();
+		TestRule1.put(COLUMN_ACTIONS, "output=1");
+		actions.add(factory.actions().output(OFPort.of(1), Integer.MAX_VALUE));
+		// done
+		FlowMod1 = FlowMod1.createBuilder().setMatch(match)
+				.setActions(actions)
+				.setFlags(Collections.singleton(OFFlowModFlags.SEND_FLOW_REM))
+				.setBufferId(OFBufferId.NO_BUFFER)
+				.setOutPort(OFPort.ANY)
+				.setPriority(Integer.MAX_VALUE)
+				.setXid(4)
+				.build();
+	}
 
-    static {
-        FlowMod2 = factory.buildFlowModify().build();
-        TestRule2 = new HashMap<String,Object>();
-        TestRule2.put(COLUMN_NAME, "TestRule2");
-        TestRule2.put(COLUMN_SWITCH, TestSwitch1DPID);
-        // setup match
-        Match match;        
-        TestRule2.put(COLUMN_DL_TYPE, "0x800");
-        TestRule2.put(COLUMN_NW_DST, "192.168.1.0/24");
-        match = MatchUtils.fromString("eth_type=0x800,ipv4_dst=192.168.1.0/24", factory.getVersion());
-        // setup actions
-        List<OFAction> actions = new LinkedList<OFAction>();
-        TestRule2.put(COLUMN_ACTIONS, "output=1");
-        actions.add(factory.actions().output(OFPort.of(1), Integer.MAX_VALUE));
-        // done
-        FlowMod2 = FlowMod2.createBuilder().setMatch(match)
-                .setActions(actions)
-                .setBufferId(OFBufferId.NO_BUFFER)
-                .setOutPort(OFPort.ANY)
-                .setPriority(Integer.MAX_VALUE)
-                .setXid(5)
-                .build();
-    }
+	static Map<String,Object> TestRule2;
+	static OFFlowMod FlowMod2;
 
-
-    static Map<String,Object> TestRule3;
-    static OFFlowMod FlowMod3;
-    private StaticFlowEntryPusher staticFlowEntryPusher;
-    private IOFSwitchService switchService;
-    private IOFSwitch mockSwitch;
-    private MockDebugCounterService debugCounterService;
-    private Capture<OFMessage> writeCapture;
-    private Capture<List<OFMessage>> writeCaptureList;
-    private long dpid;
-    private MemoryStorageSource storage;
-    static {
-        FlowMod3 = factory.buildFlowModify().build();
-        TestRule3 = new HashMap<String,Object>();
-        TestRule3.put(COLUMN_NAME, "TestRule3");
-        TestRule3.put(COLUMN_SWITCH, TestSwitch1DPID);
-        // setup match
-        Match match;
-        TestRule3.put(COLUMN_DL_DST, "00:20:30:40:50:60");
-        TestRule3.put(COLUMN_DL_VLAN, 96);
-        match = MatchUtils.fromString("eth_dst=00:20:30:40:50:60,eth_vlan_vid=96", factory.getVersion());
-        // setup actions
-        TestRule3.put(COLUMN_ACTIONS, "output=controller");
-        List<OFAction> actions = new LinkedList<OFAction>();
-        actions.add(factory.actions().output(OFPort.CONTROLLER, Integer.MAX_VALUE));
-        // done
-        FlowMod3 = FlowMod3.createBuilder().setMatch(match)
-                .setActions(actions)
-                .setBufferId(OFBufferId.NO_BUFFER)
-                .setOutPort(OFPort.ANY)
-                .setPriority(Integer.MAX_VALUE)
-                .setXid(6)
-                .build();
-    }
-
-    private void verifyFlowMod(OFFlowMod testFlowMod, OFFlowMod goodFlowMod) {
-        verifyMatch(testFlowMod, goodFlowMod);
-        verifyActions(testFlowMod, goodFlowMod);
-        // dont' bother testing the cookie; just copy it over
-        goodFlowMod = goodFlowMod.createBuilder().setCookie(testFlowMod.getCookie()).build();
-        // .. so we can continue to use .equals()
-        assertTrue(OFMessageUtils.equalsIgnoreXid(goodFlowMod, testFlowMod));
-    }
+	static {
+		FlowMod2 = factory.buildFlowModify().build();
+		TestRule2 = new HashMap<String,Object>();
+		TestRule2.put(COLUMN_NAME, "TestRule2");
+		TestRule2.put(COLUMN_SWITCH, TestSwitch1DPID);
+		// setup match
+		Match match;        
+		TestRule2.put(COLUMN_DL_TYPE, "0x800");
+		TestRule2.put(COLUMN_NW_DST, "192.168.1.0/24");
+		match = MatchUtils.fromString("eth_type=0x800,ipv4_dst=192.168.1.0/24", factory.getVersion());
+		// setup actions
+		List<OFAction> actions = new LinkedList<OFAction>();
+		TestRule2.put(COLUMN_ACTIONS, "output=1");
+		actions.add(factory.actions().output(OFPort.of(1), Integer.MAX_VALUE));
+		// done
+		FlowMod2 = FlowMod2.createBuilder().setMatch(match)
+				.setActions(actions)
+				.setFlags(Collections.singleton(OFFlowModFlags.SEND_FLOW_REM))
+				.setBufferId(OFBufferId.NO_BUFFER)
+				.setOutPort(OFPort.ANY)
+				.setPriority(Integer.MAX_VALUE)
+				.setXid(5)
+				.build();
+	}
 
 
-    private void verifyMatch(OFFlowMod testFlowMod, OFFlowMod goodFlowMod) {
-        assertEquals(goodFlowMod.getMatch(), testFlowMod.getMatch());
-    }
+	static Map<String,Object> TestRule3;
+	static OFFlowMod FlowMod3;
+	private StaticFlowEntryPusher staticFlowEntryPusher;
+	private IOFSwitchService switchService;
+	private IOFSwitch mockSwitch;
+	private MockDebugCounterService debugCounterService;
+	private Capture<OFMessage> writeCapture;
+	private Capture<List<OFMessage>> writeCaptureList;
+	private long dpid;
+	private MemoryStorageSource storage;
+	static {
+		FlowMod3 = factory.buildFlowModify().build();
+		TestRule3 = new HashMap<String,Object>();
+		TestRule3.put(COLUMN_NAME, "TestRule3");
+		TestRule3.put(COLUMN_SWITCH, TestSwitch1DPID);
+		// setup match
+		Match match;
+		TestRule3.put(COLUMN_DL_DST, "00:20:30:40:50:60");
+		TestRule3.put(COLUMN_DL_VLAN, 96);
+		match = MatchUtils.fromString("eth_dst=00:20:30:40:50:60,eth_vlan_vid=96", factory.getVersion());
+		// setup actions
+		TestRule3.put(COLUMN_ACTIONS, "output=controller");
+		List<OFAction> actions = new LinkedList<OFAction>();
+		actions.add(factory.actions().output(OFPort.CONTROLLER, Integer.MAX_VALUE));
+		// done
+		FlowMod3 = FlowMod3.createBuilder().setMatch(match)
+				.setActions(actions)
+		        .setFlags(Collections.singleton(OFFlowModFlags.SEND_FLOW_REM))
+				.setBufferId(OFBufferId.NO_BUFFER)
+				.setOutPort(OFPort.ANY)
+				.setPriority(Integer.MAX_VALUE)
+				.setXid(6)
+				.build();
+	}
+
+	private void verifyFlowMod(OFFlowMod testFlowMod, OFFlowMod goodFlowMod) {
+		verifyMatch(testFlowMod, goodFlowMod);
+		verifyActions(testFlowMod, goodFlowMod);
+		// dont' bother testing the cookie; just copy it over
+		goodFlowMod = goodFlowMod.createBuilder().setCookie(testFlowMod.getCookie()).build();
+		// .. so we can continue to use .equals()
+		assertTrue(OFMessageUtils.equalsIgnoreXid(goodFlowMod, testFlowMod));
+	}
 
 
-    private void verifyActions(OFFlowMod testFlowMod, OFFlowMod goodFlowMod) {
-        List<OFAction> goodActions = goodFlowMod.getActions();
-        List<OFAction> testActions = testFlowMod.getActions();
-        assertNotNull(goodActions);
-        assertNotNull(testActions);
-        assertEquals(goodActions.size(), testActions.size());
-        // assumes actions are marshalled in same order; should be safe
-        for(int i = 0; i < goodActions.size(); i++) {
-            assertEquals(goodActions.get(i), testActions.get(i));
-        }
-    }
+	private void verifyMatch(OFFlowMod testFlowMod, OFFlowMod goodFlowMod) {
+		assertEquals(goodFlowMod.getMatch(), testFlowMod.getMatch());
+	}
 
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        debugCounterService = new MockDebugCounterService();
-        staticFlowEntryPusher = new StaticFlowEntryPusher();
-        switchService = getMockSwitchService();
-        storage = new MemoryStorageSource();
-        dpid = HexString.toLong(TestSwitch1DPID);
-
-        mockSwitch = createNiceMock(IOFSwitch.class);
-        writeCapture = new Capture<OFMessage>(CaptureType.ALL);
-        writeCaptureList = new Capture<List<OFMessage>>(CaptureType.ALL);
-
-        mockSwitch.write(capture(writeCapture));
-        expectLastCall().anyTimes();
-        mockSwitch.write(capture(writeCaptureList));
-        expectLastCall().anyTimes();
-        mockSwitch.flush();
-        expectLastCall().anyTimes();
-        expect(mockSwitch.getOFFactory()).andReturn(factory).anyTimes();
-        replay(mockSwitch);
-
-        FloodlightModuleContext fmc = new FloodlightModuleContext();
-        fmc.addService(IStorageSourceService.class, storage);
-        fmc.addService(IOFSwitchService.class, getMockSwitchService());
-        fmc.addService(IDebugCounterService.class, debugCounterService);
-
-        MockFloodlightProvider mockFloodlightProvider = getMockFloodlightProvider();
-        Map<DatapathId, IOFSwitch> switchMap = new HashMap<DatapathId, IOFSwitch>();
-        switchMap.put(DatapathId.of(dpid), mockSwitch);
-        getMockSwitchService().setSwitches(switchMap);
-        fmc.addService(IFloodlightProviderService.class, mockFloodlightProvider);
-        RestApiServer restApi = new RestApiServer();
-        fmc.addService(IRestApiService.class, restApi);
-        fmc.addService(IOFSwitchService.class, switchService);
-                       
-        restApi.init(fmc);
-        debugCounterService.init(fmc);
-        storage.init(fmc);
-        staticFlowEntryPusher.init(fmc);
-        debugCounterService.init(fmc);
-        storage.startUp(fmc);
-        
-        createStorageWithFlowEntries();
-        
-        staticFlowEntryPusher.startUp(fmc);    // again, to hack unittest
-    }
-
-    @Test
-    public void testStaticFlowPush() throws Exception {
-
-        // verify that flowpusher read all three entries from storage
-        assertEquals(TotalTestRules, staticFlowEntryPusher.countEntries());
-
-        // if someone calls mockSwitch.getOutputStream(), return mockOutStream instead
-        //expect(mockSwitch.getOutputStream()).andReturn(mockOutStream).anyTimes();
-
-        // if someone calls getId(), return this dpid instead
-        resetToNice(mockSwitch);
-        mockSwitch.write(capture(writeCapture));
-        expectLastCall().anyTimes();
-        mockSwitch.write(capture(writeCaptureList));
-        expectLastCall().anyTimes();
-        mockSwitch.flush();
-        expectLastCall().anyTimes();
-        expect(mockSwitch.getOFFactory()).andReturn(factory).anyTimes();
-        expect(mockSwitch.getId()).andReturn(DatapathId.of(dpid)).anyTimes();
-        replay(mockSwitch);
-
-        // hook the static pusher up to the fake switch
-        staticFlowEntryPusher.switchAdded(DatapathId.of(dpid));
-
-        verify(mockSwitch);
-
-        // Verify that the switch has gotten some flow_mods
-        assertEquals(true, writeCapture.hasCaptured());
-        assertEquals(TotalTestRules, writeCapture.getValues().size());
-
-        // Order assumes how things are stored in hash bucket;
-        // should be fixed because OFMessage.hashCode() is deterministic
-        OFFlowMod firstFlowMod = (OFFlowMod) writeCapture.getValues().get(2);
-        verifyFlowMod(firstFlowMod, FlowMod1);
-        OFFlowMod secondFlowMod = (OFFlowMod) writeCapture.getValues().get(1);
-        verifyFlowMod(secondFlowMod, FlowMod2);
-        OFFlowMod thirdFlowMod = (OFFlowMod) writeCapture.getValues().get(0);
-        verifyFlowMod(thirdFlowMod, FlowMod3);
-
-        writeCapture.reset();
-
-        // delete two rules and verify they've been removed
-        // this should invoke staticFlowPusher.rowsDeleted()
-        storage.deleteRow(StaticFlowEntryPusher.TABLE_NAME, "TestRule1");
-        storage.deleteRow(StaticFlowEntryPusher.TABLE_NAME, "TestRule2");
-
-        assertEquals(1, staticFlowEntryPusher.countEntries());
-        assertEquals(2, writeCapture.getValues().size());
-
-        OFFlowMod firstDelete = (OFFlowMod) writeCapture.getValues().get(0);
-        FlowMod1 = FlowModUtils.toFlowDeleteStrict(FlowMod1);
-        verifyFlowMod(firstDelete, FlowMod1);
-
-        OFFlowMod secondDelete = (OFFlowMod) writeCapture.getValues().get(1);
-        FlowMod2 = FlowModUtils.toFlowDeleteStrict(FlowMod2);
-        verifyFlowMod(secondDelete, FlowMod2);
-
-        // add rules back to make sure that staticFlowPusher.rowsInserted() works
-        writeCapture.reset();
-        FlowMod2 = FlowModUtils.toFlowAdd(FlowMod2);
-        FlowMod2 = FlowMod2.createBuilder().setXid(12).build();
-        storage.insertRow(StaticFlowEntryPusher.TABLE_NAME, TestRule2);
-        assertEquals(2, staticFlowEntryPusher.countEntries());
-        assertEquals(1, writeCaptureList.getValues().size());
-        List<OFMessage> outList =
-            writeCaptureList.getValues().get(0);
-        assertEquals(1, outList.size());
-        OFFlowMod firstAdd = (OFFlowMod) outList.get(0);
-        verifyFlowMod(firstAdd, FlowMod2);
-        writeCapture.reset();
-        writeCaptureList.reset();
-
-        // now try an overwriting update, calling staticFlowPusher.rowUpdated()
-        TestRule3.put(COLUMN_DL_VLAN, 333);
-        storage.updateRow(StaticFlowEntryPusher.TABLE_NAME, TestRule3);
-        assertEquals(2, staticFlowEntryPusher.countEntries());
-        assertEquals(1, writeCaptureList.getValues().size());
-
-        outList = writeCaptureList.getValues().get(0);
-        assertEquals(2, outList.size());
-        OFFlowMod removeFlowMod = (OFFlowMod) outList.get(0);
-        FlowMod3 = FlowModUtils.toFlowDeleteStrict(FlowMod3);
-        verifyFlowMod(removeFlowMod, FlowMod3);
-        FlowMod3 = FlowModUtils.toFlowAdd(FlowMod3);
-        FlowMod3 = FlowMod3.createBuilder().setMatch(MatchUtils.fromString("eth_dst=00:20:30:40:50:60,eth_vlan_vid=333", factory.getVersion())).setXid(14).build();
-        OFFlowMod updateFlowMod = (OFFlowMod) outList.get(1);
-        verifyFlowMod(updateFlowMod, FlowMod3);
-        writeCaptureList.reset();
-
-        // now try an action modifying update, calling staticFlowPusher.rowUpdated()
-        TestRule3.put(COLUMN_ACTIONS, "output=controller,pop_vlan"); // added pop-vlan
-        storage.updateRow(StaticFlowEntryPusher.TABLE_NAME, TestRule3);
-        assertEquals(2, staticFlowEntryPusher.countEntries());
-        assertEquals(1, writeCaptureList.getValues().size());
-
-        outList = writeCaptureList.getValues().get(0);
-        assertEquals(1, outList.size());
-        OFFlowMod modifyFlowMod = (OFFlowMod) outList.get(0);
-        FlowMod3 = FlowModUtils.toFlowModifyStrict(FlowMod3);
-        List<OFAction> modifiedActions = FlowMod3.getActions();
-        modifiedActions.add(factory.actions().popVlan()); // add the new action to what we should expect
-        FlowMod3 = FlowMod3.createBuilder().setActions(modifiedActions).setXid(19).build();
-        verifyFlowMod(modifyFlowMod, FlowMod3);
-    }
+	private void verifyActions(OFFlowMod testFlowMod, OFFlowMod goodFlowMod) {
+		List<OFAction> goodActions = goodFlowMod.getActions();
+		List<OFAction> testActions = testFlowMod.getActions();
+		assertNotNull(goodActions);
+		assertNotNull(testActions);
+		assertEquals(goodActions.size(), testActions.size());
+		// assumes actions are marshalled in same order; should be safe
+		for(int i = 0; i < goodActions.size(); i++) {
+			assertEquals(goodActions.get(i), testActions.get(i));
+		}
+	}
 
 
-    IStorageSourceService createStorageWithFlowEntries() {
-        return populateStorageWithFlowEntries();
-    }
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		debugCounterService = new MockDebugCounterService();
+		staticFlowEntryPusher = new StaticFlowEntryPusher();
+		switchService = getMockSwitchService();
+		storage = new MemoryStorageSource();
+		dpid = HexString.toLong(TestSwitch1DPID);
 
-    IStorageSourceService populateStorageWithFlowEntries() {
-        Set<String> indexedColumns = new HashSet<String>();
-        indexedColumns.add(COLUMN_NAME);
-        storage.createTable(StaticFlowEntryPusher.TABLE_NAME, indexedColumns);
-        storage.setTablePrimaryKeyName(StaticFlowEntryPusher.TABLE_NAME, COLUMN_NAME);
+		mockSwitch = createNiceMock(IOFSwitch.class);
+		writeCapture = new Capture<OFMessage>(CaptureType.ALL);
+		writeCaptureList = new Capture<List<OFMessage>>(CaptureType.ALL);
 
-        storage.insertRow(StaticFlowEntryPusher.TABLE_NAME, TestRule1);
-        storage.insertRow(StaticFlowEntryPusher.TABLE_NAME, TestRule2);
-        storage.insertRow(StaticFlowEntryPusher.TABLE_NAME, TestRule3);
+		mockSwitch.write(capture(writeCapture));
+		expectLastCall().anyTimes();
+		mockSwitch.write(capture(writeCaptureList));
+		expectLastCall().anyTimes();
+		mockSwitch.flush();
+		expectLastCall().anyTimes();
+		expect(mockSwitch.getOFFactory()).andReturn(factory).anyTimes();
+		replay(mockSwitch);
 
-        return storage;
-    }
+		FloodlightModuleContext fmc = new FloodlightModuleContext();
+		fmc.addService(IStorageSourceService.class, storage);
+		fmc.addService(IOFSwitchService.class, getMockSwitchService());
+		fmc.addService(IDebugCounterService.class, debugCounterService);
 
-    @Test
-    public void testHARoleChanged() throws IOException {
+		MockFloodlightProvider mockFloodlightProvider = getMockFloodlightProvider();
+		Map<DatapathId, IOFSwitch> switchMap = new HashMap<DatapathId, IOFSwitch>();
+		switchMap.put(DatapathId.of(dpid), mockSwitch);
+		getMockSwitchService().setSwitches(switchMap);
+		fmc.addService(IFloodlightProviderService.class, mockFloodlightProvider);
+		RestApiServer restApi = new RestApiServer();
+		fmc.addService(IRestApiService.class, restApi);
+		fmc.addService(IOFSwitchService.class, switchService);
 
-        assert(staticFlowEntryPusher.entry2dpid.containsValue(TestSwitch1DPID));
-        assert(staticFlowEntryPusher.entriesFromStorage.containsValue(FlowMod1));
-        assert(staticFlowEntryPusher.entriesFromStorage.containsValue(FlowMod2));
-        assert(staticFlowEntryPusher.entriesFromStorage.containsValue(FlowMod3));
+		restApi.init(fmc);
+		debugCounterService.init(fmc);
+		storage.init(fmc);
+		staticFlowEntryPusher.init(fmc);
+		debugCounterService.init(fmc);
+		storage.startUp(fmc);
 
-        /* FIXME: what's the right behavior here ??
+		createStorageWithFlowEntries();
+
+		staticFlowEntryPusher.startUp(fmc);    // again, to hack unittest
+	}
+
+	@Test
+	public void testStaticFlowPush() throws Exception {
+
+		// verify that flowpusher read all three entries from storage
+		assertEquals(TotalTestRules, staticFlowEntryPusher.countEntries());
+
+		// if someone calls mockSwitch.getOutputStream(), return mockOutStream instead
+		//expect(mockSwitch.getOutputStream()).andReturn(mockOutStream).anyTimes();
+
+		// if someone calls getId(), return this dpid instead
+		resetToNice(mockSwitch);
+		mockSwitch.write(capture(writeCapture));
+		expectLastCall().anyTimes();
+		mockSwitch.write(capture(writeCaptureList));
+		expectLastCall().anyTimes();
+		mockSwitch.flush();
+		expectLastCall().anyTimes();
+		expect(mockSwitch.getOFFactory()).andReturn(factory).anyTimes();
+		expect(mockSwitch.getId()).andReturn(DatapathId.of(dpid)).anyTimes();
+		replay(mockSwitch);
+
+		// hook the static pusher up to the fake switch
+		staticFlowEntryPusher.switchAdded(DatapathId.of(dpid));
+
+		verify(mockSwitch);
+
+		// Verify that the switch has gotten some flow_mods
+		assertEquals(true, writeCapture.hasCaptured());
+		assertEquals(TotalTestRules, writeCapture.getValues().size());
+
+		// Order assumes how things are stored in hash bucket;
+		// should be fixed because OFMessage.hashCode() is deterministic
+		OFFlowMod firstFlowMod = (OFFlowMod) writeCapture.getValues().get(2);
+		verifyFlowMod(firstFlowMod, FlowMod1);
+		OFFlowMod secondFlowMod = (OFFlowMod) writeCapture.getValues().get(1);
+		verifyFlowMod(secondFlowMod, FlowMod2);
+		OFFlowMod thirdFlowMod = (OFFlowMod) writeCapture.getValues().get(0);
+		verifyFlowMod(thirdFlowMod, FlowMod3);
+
+		writeCapture.reset();
+
+		// delete two rules and verify they've been removed
+		// this should invoke staticFlowPusher.rowsDeleted()
+		storage.deleteRow(StaticFlowEntryPusher.TABLE_NAME, "TestRule1");
+		storage.deleteRow(StaticFlowEntryPusher.TABLE_NAME, "TestRule2");
+
+		assertEquals(1, staticFlowEntryPusher.countEntries());
+		assertEquals(2, writeCapture.getValues().size());
+
+		OFFlowMod firstDelete = (OFFlowMod) writeCapture.getValues().get(0);
+		FlowMod1 = FlowModUtils.toFlowDeleteStrict(FlowMod1);
+		verifyFlowMod(firstDelete, FlowMod1);
+
+		OFFlowMod secondDelete = (OFFlowMod) writeCapture.getValues().get(1);
+		FlowMod2 = FlowModUtils.toFlowDeleteStrict(FlowMod2);
+		verifyFlowMod(secondDelete, FlowMod2);
+
+		// add rules back to make sure that staticFlowPusher.rowsInserted() works
+		writeCapture.reset();
+		FlowMod2 = FlowModUtils.toFlowAdd(FlowMod2);
+		FlowMod2 = FlowMod2.createBuilder().setXid(12).build();
+		storage.insertRow(StaticFlowEntryPusher.TABLE_NAME, TestRule2);
+		assertEquals(2, staticFlowEntryPusher.countEntries());
+		assertEquals(1, writeCaptureList.getValues().size());
+		List<OFMessage> outList =
+				writeCaptureList.getValues().get(0);
+		assertEquals(1, outList.size());
+		OFFlowMod firstAdd = (OFFlowMod) outList.get(0);
+		verifyFlowMod(firstAdd, FlowMod2);
+		writeCapture.reset();
+		writeCaptureList.reset();
+
+		// now try an overwriting update, calling staticFlowPusher.rowUpdated()
+		TestRule3.put(COLUMN_DL_VLAN, 333);
+		storage.updateRow(StaticFlowEntryPusher.TABLE_NAME, TestRule3);
+		assertEquals(2, staticFlowEntryPusher.countEntries());
+		assertEquals(1, writeCaptureList.getValues().size());
+
+		outList = writeCaptureList.getValues().get(0);
+		assertEquals(2, outList.size());
+		OFFlowMod removeFlowMod = (OFFlowMod) outList.get(0);
+		FlowMod3 = FlowModUtils.toFlowDeleteStrict(FlowMod3);
+		verifyFlowMod(removeFlowMod, FlowMod3);
+		FlowMod3 = FlowModUtils.toFlowAdd(FlowMod3);
+		FlowMod3 = FlowMod3.createBuilder().setMatch(MatchUtils.fromString("eth_dst=00:20:30:40:50:60,eth_vlan_vid=333", factory.getVersion())).setXid(14).build();
+		OFFlowMod updateFlowMod = (OFFlowMod) outList.get(1);
+		verifyFlowMod(updateFlowMod, FlowMod3);
+		writeCaptureList.reset();
+
+		// now try an action modifying update, calling staticFlowPusher.rowUpdated()
+		TestRule3.put(COLUMN_ACTIONS, "output=controller,pop_vlan"); // added pop-vlan
+		storage.updateRow(StaticFlowEntryPusher.TABLE_NAME, TestRule3);
+		assertEquals(2, staticFlowEntryPusher.countEntries());
+		assertEquals(1, writeCaptureList.getValues().size());
+
+		outList = writeCaptureList.getValues().get(0);
+		assertEquals(1, outList.size());
+		OFFlowMod modifyFlowMod = (OFFlowMod) outList.get(0);
+		FlowMod3 = FlowModUtils.toFlowModifyStrict(FlowMod3);
+		List<OFAction> modifiedActions = FlowMod3.getActions();
+		modifiedActions.add(factory.actions().popVlan()); // add the new action to what we should expect
+		FlowMod3 = FlowMod3.createBuilder().setActions(modifiedActions).setXid(19).build();
+		verifyFlowMod(modifyFlowMod, FlowMod3);
+	}
+
+
+	IStorageSourceService createStorageWithFlowEntries() {
+		return populateStorageWithFlowEntries();
+	}
+
+	IStorageSourceService populateStorageWithFlowEntries() {
+		Set<String> indexedColumns = new HashSet<String>();
+		indexedColumns.add(COLUMN_NAME);
+		storage.createTable(StaticFlowEntryPusher.TABLE_NAME, indexedColumns);
+		storage.setTablePrimaryKeyName(StaticFlowEntryPusher.TABLE_NAME, COLUMN_NAME);
+
+		storage.insertRow(StaticFlowEntryPusher.TABLE_NAME, TestRule1);
+		storage.insertRow(StaticFlowEntryPusher.TABLE_NAME, TestRule2);
+		storage.insertRow(StaticFlowEntryPusher.TABLE_NAME, TestRule3);
+
+		return storage;
+	}
+
+	@Test
+	public void testHARoleChanged() throws IOException {
+
+		assert(staticFlowEntryPusher.entry2dpid.containsValue(TestSwitch1DPID));
+		assert(staticFlowEntryPusher.entriesFromStorage.containsValue(FlowMod1));
+		assert(staticFlowEntryPusher.entriesFromStorage.containsValue(FlowMod2));
+		assert(staticFlowEntryPusher.entriesFromStorage.containsValue(FlowMod3));
+
+		/* FIXME: what's the right behavior here ??
         // Send a notification that we've changed to slave
         mfp.dispatchRoleChanged(Role.SLAVE);
         // Make sure we've removed all our entries
@@ -378,6 +383,6 @@ public class StaticFlowTests extends FloodlightTestCase {
         assert(staticFlowEntryPusher.entriesFromStorage.containsValue(FlowMod1));
         assert(staticFlowEntryPusher.entriesFromStorage.containsValue(FlowMod2));
         assert(staticFlowEntryPusher.entriesFromStorage.containsValue(FlowMod3));
-        */
-    }
+		 */
+	}
 }


### PR DESCRIPTION
(1) Allow switches to handshake that do not support barrier messages (logs a warning...HP ProCurve is one such switch)

(2) Correctly apply flows for packets that pass the firewall (ignore the match that allowed the firewall to pass the packet and allow forwarding to route it)

(3) Bug fix in DebugCounterService. Don't step off the beginning of the list if it's empty (access item -1).