### PR TITLE
Correct the spelling error

### DIFF
--- a/src/main/java/net/floodlightcontroller/staticflowentry/web/StaticFlowEntryPusherResource.java
+++ b/src/main/java/net/floodlightcontroller/staticflowentry/web/StaticFlowEntryPusherResource.java
@@ -326,7 +326,7 @@ public class StaticFlowEntryPusherResource extends ServerResource {
 			return ("{\"status\" : \"" + status + "\"}");
 		} catch (IOException e) {
 			log.error("Error parsing push flow mod request: " + fmJson, e);
-			return "{\"status\" : \"Error! Could not parse flod mod, see log for details.\"}";
+			return "{\"status\" : \"Error! Could not parse flow mod, see log for details.\"}";
 		}        
 	}
 


### PR DESCRIPTION
In line 329 of StaticFlowEntryPusherResource.java, the word "flow mod"
is spelled as "flod mod".
Just encountered that when using the rest api, so I fixed it.