### PR TITLE
Bug fixes and DHCP server initial commit

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
@@ -301,7 +301,11 @@ class OFChannelHandler extends IdleStateAwareChannelHandler {
 		@Override
 		void processOFHello(OFHello m) throws IOException {
 			OFVersion version = m.getVersion();
-			factory = OFFactories.getFactory(version);
+			/* Choose the lower of the two supported versions. */
+			if (version.compareTo(factory.getVersion()) < 0) {
+				factory = OFFactories.getFactory(version);
+			} /* else The controller's version is < or = the switch's, so keep original controller factory. */
+			
 			OFMessageDecoder decoder = pipeline.get(OFMessageDecoder.class);
 			decoder.setVersion(version);
 			setState(new WaitFeaturesReplyState());

--- a/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
@@ -253,6 +253,13 @@ class OFChannelHandler extends IdleStateAwareChannelHandler {
 				case EXPERIMENTER:
 					processOFExperimenter((OFExperimenter)m);
 					break;
+				/* echos can be sent at any time */
+				case ECHO_REPLY:
+					processOFEchoReply((OFEchoReply)m);
+					break;
+				case ECHO_REQUEST:
+					processOFEchoRequest((OFEchoRequest)m);
+					break;
 				default:
 					illegalMessageReceived(m);
 					break;
@@ -260,8 +267,6 @@ class OFChannelHandler extends IdleStateAwareChannelHandler {
 			}
 			else{
 				switch(m.getType()){
-				// Always handle echos at the channel level!
-				// Echos should only be sent in the complete.
 				case ECHO_REPLY:
 					processOFEchoReply((OFEchoReply)m);
 					break;

--- a/src/main/java/net/floodlightcontroller/dhcpserver/DHCPBinding.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/DHCPBinding.java
@@ -1,0 +1,141 @@
+package net.floodlightcontroller.dhcpserver;
+
+import org.projectfloodlight.openflow.types.IPv4Address;
+import org.projectfloodlight.openflow.types.MacAddress;
+
+/**
+ * The class representing a DHCP Binding -- MAC and IP.
+ * It also contains important information regarding the lease status
+ * --active
+ * --inactive
+ * the lease type of the binding
+ * --dynamic
+ * --fixed/static
+ * and the lease times
+ * --start time in seconds
+ * --duration in seconds
+ * 
+ * @author Ryan Izard (rizard@g.clemson.edu)
+ */
+public class DHCPBinding {
+	private MacAddress MAC = MacAddress.NONE;
+	private IPv4Address IP = IPv4Address.NONE;
+	private boolean LEASE_STATUS;
+	private boolean PERMANENT_LEASE;
+	
+	private long LEASE_START_TIME_SECONDS;
+	private long LEASE_DURATION_SECONDS;
+	
+	protected DHCPBinding(IPv4Address ip, MacAddress mac) {
+		this.setMACAddress(mac);
+		this.setIPv4Addresss(ip);
+		this.setLeaseStatus(false);
+	}
+	
+	public IPv4Address getIPv4Address() {
+		return IP;
+	}
+	
+	public MacAddress getMACAddress() {
+		return MAC;
+	}
+	
+	private void setIPv4Addresss(IPv4Address ip) {
+		IP = ip; 
+	}
+	
+	public void setMACAddress(MacAddress mac) {
+		MAC = mac;
+	}
+	
+	public boolean isActiveLease() {
+		return LEASE_STATUS;
+	}
+	
+	public void setStaticIPLease(boolean staticIP) {
+		PERMANENT_LEASE = staticIP;
+	}
+	
+	public boolean isStaticIPLease() {
+		return PERMANENT_LEASE;
+	}
+	
+	public void setLeaseStatus(boolean status) {
+		LEASE_STATUS = status;
+	}
+	
+	public boolean isLeaseExpired() {
+		long currentTime = System.currentTimeMillis();
+		if ((currentTime / 1000) >= (LEASE_START_TIME_SECONDS + LEASE_DURATION_SECONDS)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	protected void setLeaseStartTimeSeconds() {
+		LEASE_START_TIME_SECONDS = System.currentTimeMillis() / 1000;
+	}
+	
+	protected void setLeaseDurationSeconds(long time) {
+		LEASE_DURATION_SECONDS = time;
+	}
+	
+	protected void clearLeaseTimes() {
+		LEASE_START_TIME_SECONDS = 0;
+		LEASE_DURATION_SECONDS = 0;
+	}
+	
+	protected boolean cancelLease() {
+		this.clearLeaseTimes();
+		this.setLeaseStatus(false);
+		return true;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((IP == null) ? 0 : IP.hashCode());
+		result = prime
+				* result
+				+ (int) (LEASE_DURATION_SECONDS ^ (LEASE_DURATION_SECONDS >>> 32));
+		result = prime
+				* result
+				+ (int) (LEASE_START_TIME_SECONDS ^ (LEASE_START_TIME_SECONDS >>> 32));
+		result = prime * result + (LEASE_STATUS ? 1231 : 1237);
+		result = prime * result + ((MAC == null) ? 0 : MAC.hashCode());
+		result = prime * result + (PERMANENT_LEASE ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		DHCPBinding other = (DHCPBinding) obj;
+		if (IP == null) {
+			if (other.IP != null)
+				return false;
+		} else if (!IP.equals(other.IP))
+			return false;
+		if (LEASE_DURATION_SECONDS != other.LEASE_DURATION_SECONDS)
+			return false;
+		if (LEASE_START_TIME_SECONDS != other.LEASE_START_TIME_SECONDS)
+			return false;
+		if (LEASE_STATUS != other.LEASE_STATUS)
+			return false;
+		if (MAC == null) {
+			if (other.MAC != null)
+				return false;
+		} else if (!MAC.equals(other.MAC))
+			return false;
+		if (PERMANENT_LEASE != other.PERMANENT_LEASE)
+			return false;
+		return true;
+	}
+}

--- a/src/main/java/net/floodlightcontroller/dhcpserver/DHCPPool.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/DHCPPool.java
@@ -1,0 +1,335 @@
+package net.floodlightcontroller.dhcpserver;
+
+import java.util.ArrayList;
+
+import org.projectfloodlight.openflow.types.IPv4Address;
+import org.projectfloodlight.openflow.types.MacAddress;
+import org.slf4j.Logger;
+
+import net.floodlightcontroller.dhcpserver.DHCPBinding;
+
+/**
+ * The class representing a DHCP Pool.
+ * This class is essentially a list of DHCPBinding objects containing IP, MAC, and lease status information.
+ *
+ * @author Ryan Izard (rizard@g.clemson.edu)
+ */
+public class DHCPPool {
+	protected Logger log;
+	private volatile static ArrayList<DHCPBinding> DHCP_POOL = new ArrayList<DHCPBinding>();
+	private volatile int POOL_SIZE;
+	private volatile int POOL_AVAILABILITY;
+	private volatile boolean POOL_FULL;
+	private volatile IPv4Address STARTING_ADDRESS;
+	private final MacAddress UNASSIGNED_MAC = MacAddress.NONE;
+
+	// Need to write this to handle subnets later...
+	// This assumes startingIPv4Address can handle size addresses
+	/**
+	 * Constructor for a DHCPPool of DHCPBinding's. Each DHCPBinding object is initialized with a
+	 * null MAC address and the lease is set to inactive (i.e. false).
+	 * @param {@code byte[]} startingIPv4Address: The lowest IP address to lease.
+	 * @param {@code integer} size: (startingIPv4Address + size) is the highest IP address to lease.
+	 * @return none
+	 */
+	public DHCPPool(IPv4Address startingIPv4Address, int size, Logger log) {
+		this.log = log;
+		int IPv4AsInt = startingIPv4Address.getInt();
+		this.setPoolSize(size);
+		this.setPoolAvailability(size);
+		STARTING_ADDRESS = startingIPv4Address;
+		for (int i = 0; i < size; i++) { 
+			DHCP_POOL.add(new DHCPBinding(IPv4Address.of(IPv4AsInt + i), UNASSIGNED_MAC));
+		}
+
+	}
+
+	private void setPoolFull(boolean full) {
+		POOL_FULL = full;
+	}
+
+	private boolean isPoolFull() {
+		return POOL_FULL;
+	}
+
+	private void setPoolSize(int size) {
+		POOL_SIZE = size;
+	}
+
+	private int getPoolSize() {
+		return POOL_SIZE;
+	}
+
+	private int getPoolAvailability() {
+		return POOL_AVAILABILITY;
+	}
+
+	private void setPoolAvailability(int size) {
+		POOL_AVAILABILITY = size;
+	}
+
+	/**
+	 * Gets the DHCPBinding object from the DHCPPool containing {@code byte[]} ip
+	 * @param {@code byte[]} ip: The IPv4 address to match in a DHCPBinding
+	 * @return {@code DHCPBinding}: The matching DHCPBinding object or null if ip is not found
+	 */
+	public DHCPBinding getDHCPbindingFromIPv4(IPv4Address ip) {
+		if (ip == null) return null;
+		for (DHCPBinding binding : DHCP_POOL) {
+			if (binding.getIPv4Address().equals(ip)) {
+				return binding;
+			}
+		}
+		return null;
+	}
+	/**
+	 * Gets the DHCPBinding object from the DHCPPool containing {@code byte[]} mac
+	 * @param {@code byte[]} mac: The MAC address to match in in a DHCPBinding
+	 * @return {@code DHCPBinding}: The matching DHCPBinding object or null if mac is not found
+	 */
+	public DHCPBinding getDHCPbindingFromMAC(MacAddress mac) {
+		if (mac == null) return null;
+		for (DHCPBinding binding : DHCP_POOL) {
+			if (binding.getMACAddress().equals(mac)) {
+				return binding;
+			}
+		}
+		return null;
+	}
+	/**
+	 * Gets the lease status of a particular IPv4 address, {@code byte[]} ip
+	 * @param {@code byte[]} ip: The IPv4 address of which to check the lease status 
+	 * @return {@code boolean}: true if lease is active, false if lease is inactive/expired
+	 */
+	public boolean isIPv4Leased(IPv4Address ip) {
+		DHCPBinding binding = this.getDHCPbindingFromIPv4(ip);
+		if (binding != null) return binding.isActiveLease();
+		else return false;
+	}
+	/**
+	 * Assigns a MAC address to the IP address of the DHCPBinding object in the DHCPPool object.
+	 * This method also sets the lease to active (i.e. true) when the assignment is made.
+	 * @param {@code DHCPBinding} binding: The DHCPBinding object in which to set the MAC
+	 * @param {@code byte[]} mac: The MAC address to set in the DHCPBinding object
+	 * @param {@code long}: The time in seconds for which the lease will be valid
+	 * @return none
+	 */
+	public void setDHCPbinding(DHCPBinding binding, MacAddress mac, int time) {
+		int index = DHCP_POOL.indexOf(binding);
+		binding.setMACAddress(mac);
+		binding.setLeaseStatus(true);
+		this.setPoolAvailability(this.getPoolAvailability() - 1);
+		DHCP_POOL.set(index, binding);
+		if (this.getPoolAvailability() == 0) setPoolFull(true);
+		binding.setLeaseStartTimeSeconds();
+		binding.setLeaseDurationSeconds(time);
+	}
+	/**
+	 * Completely removes the DHCPBinding object with IP address {@code byte[]} ip from the DHCPPool
+	 * @param {@code byte[]} ip: The IP address to remove from the pool. This address will not be available
+	 * for lease after removal.
+	 * @return none
+	 */
+	public void removeIPv4FromDHCPPool(IPv4Address ip) {
+		if (ip == null || getDHCPbindingFromIPv4(ip) == null) return;
+		if (ip.equals(STARTING_ADDRESS)) {
+			DHCPBinding lowest = null;
+			// Locate the lowest address (other than ip), which will be the new starting address
+			for (DHCPBinding binding : DHCP_POOL) {
+				if (lowest == null) {
+					lowest = binding;
+				} else if (binding.getIPv4Address().getInt() < lowest.getIPv4Address().getInt()
+						&& !binding.getIPv4Address().equals(ip))
+				{
+					lowest = binding;
+				}
+			}
+			// lowest is new starting address
+			STARTING_ADDRESS = lowest.getIPv4Address();
+		}
+		DHCP_POOL.remove(this.getDHCPbindingFromIPv4(ip));
+		this.setPoolSize(this.getPoolSize() - 1);
+		this.setPoolAvailability(this.getPoolAvailability() - 1);
+		if (this.getPoolAvailability() == 0) this.setPoolFull(true);
+	}
+	/**
+	 * Adds an IP address to the DHCPPool if the address is not already present. If present, nothing is added to the DHCPPool.
+	 * @param {@code byte[]} ip: The IP address to attempt to add to the DHCPPool
+	 * @return {@code DHCPBinding}: Reference to the DHCPBinding object if successful, null if unsuccessful
+	 */
+	public DHCPBinding addIPv4ToDHCPPool(IPv4Address ip) {
+		DHCPBinding binding = null;
+		if (this.getDHCPbindingFromIPv4(ip) == null) {
+			if (ip.getInt() < STARTING_ADDRESS.getInt()) {
+				STARTING_ADDRESS = ip;
+			}
+			binding = new DHCPBinding(ip, null);
+			DHCP_POOL.add(binding);
+			this.setPoolSize(this.getPoolSize() + 1);
+			this.setPoolFull(false);
+		}
+		return binding;
+	}
+	/**
+	 * Determines if there are available leases in this DHCPPool.
+	 * @return {@code boolean}: true if there are addresses available, false if the DHCPPool is full
+	 */
+	public boolean hasAvailableAddresses() {
+		if (isPoolFull() || getPoolAvailability() == 0) return false;
+		else return true;
+	}
+	/**
+	 * Returns an available address (DHCPBinding) for lease.
+	 * If this MAC is configured for a static/fixed IP, that DHCPBinding will be returned.
+	 * If this MAC has had a lease before and that same lease is available, that DHCPBinding will be returned.
+	 * If not, then an attempt to return an address that has not been active before will be made.
+	 * If there are no addresses that have not been used, then the lowest currently inactive address will be returned.
+	 * If all addresses are being used, then null will be returned.
+	 * @param {@code byte[]): MAC address of the device requesting the lease
+	 * @return {@code DHCPBinding}: Reference to the DHCPBinding object if successful, null if unsuccessful
+	 */
+	public DHCPBinding getAnyAvailableLease(MacAddress mac) {
+		if (isPoolFull()) return null;
+		DHCPBinding usedBinding = null;
+		usedBinding = this.getDHCPbindingFromMAC(mac);
+		if (usedBinding != null) return usedBinding;
+
+		for (DHCPBinding binding : DHCP_POOL) {
+			if (!binding.isActiveLease() 
+					&& binding.getMACAddress().equals(UNASSIGNED_MAC))
+			{
+				return binding;
+			} else if (!binding.isActiveLease() && usedBinding == null && !binding.isStaticIPLease()) {
+				usedBinding = binding;
+			}
+		}
+		return usedBinding;
+	}
+	/**
+	 * Returns a specific available IP address binding for lease. The MAC and IP will be queried
+	 * against the DHCP pool. (1) If the MAC is found in an available, fixed binding, and that binding
+	 * is not for the provided IP, the fixed binding associated with the MAC will be returned. (2) If the
+	 * IP is found in an available, fixed binding, and that binding also contains the MAC address provided, 
+	 * then the binding will be returned -- this is true only if the IP and MAC result in the same available, 
+	 * fixed binding. (3) If the IP is found in the pool and it is available and not fixed, then its
+	 * binding will be returned. (4) If the IP provided does not match any available entries or is invalid, 
+	 * null will be returned. If this is the case, run getAnyAvailableLease(mac) to resolve.
+	 * @param {@code byte[]}: The IP address on which to try and obtain a lease
+	 * @param {@code byte[]}: The MAC address on which to try and obtain a lease.
+	 * @return {@code DHCPBinding}: Reference to the DHCPBinding object if successful, null if unsuccessful.
+	 */
+	public DHCPBinding getSpecificAvailableLease(IPv4Address ip, MacAddress mac) {
+		if (ip == null || mac == null || isPoolFull()) return null;
+
+		DHCPBinding binding = this.getDHCPbindingFromIPv4(ip);
+		DHCPBinding binding2 = this.getDHCPbindingFromMAC(mac);
+
+		// For all of the following, the binding is also determined to be inactive:
+		
+		// If configured, we must return a fixed binding for a MAC address even if it's requesting another IP
+		if (binding2 != null && !binding2.isActiveLease() && binding2.isStaticIPLease() && binding != binding2) {
+			if (log != null) log.info("Fixed DHCP entry for MAC trumps requested IP. Returning binding for MAC");
+			return binding2;
+		// If configured, we must return a fixed binding for an IP if the binding is fixed to the provided MAC (ideal static request case)
+		} else if (binding != null && !binding.isActiveLease() && binding.isStaticIPLease() && mac.equals(binding.getMACAddress())) {
+			if (log != null) log.info("Found matching fixed DHCP entry for IP with MAC. Returning binding for IP with MAC");
+			return binding;
+		// The IP and MAC are not a part of a fixed binding, so return the binding of the requested IP
+		} else if (binding != null && !binding.isActiveLease() && !binding.isStaticIPLease()) {
+			if (log != null) log.info("No fixed DHCP entry for IP or MAC found. Returning dynamic binding for IP.");
+			return binding;
+		// Otherwise, the binding is fixed for both MAC and IP and this MAC does not match either, so we can't return it as available
+		} else {
+			if (log != null) log.debug("Invalid IP address request or IP is actively leased...check for any available lease to resolve");
+			return null;
+		}
+	}
+	/**
+	 * Tries to renew an IP lease.
+	 * @param {@code byte[]}: The IP address on which to try and renew a lease
+	 * @param {@code long}: The time in seconds for which the lease will be valid
+	 * @return {@code DHCPBinding}: True on success, false if unknown IP address
+	 */
+	public boolean renewLease(IPv4Address ip, int time) {
+		DHCPBinding binding = this.getDHCPbindingFromIPv4(ip);
+		if (binding != null) {
+			binding.setLeaseStartTimeSeconds();
+			binding.setLeaseDurationSeconds(time);
+			binding.setLeaseStatus(true);
+			return true;
+		}
+		return false;
+	}
+	/**
+	 * Cancel an IP lease.
+	 * @param {@code byte[]}: The IP address on which to try and cancel a lease
+	 * @return {@code boolean}: True on success, false if unknown IP address
+	 */
+	public boolean cancelLeaseOfIPv4(IPv4Address ip) {
+		DHCPBinding binding = this.getDHCPbindingFromIPv4(ip);
+		if (binding != null) {
+			binding.clearLeaseTimes();
+			binding.setLeaseStatus(false);
+			this.setPoolAvailability(this.getPoolAvailability() + 1);
+			this.setPoolFull(false);
+			return true;
+		}
+		return false;
+	}
+	/**
+	 * Cancel an IP lease.
+	 * @param {@code byte[]}: The MAC address on which to try and cancel a lease
+	 * @return {@code boolean}: True on success, false if unknown IP address
+	 */
+	public boolean cancelLeaseOfMAC(MacAddress mac) {
+		DHCPBinding binding = getDHCPbindingFromMAC(mac);
+		if (binding != null) {
+			binding.clearLeaseTimes();
+			binding.setLeaseStatus(false);
+			this.setPoolAvailability(this.getPoolAvailability() + 1);
+			this.setPoolFull(false);
+			return true;
+		}
+		return false;
+	}
+	/**
+	 * Make the addresses of expired leases available and reset the lease times.
+	 * @return {@code ArrayList<DHCPBinding>}: A list of the bindings that are now available
+	 */
+	public ArrayList<DHCPBinding> cleanExpiredLeases() {
+		ArrayList<DHCPBinding> newAvailableLeases = new ArrayList<DHCPBinding>();
+		for (DHCPBinding binding : DHCP_POOL) {
+			// isLeaseExpired() automatically excludes configured static leases
+			if (binding.isLeaseExpired() && binding.isActiveLease()) {
+				this.cancelLeaseOfIPv4(binding.getIPv4Address());
+				this.setPoolAvailability(this.getPoolAvailability() + 1);
+				this.setPoolFull(false);
+				newAvailableLeases.add(binding);
+			}
+		}
+		return newAvailableLeases;
+	}
+	/**
+	 * Used to set a particular IP binding in the pool as a fixed/static IP lease.
+	 * This method does not set the lease as active, but instead reserves that IP
+	 * for only the MAC provided. To set the lease as active, the methods getAnyAvailableLease()
+	 * or getSpecificAvailableLease() will return the correct binding given the same
+	 * MAC provided to this method is used to bind the lease later on.
+	 * @param {@code byte[]}: The IP address to set as static/fixed.
+	 * @param {@code byte[]}: The MAC address to match to the IP address ip when
+	 * an address is requested from the MAC mac
+	 * @return {@code boolean}: True upon success; false upon failure (e.g. no IP found)
+	 */
+	public boolean configureFixedIPLease(IPv4Address ip, MacAddress mac) {
+		DHCPBinding binding = this.getDHCPbindingFromIPv4(ip);
+		if (binding != null) {
+			binding.setMACAddress(mac);
+			binding.setStaticIPLease(true);
+			binding.setLeaseStatus(false);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+}

--- a/src/main/java/net/floodlightcontroller/dhcpserver/DHCPServer.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/DHCPServer.java
@@ -1,0 +1,1107 @@
+package net.floodlightcontroller.dhcpserver;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.projectfloodlight.openflow.protocol.OFMessage;
+import org.projectfloodlight.openflow.protocol.OFPacketIn;
+import org.projectfloodlight.openflow.protocol.OFPacketOut;
+import org.projectfloodlight.openflow.protocol.OFType;
+import org.projectfloodlight.openflow.protocol.action.OFAction;
+import org.projectfloodlight.openflow.types.EthType;
+import org.projectfloodlight.openflow.types.IPv4Address;
+import org.projectfloodlight.openflow.types.IpProtocol;
+import org.projectfloodlight.openflow.types.MacAddress;
+import org.projectfloodlight.openflow.types.OFBufferId;
+import org.projectfloodlight.openflow.types.OFPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.floodlightcontroller.core.FloodlightContext;
+import net.floodlightcontroller.core.IFloodlightProviderService;
+import net.floodlightcontroller.core.IOFMessageListener;
+import net.floodlightcontroller.core.IOFSwitch;
+import net.floodlightcontroller.core.internal.IOFSwitchService;
+import net.floodlightcontroller.core.module.FloodlightModuleContext;
+import net.floodlightcontroller.core.module.FloodlightModuleException;
+import net.floodlightcontroller.core.module.IFloodlightModule;
+import net.floodlightcontroller.core.module.IFloodlightService;
+import net.floodlightcontroller.forwarding.Forwarding;
+import net.floodlightcontroller.packet.DHCP.DHCPOptionCode;
+import net.floodlightcontroller.packet.Ethernet;
+import net.floodlightcontroller.packet.IPv4;
+import net.floodlightcontroller.packet.UDP;
+import net.floodlightcontroller.packet.DHCP;
+import net.floodlightcontroller.packet.DHCPOption;
+
+/**
+ * SDN DHCP Server
+ * @author Ryan Izard, rizard@g.clemson.edu
+ * 
+ * 
+ * The Floodlight Module implementing a DHCP DHCPServer.
+ * This module uses {@code DHCPPool} to manage DHCP leases.
+ * It intercepts any DHCP/BOOTP requests from connected hosts and
+ * handles the replies. The configuration file:
+ * 
+ * 		floodlight/src/main/resources/floodlightdefault.properties
+ * 
+ * contains the DHCP options and parameters that can be set. To allow
+ * all DHCP request messages to be sent to the controller (Floodlight),
+ * the DHCPSwitchFlowSetter module (in this same package) and the
+ * Forwarding module (loaded by default) should also be loaded in
+ * Floodlight. When the first DHCP request is received on a particular
+ * port of an OpenFlow switch, the request will by default be sent to
+ * the control plane to the controller for processing. The DHCPServer
+ * module will intercept the message before it makes it to the Forwarding
+ * module and process the packet. Now, because we don't want to hog all
+ * the DHCP messages (in case there is another module that is using them)
+ * we forward the packets down to other modules using Command.CONTINUE.
+ * As a side effect, the forwarding module will insert flows in the OF
+ * switch for our DHCP traffic even though we've already processed it.
+ * In order to allow all future DHCP messages from that same port to be
+ * sent to the controller (and not follow the Forwarding module's flows),
+ * we need to proactively insert flows for all DHCP client traffic on
+ * UDP port 67 to the controller. These flows will allow all DHCP traffic
+ * to be intercepted on that same port and sent to the DHCP server running
+ * on the Floodlight controller.
+ * 
+ * Currently, this DHCP server only supports a single subnet; however,
+ * work is ongoing to use connected OF switches and ports to allow
+ * the user to configure multiple subnets. On a traditional DHCP server,
+ * the machine is configured with different NICs, each with their own
+ * statically-assigned IP address/subnet/mask. The DHCP server matches
+ * the network information of each NIC with the DHCP server's configured
+ * subnets and answers the requests accordingly. To mirror this behavior
+ * on a OpenFlow network, we can differentiate between subnets based on a
+ * device's attachment point. We can assign subnets for a device per
+ * OpenFlow switch or per port per switch. This is the next step for
+ * this implementations of a SDN DHCP server.
+ *
+ * I welcome any feedback or suggestions for improvement!
+ * 
+ * 
+ */
+public class DHCPServer implements IOFMessageListener, IFloodlightModule  {
+	protected static Logger log;
+	protected static IFloodlightProviderService floodlightProvider;
+	protected static IOFSwitchService switchService;
+
+	// The garbage collector service for the DHCP server
+	// Handle expired leases by adding the IP back to the address pool
+	private static ScheduledThreadPoolExecutor leasePoliceDispatcher;
+	//private static ScheduledFuture<?> leasePoliceOfficer;
+	private static Runnable leasePolicePatrol;
+
+	// Contains the pool of IP addresses their bindings to MAC addresses
+	// Tracks the lease status and duration of DHCP bindings
+	private static volatile DHCPPool theDHCPPool;
+
+	/** START CONFIG FILE VARIABLES **/
+
+	// These variables are set using the floodlightdefault.properties file
+	// Refer to startup() for a list of the expected names in the config file
+
+	// The IP and MAC addresses of the controller/DHCP server
+	private static MacAddress CONTROLLER_MAC;
+	private static IPv4Address CONTROLLER_IP;
+
+	private static IPv4Address DHCP_SERVER_DHCP_SERVER_IP; // Same as CONTROLLER_IP but in byte[] form
+	private static IPv4Address DHCP_SERVER_SUBNET_MASK;
+	private static IPv4Address DHCP_SERVER_BROADCAST_IP;
+	private static IPv4Address DHCP_SERVER_IP_START;
+	private static IPv4Address DHCP_SERVER_IP_STOP;
+	private static int DHCP_SERVER_ADDRESS_SPACE_SIZE; // Computed in startUp()
+	private static IPv4Address DHCP_SERVER_ROUTER_IP = null;
+	private static byte[] DHCP_SERVER_NTP_IP_LIST = null;
+	private static byte[] DHCP_SERVER_DNS_IP_LIST = null;
+	private static byte[] DHCP_SERVER_DN = null;
+	private static byte[] DHCP_SERVER_IP_FORWARDING = null;
+	private static int DHCP_SERVER_DEFAULT_LEASE_TIME_SECONDS;
+	private static int DHCP_SERVER_HOLD_LEASE_TIME_SECONDS;
+	private static int DHCP_SERVER_REBIND_TIME_SECONDS; // Computed in startUp()
+	private static int DHCP_SERVER_RENEWAL_TIME_SECONDS; // Computed in startUp()
+	private static long DHCP_SERVER_LEASE_POLICE_PATROL_PERIOD_SECONDS;
+
+	/** END CONFIG FILE VARIABLES **/
+
+	/**
+	 * DHCP messages are either:
+	 *		REQUEST (client --0x01--> server)
+	 *		or REPLY (server --0x02--> client)
+	 */
+	public static byte DHCP_OPCODE_REQUEST = intToBytes(1)[0];
+	public static byte DHCP_OPCODE_REPLY = intToBytes(2)[0];
+
+	/**
+	 * DHCP REQUEST messages are either of type:
+	 *		DISCOVER (0x01)
+	 *		REQUEST (0x03)
+	 * 		DECLINE (0x04)
+	 *		RELEASE (0x07)
+	 *		or INFORM (0x08)
+	 * DHCP REPLY messages are either of type:
+	 *		OFFER (0x02)
+	 *		ACK (0x05)
+	 *		or NACK (0x06)
+	 **/
+	public static byte[] DHCP_MSG_TYPE_DISCOVER = intToBytesSizeOne(1);
+	public static byte[] DHCP_MSG_TYPE_OFFER = intToBytesSizeOne(2);
+	public static byte[] DHCP_MSG_TYPE_REQUEST = intToBytesSizeOne(3);
+	public static byte[] DHCP_MSG_TYPE_DECLINE = intToBytesSizeOne(4);
+	public static byte[] DHCP_MSG_TYPE_ACK = intToBytesSizeOne(5);
+	public static byte[] DHCP_MSG_TYPE_NACK = intToBytesSizeOne(6);
+	public static byte[] DHCP_MSG_TYPE_RELEASE = intToBytesSizeOne(7);
+	public static byte[] DHCP_MSG_TYPE_INFORM = intToBytesSizeOne(8);
+
+	/**
+	 * DHCP messages contain options requested by the client and
+	 * provided by the server. The options requested by the client are
+	 * provided in a list (option 0x37 below) and the server elects to
+	 * answer some or all of these options and may provide additional
+	 * options as necessary for the DHCP client to obtain a lease.
+	 *		OPTION NAME			HEX		DEC 		
+	 * 		Subnet Mask			0x01	1
+	 * 		Router IP			0x03	3
+	 * 		DNS Server IP		0x06	6
+	 * 		Domain Name			0x0F	15
+	 * 		IP Forwarding		0x13	19
+	 * 		Broadcast IP		0x1C	28
+	 * 		NTP Server IP		0x2A	42
+	 * 		NetBios Name IP		0x2C	44
+	 * 		NetBios DDS IP		0x2D	45
+	 * 		NetBios Node Type	0x2E	46
+	 * 		NetBios Scope ID	0x2F	47
+	 * 		Requested IP		0x32	50
+	 * 		Lease Time (s)		0x33	51
+	 * 		Msg Type (above)	0x35	53
+	 * 		DHCP Server IP		0x36	54
+	 * 		Option List (this)	0x37	55
+	 * 		Renewal Time (s)	0x3A	58
+	 * 		Rebind Time (s)		0x3B	59
+	 * 		End Option List		0xFF	255
+	 * 
+	 * NetBios options are not currently implemented in this server but can be added
+	 * via the configuration file.
+	 **/
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_SN = intToBytes(1)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_ROUTER = intToBytes(3)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_DNS = intToBytes(6)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_DN = intToBytes(15)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_IP_FORWARDING = intToBytes(19)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_BROADCAST_IP = intToBytes(28)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_NTP_IP = intToBytes(42)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_NET_BIOS_NAME_IP = intToBytes(44)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_NET_BIOS_DDS_IP = intToBytes(45)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_NET_BIOS_NODE_TYPE = intToBytes(46)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_NET_BIOS_SCOPE_ID = intToBytes(47)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_REQUESTED_IP = intToBytes(50)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_LEASE_TIME = intToBytes(51)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_MSG_TYPE = intToBytes(53)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_DHCP_SERVER = intToBytes(54)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_REQUESTED_PARAMTERS = intToBytes(55)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_RENEWAL_TIME = intToBytes(58)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_REBIND_TIME = intToBytes(59)[0];
+	public static byte DHCP_REQ_PARAM_OPTION_CODE_END = intToBytes(255)[0];
+
+	// Used for composing DHCP REPLY messages
+	public static final MacAddress BROADCAST_MAC = MacAddress.BROADCAST;
+	public static final IPv4Address BROADCAST_IP = IPv4Address.NO_MASK; /* no_mask is all 1's */
+	public static final IPv4Address UNASSIGNED_IP = IPv4Address.FULL_MASK; /* full_mask is all 0's */
+	
+	@Override
+	public Collection<Class<? extends IFloodlightService>> getModuleDependencies() {
+		Collection<Class<? extends IFloodlightService>> l = 
+				new ArrayList<Class<? extends IFloodlightService>>();
+		l.add(IFloodlightProviderService.class);
+		return l;
+	}
+
+	@Override
+	public void init(FloodlightModuleContext context) throws FloodlightModuleException {
+		floodlightProvider = context.getServiceImpl(IFloodlightProviderService.class);
+		switchService = context.getServiceImpl(IOFSwitchService.class);
+		log = LoggerFactory.getLogger(DHCPServer.class);
+	}
+
+	@Override
+	public void startUp(FloodlightModuleContext context) {
+		floodlightProvider.addOFMessageListener(OFType.PACKET_IN, this);
+
+		// Read our config options for the DHCP DHCPServer
+		Map<String, String> configOptions = context.getConfigParams(this);
+		try {
+			DHCP_SERVER_SUBNET_MASK = IPv4Address.of(configOptions.get("subnet-mask"));
+			DHCP_SERVER_IP_START = IPv4Address.of(configOptions.get("lower-ip-range"));
+			DHCP_SERVER_IP_STOP = IPv4Address.of(configOptions.get("upper-ip-range"));
+			DHCP_SERVER_ADDRESS_SPACE_SIZE = DHCP_SERVER_IP_STOP.getInt() - DHCP_SERVER_IP_START.getInt() + 1;
+			DHCP_SERVER_BROADCAST_IP = IPv4Address.of(configOptions.get("broadcast-address"));
+			DHCP_SERVER_ROUTER_IP = IPv4Address.of(configOptions.get("router"));
+			DHCP_SERVER_DN = configOptions.get("domain-name").getBytes();
+			DHCP_SERVER_DEFAULT_LEASE_TIME_SECONDS = Integer.parseInt(configOptions.get("default-lease-time"));
+			DHCP_SERVER_HOLD_LEASE_TIME_SECONDS = Integer.parseInt(configOptions.get("hold-lease-time"));
+			DHCP_SERVER_RENEWAL_TIME_SECONDS = (int) (DHCP_SERVER_DEFAULT_LEASE_TIME_SECONDS / 2.0);
+			DHCP_SERVER_REBIND_TIME_SECONDS = (int) (DHCP_SERVER_DEFAULT_LEASE_TIME_SECONDS * 0.875);
+			DHCP_SERVER_LEASE_POLICE_PATROL_PERIOD_SECONDS = Long.parseLong(configOptions.get("lease-gc-period"));
+			DHCP_SERVER_IP_FORWARDING = intToBytesSizeOne(Integer.parseInt(configOptions.get("ip-forwarding")));
+
+			CONTROLLER_MAC = MacAddress.of(configOptions.get("controller-mac"));
+			CONTROLLER_IP = IPv4Address.of(configOptions.get("controller-ip"));
+			DHCP_SERVER_DHCP_SERVER_IP = CONTROLLER_IP;
+
+			// NetBios and other options can be added to this function here as needed in the future
+		} catch(IllegalArgumentException ex) {
+			log.error("Incorrect DHCP Server configuration options", ex);
+			throw ex;
+		} catch(NullPointerException ex) {
+			log.error("Incorrect DHCP Server configuration options", ex);
+			throw ex;
+		}
+		// Create our new DHCPPool object with the specific address size
+		theDHCPPool = new DHCPPool(DHCP_SERVER_IP_START, DHCP_SERVER_ADDRESS_SPACE_SIZE, log);
+
+		// Any addresses that need to be set as static/fixed can be permanently added to the pool with a set MAC
+		String staticAddresses = configOptions.get("reserved-static-addresses");
+		if (staticAddresses != null) {
+			String[] macIpCouples = staticAddresses.split("\\s*;\\s*");
+			int i;
+			String[] macIpSplit;
+			int ipPos, macPos;
+			for (i = 0; i < macIpCouples.length; i++) {
+				macIpSplit = macIpCouples[i].split("\\s*,\\s*");
+				// Determine which element is the MAC and which is the IP
+				// i.e. which order have they been typed in in the config file?
+				if (macIpSplit[0].length() > macIpSplit[1].length()) {
+					macPos = 0;
+					ipPos = 1;
+				} else {
+					macPos = 1;
+					ipPos = 0;
+				}
+				if (theDHCPPool.configureFixedIPLease(IPv4Address.of(macIpSplit[ipPos]), MacAddress.of(macIpSplit[macPos]))) {
+					String ip = theDHCPPool.getDHCPbindingFromIPv4(IPv4Address.of(macIpSplit[ipPos])).getIPv4Address().toString();
+					String mac = theDHCPPool.getDHCPbindingFromIPv4(IPv4Address.of(macIpSplit[ipPos])).getMACAddress().toString();
+					log.info("Configured fixed address of " + ip + " for device " + mac);
+				} else {
+					log.error("Could not configure fixed address " + macIpSplit[ipPos] + " for device " + macIpSplit[macPos]);
+				}
+			}
+		}
+
+		// The order of the DNS and NTP servers should be most reliable to least
+		String dnses = configOptions.get("domain-name-servers");
+		String ntps = configOptions.get("ntp-servers");
+
+		// Separate the servers in the comma-delimited list
+		// TODO If the list is null then we need to not include this information with the options request,
+		// otherwise the client will get incorrect option information
+		if (dnses != null) {
+			DHCP_SERVER_DNS_IP_LIST = IPv4.toIPv4AddressBytes(dnses.split("\\s*,\\s*")[0].toString());
+		}
+		if (ntps != null) {
+			DHCP_SERVER_NTP_IP_LIST = IPv4.toIPv4AddressBytes(ntps.split("\\s*,\\s*")[0].toString());
+		}
+
+		// Monitor bindings for expired leases and clean them up
+		leasePoliceDispatcher = new ScheduledThreadPoolExecutor(1);
+		leasePolicePatrol = new DHCPLeasePolice();
+		/*leasePoliceOfficer = */
+		leasePoliceDispatcher.scheduleAtFixedRate(leasePolicePatrol, 10, 
+				DHCP_SERVER_LEASE_POLICE_PATROL_PERIOD_SECONDS, TimeUnit.SECONDS);
+	}
+
+	@Override
+	public Collection<Class<? extends IFloodlightService>> getModuleServices() {
+		return null;
+	}
+
+	@Override
+	public Map<Class<? extends IFloodlightService>, IFloodlightService> getServiceImpls() {
+		return null;
+	}
+
+	@Override
+	public String getName() {
+		return DHCPServer.class.getSimpleName();
+	}
+
+	@Override
+	public boolean isCallbackOrderingPrereq(OFType type, String name) {
+		return false;
+	}
+
+	@Override
+	public boolean isCallbackOrderingPostreq(OFType type, String name) {
+		// We will rely on forwarding to forward out any DHCP packets that are not
+		// destined for our DHCP server. This is to allow an environment where
+		// multiple DHCP servers operate cooperatively
+		if (type == OFType.PACKET_IN && name.equals(Forwarding.class.getSimpleName())) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	public static byte[] intToBytes(int integer) {
+		byte[] bytes = new byte[4];
+		bytes[3] = (byte) (integer >> 24);
+		bytes[2] = (byte) (integer >> 16);
+		bytes[1] = (byte) (integer >> 8);
+		bytes[0] = (byte) (integer);
+		return bytes;
+	}
+
+	public static byte[] intToBytesSizeOne(int integer) {
+		byte[] bytes = new byte[1];
+		bytes[0] = (byte) (integer);
+		return bytes;
+	}
+
+	public void sendDHCPOffer(IOFSwitch sw, OFPort inPort, MacAddress chaddr, IPv4Address dstIPAddr, 
+			IPv4Address yiaddr, IPv4Address giaddr, int xid, ArrayList<Byte> requestOrder) {
+		// Compose DHCP OFFER
+		/** (2) DHCP Offer
+		 * -- UDP src port = 67
+		 * -- UDP dst port = 68
+		 * -- IP src addr = DHCP DHCPServer's IP
+		 * -- IP dst addr = 255.255.255.255
+		 * -- Opcode = 0x02
+		 * -- XID = transactionX
+		 * -- ciaddr = blank
+		 * -- yiaddr = offer IP
+		 * -- siaddr = DHCP DHCPServer IP
+		 * -- giaddr = blank
+		 * -- chaddr = Client's MAC
+		 * -- Options:
+		 * --	Option 53 = DHCP Offer
+		 * --	Option 1 = SN Mask IP
+		 * --	Option 3 = Router IP
+		 * --	Option 51 = Lease time (s)
+		 * --	Option 54 = DHCP DHCPServer IP
+		 * --	Option 6 = DNS servers
+		 **/
+		OFPacketOut.Builder DHCPOfferPacket = sw.getOFFactory().buildPacketOut();
+		DHCPOfferPacket.setBufferId(OFBufferId.NO_BUFFER);
+
+		Ethernet ethDHCPOffer = new Ethernet();
+		ethDHCPOffer.setSourceMACAddress(CONTROLLER_MAC);
+		ethDHCPOffer.setDestinationMACAddress(chaddr);
+		ethDHCPOffer.setEtherType(EthType.IPv4);
+
+		IPv4 ipv4DHCPOffer = new IPv4();
+		if (dstIPAddr.equals(IPv4Address.NONE)) {
+			ipv4DHCPOffer.setDestinationAddress(BROADCAST_IP);
+		} else { // Client has IP and dhcpc must have crashed
+			ipv4DHCPOffer.setDestinationAddress(dstIPAddr);
+		}
+		ipv4DHCPOffer.setSourceAddress(CONTROLLER_IP);
+		ipv4DHCPOffer.setProtocol(IpProtocol.UDP);
+		ipv4DHCPOffer.setTtl((byte) 64);
+
+		UDP udpDHCPOffer = new UDP();
+		udpDHCPOffer.setDestinationPort(UDP.DHCP_CLIENT_PORT);
+		udpDHCPOffer.setSourcePort(UDP.DHCP_SERVER_PORT);
+
+		DHCP dhcpDHCPOffer = new DHCP();
+		dhcpDHCPOffer.setOpCode(DHCP_OPCODE_REPLY);
+		dhcpDHCPOffer.setHardwareType((byte) 1);
+		dhcpDHCPOffer.setHardwareAddressLength((byte) 6);
+		dhcpDHCPOffer.setHops((byte) 0);
+		dhcpDHCPOffer.setTransactionId(xid);
+		dhcpDHCPOffer.setSeconds((short) 0);
+		dhcpDHCPOffer.setFlags((short) 0);
+		dhcpDHCPOffer.setClientIPAddress(UNASSIGNED_IP);
+		dhcpDHCPOffer.setYourIPAddress(yiaddr);
+		dhcpDHCPOffer.setServerIPAddress(CONTROLLER_IP);
+		dhcpDHCPOffer.setGatewayIPAddress(giaddr);
+		dhcpDHCPOffer.setClientHardwareAddress(chaddr);
+
+		List<DHCPOption> dhcpOfferOptions = new ArrayList<DHCPOption>();
+		DHCPOption newOption;
+
+		newOption = new DHCPOption();
+		newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_MSG_TYPE);
+		newOption.setData(DHCP_MSG_TYPE_OFFER);
+		newOption.setLength((byte) 1);
+		dhcpOfferOptions.add(newOption);
+
+		for (Byte specificRequest : requestOrder) {
+			if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_SN) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_SN);
+				newOption.setData(DHCP_SERVER_SUBNET_MASK.getBytes());
+				newOption.setLength((byte) 4);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_ROUTER) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_ROUTER);
+				newOption.setData(DHCP_SERVER_ROUTER_IP.getBytes());
+				newOption.setLength((byte) 4);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_DN) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_DN);
+				newOption.setData(DHCP_SERVER_DN);
+				newOption.setLength((byte) DHCP_SERVER_DN.length);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_DNS) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_DNS);
+				newOption.setData(DHCP_SERVER_DNS_IP_LIST);
+				newOption.setLength((byte) DHCP_SERVER_DNS_IP_LIST.length);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_BROADCAST_IP) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_BROADCAST_IP);
+				newOption.setData(DHCP_SERVER_BROADCAST_IP.getBytes());
+				newOption.setLength((byte) 4);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_DHCP_SERVER) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_DHCP_SERVER);
+				newOption.setData(DHCP_SERVER_DHCP_SERVER_IP.getBytes());
+				newOption.setLength((byte) 4);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_LEASE_TIME) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_LEASE_TIME);
+				newOption.setData(intToBytes(DHCP_SERVER_DEFAULT_LEASE_TIME_SECONDS));
+				newOption.setLength((byte) 4);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_NTP_IP) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_NTP_IP);
+				newOption.setData(DHCP_SERVER_NTP_IP_LIST);
+				newOption.setLength((byte) DHCP_SERVER_NTP_IP_LIST.length);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_REBIND_TIME) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_REBIND_TIME);
+				newOption.setData(intToBytes(DHCP_SERVER_REBIND_TIME_SECONDS));
+				newOption.setLength((byte) 4);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_RENEWAL_TIME) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_RENEWAL_TIME);
+				newOption.setData(intToBytes(DHCP_SERVER_RENEWAL_TIME_SECONDS));
+				newOption.setLength((byte) 4);
+				dhcpOfferOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_IP_FORWARDING) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_IP_FORWARDING);
+				newOption.setData(DHCP_SERVER_IP_FORWARDING);
+				newOption.setLength((byte) 1);
+				dhcpOfferOptions.add(newOption);
+			} else {
+				//log.debug("Setting specific request for OFFER failed");
+			}
+		}
+
+		newOption = new DHCPOption();
+		newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_END);
+		newOption.setLength((byte) 0);
+		dhcpOfferOptions.add(newOption);
+
+		dhcpDHCPOffer.setOptions(dhcpOfferOptions);
+
+		ethDHCPOffer.setPayload(ipv4DHCPOffer.setPayload(udpDHCPOffer.setPayload(dhcpDHCPOffer)));
+
+		DHCPOfferPacket.setInPort(OFPort.ANY);
+
+		List<OFAction> actions = new ArrayList<OFAction>(1);
+		actions.add(sw.getOFFactory().actions().output(inPort, 0xffFFffFF));
+		DHCPOfferPacket.setActions(actions);
+
+		DHCPOfferPacket.setData(ethDHCPOffer.serialize());
+
+		log.debug("Sending DHCP OFFER");
+		sw.write(DHCPOfferPacket.build());
+	}
+
+	public void sendDHCPAck(IOFSwitch sw, OFPort inPort, MacAddress chaddr, IPv4Address dstIPAddr, 
+			IPv4Address yiaddr, IPv4Address giaddr, int xid, ArrayList<Byte> requestOrder) {
+		/** (4) DHCP ACK
+		 * -- UDP src port = 67
+		 * -- UDP dst port = 68
+		 * -- IP src addr = DHCP DHCPServer's IP
+		 * -- IP dst addr = 255.255.255.255
+		 * -- Opcode = 0x02
+		 * -- XID = transactionX
+		 * -- ciaddr = blank
+		 * -- yiaddr = offer IP
+		 * -- siaddr = DHCP DHCPServer IP
+		 * -- giaddr = blank
+		 * -- chaddr = Client's MAC
+		 * -- Options:
+		 * --	Option 53 = DHCP ACK
+		 * --	Option 1 = SN Mask IP
+		 * --	Option 3 = Router IP
+		 * --	Option 51 = Lease time (s)
+		 * --	Option 54 = DHCP DHCPServer IP
+		 * --	Option 6 = DNS servers
+		 **/
+		OFPacketOut.Builder DHCPACKPacket = sw.getOFFactory().buildPacketOut();
+		DHCPACKPacket.setBufferId(OFBufferId.NO_BUFFER);
+
+		Ethernet ethDHCPAck = new Ethernet();
+		ethDHCPAck.setSourceMACAddress(CONTROLLER_MAC);
+		ethDHCPAck.setDestinationMACAddress(chaddr);
+		ethDHCPAck.setEtherType(EthType.IPv4);
+
+		IPv4 ipv4DHCPAck = new IPv4();
+		if (dstIPAddr.equals(IPv4Address.NONE)) {
+			ipv4DHCPAck.setDestinationAddress(BROADCAST_IP);
+		} else { // Client has IP and dhclient must have crashed
+			ipv4DHCPAck.setDestinationAddress(dstIPAddr);
+		}
+		ipv4DHCPAck.setSourceAddress(CONTROLLER_IP);
+		ipv4DHCPAck.setProtocol(IpProtocol.UDP);
+		ipv4DHCPAck.setTtl((byte) 64);
+
+		UDP udpDHCPAck = new UDP();
+		udpDHCPAck.setDestinationPort(UDP.DHCP_CLIENT_PORT);
+		udpDHCPAck.setSourcePort(UDP.DHCP_SERVER_PORT);
+
+		DHCP dhcpDHCPAck = new DHCP();
+		dhcpDHCPAck.setOpCode(DHCP_OPCODE_REPLY);
+		dhcpDHCPAck.setHardwareType((byte) 1);
+		dhcpDHCPAck.setHardwareAddressLength((byte) 6);
+		dhcpDHCPAck.setHops((byte) 0);
+		dhcpDHCPAck.setTransactionId(xid);
+		dhcpDHCPAck.setSeconds((short) 0);
+		dhcpDHCPAck.setFlags((short) 0);
+		dhcpDHCPAck.setClientIPAddress(UNASSIGNED_IP);
+		dhcpDHCPAck.setYourIPAddress(yiaddr);
+		dhcpDHCPAck.setServerIPAddress(CONTROLLER_IP);
+		dhcpDHCPAck.setGatewayIPAddress(giaddr);
+		dhcpDHCPAck.setClientHardwareAddress(chaddr);
+
+		List<DHCPOption> dhcpAckOptions = new ArrayList<DHCPOption>();
+		DHCPOption newOption;
+
+		newOption = new DHCPOption();
+		newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_MSG_TYPE);
+		newOption.setData(DHCP_MSG_TYPE_ACK);
+		newOption.setLength((byte) 1);
+		dhcpAckOptions.add(newOption);
+
+		for (Byte specificRequest : requestOrder) {
+			if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_SN) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_SN);
+				newOption.setData(DHCP_SERVER_SUBNET_MASK.getBytes());
+				newOption.setLength((byte) 4);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_ROUTER) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_ROUTER);
+				newOption.setData(DHCP_SERVER_ROUTER_IP.getBytes());
+				newOption.setLength((byte) 4);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_DN) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_DN);
+				newOption.setData(DHCP_SERVER_DN);
+				newOption.setLength((byte) DHCP_SERVER_DN.length);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_DNS) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_DNS);
+				newOption.setData(DHCP_SERVER_DNS_IP_LIST);
+				newOption.setLength((byte) DHCP_SERVER_DNS_IP_LIST.length);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_BROADCAST_IP) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_BROADCAST_IP);
+				newOption.setData(DHCP_SERVER_BROADCAST_IP.getBytes());
+				newOption.setLength((byte) 4);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_DHCP_SERVER) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_DHCP_SERVER);
+				newOption.setData(DHCP_SERVER_DHCP_SERVER_IP.getBytes());
+				newOption.setLength((byte) 4);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_LEASE_TIME) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_LEASE_TIME);
+				newOption.setData(intToBytes(DHCP_SERVER_DEFAULT_LEASE_TIME_SECONDS));
+				newOption.setLength((byte) 4);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_NTP_IP) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_NTP_IP);
+				newOption.setData(DHCP_SERVER_NTP_IP_LIST);
+				newOption.setLength((byte) DHCP_SERVER_NTP_IP_LIST.length);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_REBIND_TIME) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_REBIND_TIME);
+				newOption.setData(intToBytes(DHCP_SERVER_REBIND_TIME_SECONDS));
+				newOption.setLength((byte) 4);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_RENEWAL_TIME) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_RENEWAL_TIME);
+				newOption.setData(intToBytes(DHCP_SERVER_RENEWAL_TIME_SECONDS));
+				newOption.setLength((byte) 4);
+				dhcpAckOptions.add(newOption);
+			} else if (specificRequest.byteValue() == DHCP_REQ_PARAM_OPTION_CODE_IP_FORWARDING) {
+				newOption = new DHCPOption();
+				newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_IP_FORWARDING);
+				newOption.setData(DHCP_SERVER_IP_FORWARDING);
+				newOption.setLength((byte) 1);
+				dhcpAckOptions.add(newOption);
+			}else {
+				log.debug("Setting specific request for ACK failed");
+			}
+		}
+
+		newOption = new DHCPOption();
+		newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_END);
+		newOption.setLength((byte) 0);
+		dhcpAckOptions.add(newOption);
+
+		dhcpDHCPAck.setOptions(dhcpAckOptions);
+
+		ethDHCPAck.setPayload(ipv4DHCPAck.setPayload(udpDHCPAck.setPayload(dhcpDHCPAck)));
+
+		DHCPACKPacket.setInPort(OFPort.ANY);
+
+		List<OFAction> actions = new ArrayList<OFAction>(1);
+		actions.add(sw.getOFFactory().actions().output(inPort, 0xffFFffFF));
+		DHCPACKPacket.setActions(actions);
+
+		DHCPACKPacket.setData(ethDHCPAck.serialize());
+
+		log.debug("Sending DHCP ACK");
+		sw.write(DHCPACKPacket.build());
+	}
+
+	public void sendDHCPNack(IOFSwitch sw, OFPort inPort, MacAddress chaddr, IPv4Address giaddr, int xid) {
+		OFPacketOut.Builder DHCPOfferPacket = sw.getOFFactory().buildPacketOut();
+		DHCPOfferPacket.setBufferId(OFBufferId.NO_BUFFER);
+
+		Ethernet ethDHCPOffer = new Ethernet();
+		ethDHCPOffer.setSourceMACAddress(CONTROLLER_MAC);
+		ethDHCPOffer.setDestinationMACAddress(chaddr);
+		ethDHCPOffer.setEtherType(EthType.IPv4);
+
+		IPv4 ipv4DHCPOffer = new IPv4();
+		ipv4DHCPOffer.setDestinationAddress(BROADCAST_IP);
+		ipv4DHCPOffer.setSourceAddress(CONTROLLER_IP);
+		ipv4DHCPOffer.setProtocol(IpProtocol.UDP);
+		ipv4DHCPOffer.setTtl((byte) 64);
+
+		UDP udpDHCPOffer = new UDP();
+		udpDHCPOffer.setDestinationPort(UDP.DHCP_CLIENT_PORT);
+		udpDHCPOffer.setSourcePort(UDP.DHCP_SERVER_PORT);
+
+		DHCP dhcpDHCPOffer = new DHCP();
+		dhcpDHCPOffer.setOpCode(DHCP_OPCODE_REPLY);
+		dhcpDHCPOffer.setHardwareType((byte) 1);
+		dhcpDHCPOffer.setHardwareAddressLength((byte) 6);
+		dhcpDHCPOffer.setHops((byte) 0);
+		dhcpDHCPOffer.setTransactionId(xid);
+		dhcpDHCPOffer.setSeconds((short) 0);
+		dhcpDHCPOffer.setFlags((short) 0);
+		dhcpDHCPOffer.setClientIPAddress(UNASSIGNED_IP);
+		dhcpDHCPOffer.setYourIPAddress(UNASSIGNED_IP);
+		dhcpDHCPOffer.setServerIPAddress(CONTROLLER_IP);
+		dhcpDHCPOffer.setGatewayIPAddress(giaddr);
+		dhcpDHCPOffer.setClientHardwareAddress(chaddr);
+
+		List<DHCPOption> dhcpOfferOptions = new ArrayList<DHCPOption>();
+		DHCPOption newOption;
+
+		newOption = new DHCPOption();
+		newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_MSG_TYPE);
+		newOption.setData(DHCP_MSG_TYPE_NACK);
+		newOption.setLength((byte) 1);
+		dhcpOfferOptions.add(newOption);
+
+		newOption = new DHCPOption();
+		newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_DHCP_SERVER);
+		newOption.setData(DHCP_SERVER_DHCP_SERVER_IP.getBytes());
+		newOption.setLength((byte) 4);
+		dhcpOfferOptions.add(newOption);
+
+		newOption = new DHCPOption();
+		newOption.setCode(DHCP_REQ_PARAM_OPTION_CODE_END);
+		newOption.setLength((byte) 0);
+		dhcpOfferOptions.add(newOption);
+
+		dhcpDHCPOffer.setOptions(dhcpOfferOptions);
+
+		ethDHCPOffer.setPayload(ipv4DHCPOffer.setPayload(udpDHCPOffer.setPayload(dhcpDHCPOffer)));
+
+		DHCPOfferPacket.setInPort(OFPort.ANY);
+
+		List<OFAction> actions = new ArrayList<OFAction>(1);
+		actions.add(sw.getOFFactory().actions().output(inPort, 0xffFFffFF));
+		DHCPOfferPacket.setActions(actions);
+
+		DHCPOfferPacket.setData(ethDHCPOffer.serialize());
+
+		log.info("Sending DHCP NACK");
+		sw.write(DHCPOfferPacket.build());
+	}
+
+	public ArrayList<Byte> getRequestedParameters(DHCP DHCPPayload, boolean isInform) {
+		ArrayList<Byte> requestOrder = new ArrayList<Byte>();
+		byte[] requests = DHCPPayload.getOption(DHCPOptionCode.OptionCode_RequestedParameters).getData();
+		boolean requestedLeaseTime = false;
+		boolean requestedRebindTime = false;
+		boolean requestedRenewTime = false;
+		for (byte specificRequest : requests) {
+			if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_SN) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_SN);
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_ROUTER) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_ROUTER);
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_DN) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_DN);
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_DNS) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_DNS);
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_LEASE_TIME) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_LEASE_TIME);
+				requestedLeaseTime = true;
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_DHCP_SERVER) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_DHCP_SERVER);
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_BROADCAST_IP) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_BROADCAST_IP);
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_NTP_IP) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_NTP_IP);
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_REBIND_TIME) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_REBIND_TIME);
+				requestedRebindTime = true;
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_RENEWAL_TIME) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_RENEWAL_TIME);
+				requestedRenewTime = true;
+			} else if (specificRequest == DHCP_REQ_PARAM_OPTION_CODE_IP_FORWARDING) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_IP_FORWARDING);
+				log.debug("requested IP FORWARDING");
+			} else {
+				//log.debug("Requested option 0x" + Byte.toString(specificRequest) + " not available");
+			}
+		}
+		
+		// We need to add these in regardless if the request list includes them
+		if (!isInform) {
+			if (!requestedLeaseTime) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_LEASE_TIME);
+				log.debug("added option LEASE TIME");
+			}
+			if (!requestedRenewTime) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_RENEWAL_TIME);
+				log.debug("added option RENEWAL TIME");
+			}
+			if (!requestedRebindTime) {
+				requestOrder.add(DHCP_REQ_PARAM_OPTION_CODE_REBIND_TIME);
+				log.debug("added option REBIND TIME");
+			}
+		}
+		return requestOrder;
+	}
+
+	@Override
+	public net.floodlightcontroller.core.IListener.Command receive(IOFSwitch sw, OFMessage msg, FloodlightContext cntx) {
+
+		OFPacketIn pi = (OFPacketIn) msg;
+
+		if (!theDHCPPool.hasAvailableAddresses()) {
+			log.info("DHCP Pool is full! Consider increasing the pool size.");
+			return Command.CONTINUE;
+		}
+
+		Ethernet eth = IFloodlightProviderService.bcStore.get(cntx,
+				IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
+
+		if (eth.getEtherType() == EthType.IPv4) { /* shallow compare is okay for EthType */
+			log.debug("Got IPv4 Packet");
+			IPv4 IPv4Payload = (IPv4) eth.getPayload();
+			IPv4Address IPv4SrcAddr = IPv4Payload.getSourceAddress();
+
+			if (IPv4Payload.getProtocol() == IpProtocol.UDP) { /* shallow compare also okay for IpProtocol */
+				log.debug("Got UDP Packet");
+				UDP UDPPayload = (UDP) IPv4Payload.getPayload();
+
+				if ((UDPPayload.getDestinationPort().equals(UDP.DHCP_SERVER_PORT) /* TransportPort must be deep though */
+						|| UDPPayload.getDestinationPort().equals(UDP.DHCP_CLIENT_PORT))
+						&& (UDPPayload.getSourcePort().equals(UDP.DHCP_SERVER_PORT)
+						|| UDPPayload.getSourcePort().equals(UDP.DHCP_CLIENT_PORT)))
+				{
+					log.debug("Got DHCP Packet");
+					// This is a DHCP packet that we need to process
+					DHCP DHCPPayload = (DHCP) UDPPayload.getPayload();
+					OFPort inPort = pi.getInPort();
+
+					/* DHCP/IPv4 Header Information */
+					int xid = 0;
+					IPv4Address yiaddr = IPv4Address.NONE;
+					IPv4Address giaddr = IPv4Address.NONE;
+					MacAddress chaddr = null;
+					IPv4Address desiredIPAddr = null;
+					ArrayList<Byte> requestOrder = new ArrayList<Byte>();
+					if (DHCPPayload.getOpCode() == DHCP_OPCODE_REQUEST) {
+						/**  * (1) DHCP Discover
+						 * -- UDP src port = 68
+						 * -- UDP dst port = 67
+						 * -- IP src addr = 0.0.0.0
+						 * -- IP dst addr = 255.255.255.255
+						 * -- Opcode = 0x01
+						 * -- XID = transactionX
+						 * -- All addresses blank:
+						 * --	ciaddr (client IP)
+						 * --	yiaddr (your IP)
+						 * --	siaddr (DHCPServer IP)
+						 * --	giaddr (GW IP)
+						 * -- chaddr = Client's MAC
+						 * -- Options:
+						 * --	Option 53 = DHCP Discover
+						 * --	Option 50 = possible IP request
+						 * --	Option 55 = parameter request list
+						 * --		(1) SN Mask
+						 * --		(3) Router
+						 * --		(15) Domain Name
+						 * --		(6) DNS
+						 **/
+						if (Arrays.equals(DHCPPayload.getOption(DHCP.DHCPOptionCode.OptionCode_MessageType).getData(), DHCP_MSG_TYPE_DISCOVER)) {
+							log.debug("DHCP DISCOVER Received");
+							xid = DHCPPayload.getTransactionId();
+							yiaddr = DHCPPayload.getYourIPAddress();
+							// Will have GW IP if a relay agent was used
+							giaddr = DHCPPayload.getGatewayIPAddress();
+							chaddr = DHCPPayload.getClientHardwareAddress();
+							List<DHCPOption> options = DHCPPayload.getOptions();
+							for (DHCPOption option : options) {
+								if (option.getCode() == DHCP_REQ_PARAM_OPTION_CODE_REQUESTED_IP) {
+									desiredIPAddr = IPv4Address.of(option.getData());
+									log.debug("Got requested IP");
+								} else if (option.getCode() == DHCP_REQ_PARAM_OPTION_CODE_REQUESTED_PARAMTERS) {
+									log.debug("Got requested param list");
+									requestOrder = getRequestedParameters(DHCPPayload, false); 		
+								}
+							}
+
+							// Process DISCOVER message and prepare an OFFER with minimum-hold lease
+							// A HOLD lease should be a small amount of time sufficient for the client to respond
+							// with a REQUEST, at which point the ACK will set the least time to the DEFAULT
+							synchronized (theDHCPPool) {
+								if (!theDHCPPool.hasAvailableAddresses()) {
+									log.info("DHCP Pool is full! Consider increasing the pool size.");
+									log.info("Device with MAC " + chaddr.toString() + " was not granted an IP lease");
+									return Command.CONTINUE;
+								}
+								DHCPBinding lease = theDHCPPool.getSpecificAvailableLease(desiredIPAddr, chaddr);
+
+								if (lease != null) {
+									log.debug("Checking new lease with specific IP");
+									theDHCPPool.setDHCPbinding(lease, chaddr, DHCP_SERVER_HOLD_LEASE_TIME_SECONDS);
+									yiaddr = lease.getIPv4Address();
+									log.debug("Got new lease for " + yiaddr.toString());
+								} else {
+									log.debug("Checking new lease for any IP");
+									lease = theDHCPPool.getAnyAvailableLease(chaddr);
+									theDHCPPool.setDHCPbinding(lease, chaddr, DHCP_SERVER_HOLD_LEASE_TIME_SECONDS);
+									yiaddr = lease.getIPv4Address();
+									log.debug("Got new lease for " + yiaddr.toString());
+								}
+							}
+
+							sendDHCPOffer(sw, inPort, chaddr, IPv4SrcAddr, yiaddr, giaddr, xid, requestOrder);
+						} // END IF DISCOVER
+
+						/** (3) DHCP Request
+						 * -- UDP src port = 68
+						 * -- UDP dst port = 67
+						 * -- IP src addr = 0.0.0.0
+						 * -- IP dst addr = 255.255.255.255
+						 * -- Opcode = 0x01
+						 * -- XID = transactionX
+						 * -- ciaddr = blank
+						 * -- yiaddr = blank
+						 * -- siaddr = DHCP DHCPServer IP
+						 * -- giaddr = GW IP
+						 * -- chaddr = Client's MAC
+						 * -- Options:
+						 * --	Option 53 = DHCP Request
+						 * --	Option 50 = IP requested (from offer)
+						 * --	Option 54 = DHCP DHCPServer IP
+						 **/
+						else if (Arrays.equals(DHCPPayload.getOption(DHCP.DHCPOptionCode.OptionCode_MessageType).getData(), DHCP_MSG_TYPE_REQUEST)) {
+							log.debug(": DHCP REQUEST received");
+							IPv4SrcAddr = IPv4Payload.getSourceAddress();
+							xid = DHCPPayload.getTransactionId();
+							yiaddr = DHCPPayload.getYourIPAddress();
+							giaddr = DHCPPayload.getGatewayIPAddress();
+							chaddr = DHCPPayload.getClientHardwareAddress();
+
+							List<DHCPOption> options = DHCPPayload.getOptions();
+							for (DHCPOption option : options) {
+								if (option.getCode() == DHCP_REQ_PARAM_OPTION_CODE_REQUESTED_IP) {
+									desiredIPAddr = IPv4Address.of(option.getData());
+									if (!desiredIPAddr.equals(theDHCPPool.getDHCPbindingFromMAC(chaddr).getIPv4Address())) {
+										// This client wants a different IP than what we have on file, so cancel its HOLD lease now (if we have one)
+										theDHCPPool.cancelLeaseOfMAC(chaddr);
+										return Command.CONTINUE;
+									}
+								} else if (option.getCode() == DHCP_REQ_PARAM_OPTION_CODE_DHCP_SERVER) {
+									if (!IPv4Address.of(option.getData()).equals(DHCP_SERVER_DHCP_SERVER_IP)) {
+										// We're not the DHCPServer the client wants to use, so cancel its HOLD lease now and ignore the client
+										theDHCPPool.cancelLeaseOfMAC(chaddr);
+										return Command.CONTINUE;
+									}
+								} else if (option.getCode() == DHCP_REQ_PARAM_OPTION_CODE_REQUESTED_PARAMTERS) {
+									requestOrder = getRequestedParameters(DHCPPayload, false);
+								}
+							}
+							// Process REQUEST message and prepare an ACK with default lease time
+							// This extends the hold lease time to that of a normal lease
+							boolean sendACK = true;
+							synchronized (theDHCPPool) {
+								if (!theDHCPPool.hasAvailableAddresses()) {
+									log.info("DHCP Pool is full! Consider increasing the pool size.");
+									log.info("Device with MAC " + chaddr.toString() + " was not granted an IP lease");
+									return Command.CONTINUE;
+								}
+								DHCPBinding lease;
+								// Get any binding, in use now or not
+								if (desiredIPAddr != null) {
+									lease = theDHCPPool.getDHCPbindingFromIPv4(desiredIPAddr);
+								} else {
+									lease = theDHCPPool.getAnyAvailableLease(chaddr);
+								}
+								// This IP is not in our allocation range
+								if (lease == null) {
+									log.info("The IP " + desiredIPAddr.toString() + " is not in the range " 
+											+ DHCP_SERVER_IP_START.toString() + " to " + DHCP_SERVER_IP_STOP.toString());
+									log.info("Device with MAC " + chaddr.toString() + " was not granted an IP lease");
+									sendACK = false;
+									// Determine if the IP in the binding we just retrieved is okay to allocate to the MAC requesting it
+								} else if (!lease.getMACAddress().equals(chaddr) && lease.isActiveLease()) {
+									log.debug("Tried to REQUEST an IP that is currently assigned to another MAC");
+									log.debug("Device with MAC " + chaddr.toString() + " was not granted an IP lease");
+									sendACK = false;
+									// Check if we want to renew the MAC's current lease
+								} else if (lease.getMACAddress().equals(chaddr) && lease.isActiveLease()) {
+									log.debug("Renewing lease for MAC " + chaddr.toString());
+									theDHCPPool.renewLease(lease.getIPv4Address(), DHCP_SERVER_DEFAULT_LEASE_TIME_SECONDS);
+									yiaddr = lease.getIPv4Address();
+									log.debug("Finalized renewed lease for " + yiaddr.toString());
+									// Check if we want to create a new lease for the MAC
+								} else if (!lease.isActiveLease()){
+									log.debug("Assigning new lease for MAC " + chaddr.toString());
+									theDHCPPool.setDHCPbinding(lease, chaddr, DHCP_SERVER_DEFAULT_LEASE_TIME_SECONDS);
+									yiaddr = lease.getIPv4Address();
+									log.debug("Finalized new lease for " + yiaddr.toString());
+								} else {
+									log.debug("Don't know how we got here");
+									return Command.CONTINUE;
+								}
+							}
+							if (sendACK) {
+								sendDHCPAck(sw, inPort, chaddr, IPv4SrcAddr, yiaddr, giaddr, xid, requestOrder);							
+							} else {
+								sendDHCPNack(sw, inPort, chaddr, giaddr, xid);
+							}
+						} // END IF REQUEST
+						else if (Arrays.equals(DHCPPayload.getOption(DHCP.DHCPOptionCode.OptionCode_MessageType).getData(), DHCP_MSG_TYPE_RELEASE)) {
+							if (DHCPPayload.getServerIPAddress() != CONTROLLER_IP) {
+								log.info("DHCP RELEASE message not for our DHCP server");
+								// Send the packet out the port it would normally go out via the Forwarding module
+								// Execution jumps to return Command.CONTINUE at end of receive()
+							} else {
+								log.debug("Got DHCP RELEASE. Cancelling remaining time on DHCP lease");
+								synchronized(theDHCPPool) {
+									if (theDHCPPool.cancelLeaseOfMAC(DHCPPayload.getClientHardwareAddress())) {
+										log.info("Cancelled DHCP lease of " + DHCPPayload.getClientHardwareAddress().toString());
+										log.info("IP " + theDHCPPool.getDHCPbindingFromMAC(DHCPPayload.getClientHardwareAddress()).getIPv4Address().toString()
+												+ " is now available in the DHCP address pool");
+									} else {
+										log.debug("Lease of " + DHCPPayload.getClientHardwareAddress().toString()
+												+ " was already inactive");
+									}
+								}
+							}
+						} // END IF RELEASE
+						else if (Arrays.equals(DHCPPayload.getOption(DHCP.DHCPOptionCode.OptionCode_MessageType).getData(), DHCP_MSG_TYPE_DECLINE)) {
+							log.debug("Got DHCP DECLINE. Cancelling HOLD time on DHCP lease");
+							synchronized(theDHCPPool) {
+								if (theDHCPPool.cancelLeaseOfMAC(DHCPPayload.getClientHardwareAddress())) {
+									log.info("Cancelled DHCP lease of " + DHCPPayload.getClientHardwareAddress().toString());
+									log.info("IP " + theDHCPPool.getDHCPbindingFromMAC(DHCPPayload.getClientHardwareAddress()).getIPv4Address().toString()
+											+ " is now available in the DHCP address pool");
+								} else {
+									log.info("HOLD Lease of " + DHCPPayload.getClientHardwareAddress().toString()
+											+ " has already expired");
+								}
+							}
+						} // END IF DECLINE
+						else if (Arrays.equals(DHCPPayload.getOption(DHCP.DHCPOptionCode.OptionCode_MessageType).getData(), DHCP_MSG_TYPE_INFORM)) {
+							log.debug("Got DHCP INFORM. Retreiving requested parameters from message");
+							IPv4SrcAddr = IPv4Payload.getSourceAddress();
+							xid = DHCPPayload.getTransactionId();
+							yiaddr = DHCPPayload.getYourIPAddress();
+							giaddr = DHCPPayload.getGatewayIPAddress();
+							chaddr = DHCPPayload.getClientHardwareAddress();
+
+							// Get the requests from the INFORM message. True for inform -- we don't want to include lease information
+							requestOrder = getRequestedParameters(DHCPPayload, true);
+							
+							// Process INFORM message and send an ACK with requested information
+							sendDHCPAck(sw, inPort, chaddr, IPv4SrcAddr, yiaddr, giaddr, xid, requestOrder);							
+						} // END IF INFORM
+					} // END IF DHCP OPCODE REQUEST 
+					else if (DHCPPayload.getOpCode() == DHCP_OPCODE_REPLY) {
+						// Do nothing right now. The DHCP DHCPServer isn't supposed to receive replies but ISSUE them instead
+						log.debug("Got an OFFER/ACK (REPLY)...this shouldn't happen unless there's another DHCP Server somewhere");
+					} else {
+						log.debug("Got DHCP packet, but not a known DHCP packet opcode");
+					}
+				} // END IF DHCP packet
+			} // END IF UDP packet
+		} // END IF IPv4 packet
+		return Command.CONTINUE;
+	} // END of receive(pkt)
+
+	/**
+	 * DHCPLeasePolice is a simple class that is instantiated and invoked
+	 * as a runnable thread. The objective is to clean up the expired DHCP
+	 * leases on a set time interval. Most DHCP leases are hours in length,
+	 * so the granularity of our check can be on the order of minutes (IMHO).
+	 * The period of the check for expired leases, in seconds, is specified
+	 * in the configuration file:
+	 * 
+	 * 		floodlight/src/main/resources/floodlightdefault.properties
+	 * 
+	 * as option:
+	 * 
+	 * 		net.floodlightcontroller.dhcpserver.DHCPServer.lease-gc-period = <seconds>
+	 * 
+	 * where gc stands for "garbage collection".
+	 * 
+	 * @author Ryan Izard, rizard@g.clemson.edu
+	 *
+	 */
+	class DHCPLeasePolice implements Runnable {
+		@Override
+		public void run() {
+			log.info("Cleaning any expired DHCP leases...");
+			ArrayList<DHCPBinding> newAvailableBindings;
+			synchronized(theDHCPPool) {
+				// Loop through lease pool and check all leases to see if they are expired
+				// If a lease is expired, then clean it up and make the binding available
+				newAvailableBindings = theDHCPPool.cleanExpiredLeases();
+			}
+			for (DHCPBinding binding : newAvailableBindings) {
+				log.info("MAC " + binding.getMACAddress().toString() + " has expired");
+				log.info("Lease now available for IP " + binding.getIPv4Address().toString());
+			}
+		}
+	} // END DHCPLeasePolice Class
+} // END DHCPServer Class

--- a/src/main/java/net/floodlightcontroller/dhcpserver/DHCPServer.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/DHCPServer.java
@@ -12,7 +12,9 @@ import org.projectfloodlight.openflow.protocol.OFMessage;
 import org.projectfloodlight.openflow.protocol.OFPacketIn;
 import org.projectfloodlight.openflow.protocol.OFPacketOut;
 import org.projectfloodlight.openflow.protocol.OFType;
+import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.protocol.action.OFAction;
+import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.IPv4Address;
 import org.projectfloodlight.openflow.types.IpProtocol;
@@ -838,7 +840,7 @@ public class DHCPServer implements IOFMessageListener, IFloodlightModule  {
 					log.debug("Got DHCP Packet");
 					// This is a DHCP packet that we need to process
 					DHCP DHCPPayload = (DHCP) UDPPayload.getPayload();
-					OFPort inPort = pi.getInPort();
+					OFPort inPort = (pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT));
 
 					/* DHCP/IPv4 Header Information */
 					int xid = 0;

--- a/src/main/java/net/floodlightcontroller/dhcpserver/DHCPSwitchFlowSetter.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/DHCPSwitchFlowSetter.java
@@ -1,0 +1,119 @@
+package net.floodlightcontroller.dhcpserver;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import org.projectfloodlight.openflow.protocol.OFFlowAdd;
+import org.projectfloodlight.openflow.protocol.OFPortDesc;
+import org.projectfloodlight.openflow.protocol.action.OFAction;
+import org.projectfloodlight.openflow.protocol.action.OFActionOutput;
+import org.projectfloodlight.openflow.protocol.match.Match;
+import org.projectfloodlight.openflow.protocol.match.MatchField;
+import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.EthType;
+import org.projectfloodlight.openflow.types.IpProtocol;
+import org.projectfloodlight.openflow.types.OFBufferId;
+import org.projectfloodlight.openflow.types.OFPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.floodlightcontroller.core.IFloodlightProviderService;
+import net.floodlightcontroller.core.IOFSwitch;
+import net.floodlightcontroller.core.IOFSwitchListener;
+import net.floodlightcontroller.core.PortChangeType;
+import net.floodlightcontroller.core.internal.IOFSwitchService;
+import net.floodlightcontroller.core.module.FloodlightModuleContext;
+import net.floodlightcontroller.core.module.FloodlightModuleException;
+import net.floodlightcontroller.core.module.IFloodlightModule;
+import net.floodlightcontroller.core.module.IFloodlightService;
+import net.floodlightcontroller.packet.UDP;
+import net.floodlightcontroller.staticflowentry.IStaticFlowEntryPusherService;
+// Adding a comment to test a new commit
+public class DHCPSwitchFlowSetter implements IFloodlightModule, IOFSwitchListener {
+	protected static Logger log;
+	protected IFloodlightProviderService floodlightProvider;
+	protected IStaticFlowEntryPusherService sfp;
+	protected IOFSwitchService switchService;
+	
+	@Override
+	public Collection<Class<? extends IFloodlightService>> getModuleServices() {
+		return null;
+	}
+
+	@Override
+	public Map<Class<? extends IFloodlightService>, IFloodlightService> getServiceImpls() {
+		return null;
+	}
+
+	@Override
+	public Collection<Class<? extends IFloodlightService>> getModuleDependencies() {
+		Collection<Class<? extends IFloodlightService>> l = 
+				new ArrayList<Class<? extends IFloodlightService>>();
+		l.add(IFloodlightProviderService.class);
+		l.add(IStaticFlowEntryPusherService.class);
+		l.add(IOFSwitchService.class);
+		return l;
+	}
+
+	@Override
+	public void init(FloodlightModuleContext context)
+			throws FloodlightModuleException {
+		floodlightProvider = context.getServiceImpl(IFloodlightProviderService.class);
+		log = LoggerFactory.getLogger(DHCPServer.class);
+		sfp = context.getServiceImpl(IStaticFlowEntryPusherService.class);
+		switchService = context.getServiceImpl(IOFSwitchService.class);
+	}
+
+	@Override
+	public void startUp(FloodlightModuleContext context) {
+	}
+
+	@Override
+	public void switchAdded(DatapathId dpid) {
+		/* Insert static flows on all ports of the switch to redirect
+		 * DHCP client --> DHCP DHCPServer traffic to the controller.
+		 * DHCP client's operate on UDP port 67
+		 */
+		IOFSwitch sw = switchService.getSwitch(dpid);
+		
+		OFFlowAdd.Builder flow = sw.getOFFactory().buildFlowAdd();
+		Match.Builder match = sw.getOFFactory().buildMatch();
+		ArrayList<OFAction> actionList = new ArrayList<OFAction>();
+		OFActionOutput.Builder action = sw.getOFFactory().actions().buildOutput();
+		for (OFPortDesc port : sw.getPorts()) {
+			match.setExact(MatchField.IN_PORT, port.getPortNo());
+			match.setExact(MatchField.ETH_TYPE, EthType.IPv4);
+			match.setExact(MatchField.IP_PROTO, IpProtocol.UDP);
+			match.setExact(MatchField.UDP_SRC, UDP.DHCP_CLIENT_PORT);
+			action.setMaxLen(0xffFFffFF);
+			action.setPort(OFPort.CONTROLLER);
+			actionList.add(action.build());
+			
+			flow.setBufferId(OFBufferId.NO_BUFFER);
+			flow.setHardTimeout(0);
+			flow.setIdleTimeout(0);
+			flow.setOutPort(OFPort.CONTROLLER);
+			flow.setActions(actionList);
+			flow.setMatch(match.build());
+			flow.setPriority(32767);
+			sfp.addFlow("dhcp-port---" + port.getPortNo().getPortNumber() + "---(" + port.getName() + ")", flow.build(), sw.getId());
+		}		
+	}
+
+	@Override
+	public void switchRemoved(DatapathId switchId) {
+	}
+
+	@Override
+	public void switchActivated(DatapathId switchId) {
+	}
+
+	@Override
+	public void switchPortChanged(DatapathId switchId, OFPortDesc port, PortChangeType type) {
+	}
+
+	@Override
+	public void switchChanged(DatapathId switchId) {
+	}
+}

--- a/src/main/java/net/floodlightcontroller/firewall/Firewall.java
+++ b/src/main/java/net/floodlightcontroller/firewall/Firewall.java
@@ -494,7 +494,7 @@ public class Firewall implements IFirewallService, IOFMessageListener,
         	Match.Builder mb = MatchUtils.createRetentiveBuilder(pi.getMatch()); // capture the ingress port
         	mb.setExact(MatchField.ETH_SRC, eth.getSourceMACAddress())
         		.setExact(MatchField.ETH_DST, eth.getDestinationMACAddress())
-        		.setExact(MatchField.ETH_TYPE, EthType.of(eth.getEtherType()));
+        		.setExact(MatchField.ETH_TYPE, eth.getEtherType());
         	
         	if (mb.get(MatchField.ETH_TYPE).equals(EthType.IPv4)) {
         		IPv4 ipv4 = (IPv4) eth.getPayload();

--- a/src/main/java/net/floodlightcontroller/firewall/FirewallRule.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallRule.java
@@ -338,7 +338,7 @@ public class FirewallRule implements Comparable<FirewallRule> {
         // return false match - no need to continue protocol specific check
         if (any_dl_type == false) {
             if (dl_type.equals(EthType.ARP)) {
-                if (packet.getEtherType() != EthType.ARP.getValue())
+                if (packet.getEtherType() != EthType.ARP) /* shallow check for equality is okay for EthType */
                     return false;
                 else {
                     if (action == FirewallRule.FirewallAction.DROP) {
@@ -354,7 +354,7 @@ public class FirewallRule implements Comparable<FirewallRule> {
                     }
                 }
             } else if (dl_type.equals(EthType.IPv4)) {
-                if (packet.getEtherType() != EthType.IPv4.getValue())
+                if (packet.getEtherType() != EthType.IPv4) /* shallow check for equality is okay for EthType */
                     return false;
                 else {
                     if (action == FirewallRule.FirewallAction.DROP) {

--- a/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
+++ b/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
@@ -301,7 +301,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule {
 
 		// TODO Detect switch type and match to create hardware-implemented flow
 		// TODO Set option in config file to support specific or MAC-only matches
-		if (eth.getEtherType() == Ethernet.TYPE_IPv4) {
+		if (eth.getEtherType() == EthType.IPv4) { /* shallow check for equality is okay for EthType */
 			IPv4 ip = (IPv4) eth.getPayload();
 			IPv4Address srcIp = ip.getSourceAddress();
 			IPv4Address dstIp = ip.getDestinationAddress();
@@ -320,7 +320,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule {
 				.setExact(MatchField.UDP_SRC, udp.getSourcePort())
 				.setExact(MatchField.UDP_DST, udp.getDestinationPort());
 			}	
-		} else if (eth.getEtherType() == Ethernet.TYPE_ARP) {
+		} else if (eth.getEtherType() == EthType.ARP) { /* shallow check for equality is okay for EthType */
 			mb.setExact(MatchField.ETH_TYPE, EthType.ARP);
 		}
 		return mb.build();

--- a/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
+++ b/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
@@ -129,23 +129,8 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule {
 					"drop flow mod to a switch",
 					recommendation=LogMessageDoc.CHECK_SWITCH)
 	protected void doDropFlow(IOFSwitch sw, OFPacketIn pi, IRoutingDecision decision, FloodlightContext cntx) {
-		// initialize match structure and populate it based on the packet in's match
-		Match.Builder mb = null;
-		if (decision.getMatch() != null) {
-			/* This routing decision should be a match object with all appropriate fields set,
-			 * not just masked. If it's a decision that matches the packet we received, then simply setting
-			 * the masks to the new match will create the same match in the end. We can just use the routing
-			 * match object instead.
-			 * 
-			 * The Firewall is currently the only module/service that sets routing decisions in the context 
-			 * store (or instantiates any for that matter). It's disabled by default, so as-is a decision's 
-			 * match should always be null, meaning this will never be true.
-			 */
-			mb = decision.getMatch().createBuilder();
-		} else {
-			mb = pi.getMatch().createBuilder(); // otherwise no route is known so go based on packet's match object
-		}
-
+		OFPort inPort = (pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT));
+		Match m = createMatchFromPacket(sw, inPort, cntx);
 		OFFlowMod.Builder fmb = sw.getOFFactory().buildFlowAdd(); // this will be a drop-flow; a flow that will not output to any ports
 		List<OFAction> actions = new ArrayList<OFAction>(); // set no action to drop
 		U64 cookie = AppCookie.makeCookie(FORWARDING_APP_ID, 0);
@@ -154,14 +139,14 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule {
 		.setHardTimeout(FLOWMOD_DEFAULT_HARD_TIMEOUT)
 		.setIdleTimeout(FLOWMOD_DEFAULT_IDLE_TIMEOUT)
 		.setBufferId(OFBufferId.NO_BUFFER)
-		.setMatch(mb.build())
+		.setMatch(m)
 		.setActions(actions) // empty list
 		.setPriority(FLOWMOD_DEFAULT_PRIORITY);
 
 		try {
 			if (log.isDebugEnabled()) {
 				log.debug("write drop flow-mod sw={} match={} flow-mod={}",
-						new Object[] { sw, mb.build(), fmb.build() });
+						new Object[] { sw, m, fmb.build() });
 			}
 			boolean dampened = messageDamper.write(sw, fmb.build());
 			log.debug("OFMessage dampened: {}", dampened);
@@ -259,53 +244,12 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule {
 										dstDap.getSwitchDPID(),
 										dstDap.getPort()});
 							}
+
 							U64 cookie = AppCookie.makeCookie(FORWARDING_APP_ID, 0);
 
-							// The packet in match will only contain the port number.
-							// We need to add in specifics for the hosts we're routing between.
-							Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
-							VlanVid vlan = VlanVid.ofVlan(eth.getVlanID());
-							MacAddress srcMac = eth.getSourceMACAddress();
-							MacAddress dstMac = eth.getDestinationMACAddress();
+							Match m = createMatchFromPacket(sw, inPort, cntx);
 
-							// A retentive builder will remember all MatchFields of the parent the builder was generated from
-							// With a normal builder, all parent MatchFields will be lost if any MatchFields are added, mod, del
-							// TODO (This is a bug in Loxigen and the retentive builder is a workaround.)
-							Match.Builder mb = sw.getOFFactory().buildMatch();
-							mb.setExact(MatchField.IN_PORT, inPort)
-							.setExact(MatchField.ETH_SRC, srcMac)
-							.setExact(MatchField.ETH_DST, dstMac);
-
-							if (!vlan.equals(VlanVid.ZERO)) {
-								mb.setExact(MatchField.VLAN_VID, OFVlanVidMatch.ofVlanVid(vlan));
-							}
-
-							// TODO Detect switch type and match to create hardware-implemented flow
-							// TODO Set option in config file to support specific or MAC-only matches
-							if (eth.getEtherType() == Ethernet.TYPE_IPv4) {
-								IPv4 ip = (IPv4) eth.getPayload();
-								IPv4Address srcIp = ip.getSourceAddress();
-								IPv4Address dstIp = ip.getDestinationAddress();
-								mb.setExact(MatchField.IPV4_SRC, srcIp)
-								.setExact(MatchField.IPV4_DST, dstIp)
-								.setExact(MatchField.ETH_TYPE, EthType.IPv4);
-
-								if (ip.getProtocol().equals(IpProtocol.TCP)) {
-									TCP tcp = (TCP) ip.getPayload();
-									mb.setExact(MatchField.IP_PROTO, IpProtocol.TCP)
-									.setExact(MatchField.TCP_SRC, tcp.getSourcePort())
-									.setExact(MatchField.TCP_DST, tcp.getDestinationPort());
-								} else if (ip.getProtocol().equals(IpProtocol.UDP)) {
-									UDP udp = (UDP) ip.getPayload();
-									mb.setExact(MatchField.IP_PROTO, IpProtocol.UDP)
-									.setExact(MatchField.UDP_SRC, udp.getSourcePort())
-									.setExact(MatchField.UDP_DST, udp.getDestinationPort());
-								}	
-							} else if (eth.getEtherType() == Ethernet.TYPE_ARP) {
-								mb.setExact(MatchField.ETH_TYPE, EthType.ARP);
-							}
-
-							pushRoute(route, mb.build(), pi, sw.getId(), cookie,
+							pushRoute(route, m, pi, sw.getId(), cookie,
 									cntx, requestFlowRemovedNotifn, false,
 									OFFlowModCommand.ADD);
 						}
@@ -324,6 +268,64 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule {
 		}
 	}
 
+	/**
+	 * Instead of using the Firewall's routing decision Match, which might be as general
+	 * as "in_port" and inadvertently Match packets erroneously, construct a more
+	 * specific Match based on the deserialized OFPacketIn's payload, which has been 
+	 * placed in the FloodlightContext already by the Controller.
+	 * 
+	 * @param sw, the switch on which the packet was received
+	 * @param inPort, the ingress switch port on which the packet was received
+	 * @param cntx, the current context which contains the deserialized packet
+	 * @return a composed Match object based on the provided information
+	 */
+	protected Match createMatchFromPacket(IOFSwitch sw, OFPort inPort, FloodlightContext cntx) {
+		// The packet in match will only contain the port number.
+		// We need to add in specifics for the hosts we're routing between.
+		Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
+		VlanVid vlan = VlanVid.ofVlan(eth.getVlanID());
+		MacAddress srcMac = eth.getSourceMACAddress();
+		MacAddress dstMac = eth.getDestinationMACAddress();
+
+		// A retentive builder will remember all MatchFields of the parent the builder was generated from
+		// With a normal builder, all parent MatchFields will be lost if any MatchFields are added, mod, del
+		// TODO (This is a bug in Loxigen and the retentive builder is a workaround.)
+		Match.Builder mb = sw.getOFFactory().buildMatch();
+		mb.setExact(MatchField.IN_PORT, inPort)
+		.setExact(MatchField.ETH_SRC, srcMac)
+		.setExact(MatchField.ETH_DST, dstMac);
+
+		if (!vlan.equals(VlanVid.ZERO)) {
+			mb.setExact(MatchField.VLAN_VID, OFVlanVidMatch.ofVlanVid(vlan));
+		}
+
+		// TODO Detect switch type and match to create hardware-implemented flow
+		// TODO Set option in config file to support specific or MAC-only matches
+		if (eth.getEtherType() == Ethernet.TYPE_IPv4) {
+			IPv4 ip = (IPv4) eth.getPayload();
+			IPv4Address srcIp = ip.getSourceAddress();
+			IPv4Address dstIp = ip.getDestinationAddress();
+			mb.setExact(MatchField.IPV4_SRC, srcIp)
+			.setExact(MatchField.IPV4_DST, dstIp)
+			.setExact(MatchField.ETH_TYPE, EthType.IPv4);
+
+			if (ip.getProtocol().equals(IpProtocol.TCP)) {
+				TCP tcp = (TCP) ip.getPayload();
+				mb.setExact(MatchField.IP_PROTO, IpProtocol.TCP)
+				.setExact(MatchField.TCP_SRC, tcp.getSourcePort())
+				.setExact(MatchField.TCP_DST, tcp.getDestinationPort());
+			} else if (ip.getProtocol().equals(IpProtocol.UDP)) {
+				UDP udp = (UDP) ip.getPayload();
+				mb.setExact(MatchField.IP_PROTO, IpProtocol.UDP)
+				.setExact(MatchField.UDP_SRC, udp.getSourcePort())
+				.setExact(MatchField.UDP_DST, udp.getDestinationPort());
+			}	
+		} else if (eth.getEtherType() == Ethernet.TYPE_ARP) {
+			mb.setExact(MatchField.ETH_TYPE, EthType.ARP);
+		}
+		return mb.build();
+	}
+	
 	/**
 	 * Creates a OFPacketOut with the OFPacketIn data that is flooded on all ports unless
 	 * the port is blocked, in which case the packet will be dropped.

--- a/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
@@ -99,6 +99,7 @@ import org.projectfloodlight.openflow.protocol.OFPortDesc;
 import org.projectfloodlight.openflow.protocol.OFPortState;
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.MacAddress;
 import org.projectfloodlight.openflow.types.OFBufferId;
 import org.projectfloodlight.openflow.types.OFPort;
@@ -370,7 +371,7 @@ IFloodlightModule, IInfoProvider {
 		if (isStandard) {
 			ethernet = new Ethernet().setSourceMACAddress(ofpPort.getHwAddr())
 					.setDestinationMACAddress(LLDP_STANDARD_DST_MAC_STRING)
-					.setEtherType(Ethernet.TYPE_LLDP);
+					.setEtherType(EthType.LLDP);
 			ethernet.setPayload(lldp);
 		} else {
 			BSN bsn = new BSN(BSN.BSN_TYPE_BDDP);
@@ -378,7 +379,7 @@ IFloodlightModule, IInfoProvider {
 
 			ethernet = new Ethernet().setSourceMACAddress(ofpPort.getHwAddr())
 					.setDestinationMACAddress(LLDP_BSN_DST_MAC_STRING)
-					.setEtherType(Ethernet.TYPE_BSN);
+					.setEtherType(EthType.of(Ethernet.TYPE_BSN & 0xffff)); /* treat as unsigned */
 			ethernet.setPayload(bsn);
 		}
 
@@ -582,7 +583,7 @@ IFloodlightModule, IInfoProvider {
 			return handleLldp((LLDP) bsn.getPayload(), sw, inPort, false, cntx);
 		} else if (eth.getPayload() instanceof LLDP) {
 			return handleLldp((LLDP) eth.getPayload(), sw, inPort, true, cntx);
-		} else if (eth.getEtherType() < 1536 /*&& eth.getEtherType() >= 17*/) {
+		} else if (eth.getEtherType().getValue() < 1536 && eth.getEtherType().getValue() >= 17) {
 	        long destMac = eth.getDestinationMACAddress().getLong();
 	        if ((destMac & LINK_LOCAL_MASK) == LINK_LOCAL_VALUE) {
 	            ctrLinkLocalDrops.increment();
@@ -592,10 +593,10 @@ IFloodlightModule, IInfoProvider {
 	            }
 	            return Command.STOP;
 	        }
-	    } /*else if (eth.getEtherType() < 17) {
+	    } else if (eth.getEtherType().getValue() < 17) {
 	        log.error("Received invalid ethertype of {}.", eth.getEtherType());
 	        return Command.STOP;
-	    }*/
+	    }
 
 		if (ignorePacketInFromSource(eth.getSourceMACAddress())) {
 			ctrIgnoreSrcMacDrops.increment();

--- a/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
@@ -582,7 +582,7 @@ IFloodlightModule, IInfoProvider {
 			return handleLldp((LLDP) bsn.getPayload(), sw, inPort, false, cntx);
 		} else if (eth.getPayload() instanceof LLDP) {
 			return handleLldp((LLDP) eth.getPayload(), sw, inPort, true, cntx);
-		} else if (eth.getEtherType() < 1536 && eth.getEtherType() >= 17) {
+		} else if (eth.getEtherType() < 1536 /*&& eth.getEtherType() >= 17*/) {
 	        long destMac = eth.getDestinationMACAddress().getLong();
 	        if ((destMac & LINK_LOCAL_MASK) == LINK_LOCAL_VALUE) {
 	            ctrLinkLocalDrops.increment();
@@ -592,10 +592,10 @@ IFloodlightModule, IInfoProvider {
 	            }
 	            return Command.STOP;
 	        }
-	    } else if (eth.getEtherType() < 17) {
+	    } /*else if (eth.getEtherType() < 17) {
 	        log.error("Received invalid ethertype of {}.", eth.getEtherType());
 	        return Command.STOP;
-	    }
+	    }*/
 
 		if (ignorePacketInFromSource(eth.getSourceMACAddress())) {
 			ctrIgnoreSrcMacDrops.increment();

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
@@ -271,7 +271,7 @@ public class LoadBalancer implements IFloodlightModule,
         IPacket arpReply = new Ethernet()
             .setSourceMACAddress(vipProxyMacBytes)
             .setDestinationMACAddress(eth.getSourceMACAddress())
-            .setEtherType(Ethernet.TYPE_ARP)
+            .setEtherType(EthType.ARP)
             .setVlanID(eth.getVlanID())
             .setPriorityCode(eth.getPriorityCode())
             .setPayload(
@@ -523,9 +523,12 @@ public class LoadBalancer implements IFloodlightModule,
                 	   mb.setExact(MatchField.UDP_SRC, client.srcPort);
                    } else if (client.nw_proto.equals(IpProtocol.SCTP)) {
                 	   mb.setExact(MatchField.SCTP_SRC, client.srcPort);
+                   } else if (client.nw_proto.equals(IpProtocol.ICMP)) {
+                	   /* no-op */
                    } else {
                 	   log.error("Unknown IpProtocol {} detected during inbound static VIP route push.", client.nw_proto);
                    }
+                   
 
                    if (sw.equals(pinSwitch.getId())) {
                        if (pinSwitch.getOFFactory().getVersion().compareTo(OFVersion.OF_12) < 0) { 
@@ -553,6 +556,8 @@ public class LoadBalancer implements IFloodlightModule,
                 	   mb.setExact(MatchField.UDP_DST, client.srcPort);
                    } else if (client.nw_proto.equals(IpProtocol.SCTP)) {
                 	   mb.setExact(MatchField.SCTP_DST, client.srcPort);
+                   } else if (client.nw_proto.equals(IpProtocol.ICMP)) {
+                	   /* no-op */
                    } else {
                 	   log.error("Unknown IpProtocol {} detected during outbound static VIP route push.", client.nw_proto);
                    }

--- a/src/main/java/net/floodlightcontroller/packet/BSN.java
+++ b/src/main/java/net/floodlightcontroller/packet/BSN.java
@@ -23,6 +23,8 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.projectfloodlight.openflow.types.EthType;
+
 /**
  * @author Shudong Zhou (shudong.zhou@bigswitch.com)
  *
@@ -90,7 +92,7 @@ public class BSN extends BasePacket {
             bb.put(payloadData);
 
         if (this.parent != null && this.parent instanceof Ethernet)
-            ((Ethernet)this.parent).setEtherType(Ethernet.TYPE_BSN);
+            ((Ethernet)this.parent).setEtherType(EthType.of(Ethernet.TYPE_BSN & 0xffff)); /* treat as unsigned */
 
         return data;
     }

--- a/src/main/java/net/floodlightcontroller/packet/DHCP.java
+++ b/src/main/java/net/floodlightcontroller/packet/DHCP.java
@@ -23,6 +23,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 
+import org.projectfloodlight.openflow.types.IPv4Address;
+import org.projectfloodlight.openflow.types.MacAddress;
+
 /**
  *
  * @author David Erickson (daviderickson@cs.stanford.edu)
@@ -92,11 +95,11 @@ public class DHCP extends BasePacket {
     protected int transactionId;
     protected short seconds;
     protected short flags;
-    protected int clientIPAddress;
-    protected int yourIPAddress;
-    protected int serverIPAddress;
-    protected int gatewayIPAddress;
-    protected byte[] clientHardwareAddress;
+    protected IPv4Address clientIPAddress;
+    protected IPv4Address yourIPAddress;
+    protected IPv4Address serverIPAddress;
+    protected IPv4Address gatewayIPAddress;
+    protected MacAddress clientHardwareAddress;
     protected String serverName;
     protected String bootFileName;
     protected List<DHCPOption> options = new ArrayList<DHCPOption>();
@@ -209,14 +212,14 @@ public class DHCP extends BasePacket {
     /**
      * @return the clientIPAddress
      */
-    public int getClientIPAddress() {
+    public IPv4Address getClientIPAddress() {
         return clientIPAddress;
     }
 
     /**
      * @param clientIPAddress the clientIPAddress to set
      */
-    public DHCP setClientIPAddress(int clientIPAddress) {
+    public DHCP setClientIPAddress(IPv4Address clientIPAddress) {
         this.clientIPAddress = clientIPAddress;
         return this;
     }
@@ -224,14 +227,14 @@ public class DHCP extends BasePacket {
     /**
      * @return the yourIPAddress
      */
-    public int getYourIPAddress() {
+    public IPv4Address getYourIPAddress() {
         return yourIPAddress;
     }
 
     /**
      * @param yourIPAddress the yourIPAddress to set
      */
-    public DHCP setYourIPAddress(int yourIPAddress) {
+    public DHCP setYourIPAddress(IPv4Address yourIPAddress) {
         this.yourIPAddress = yourIPAddress;
         return this;
     }
@@ -239,14 +242,14 @@ public class DHCP extends BasePacket {
     /**
      * @return the serverIPAddress
      */
-    public int getServerIPAddress() {
+    public IPv4Address getServerIPAddress() {
         return serverIPAddress;
     }
 
     /**
      * @param serverIPAddress the serverIPAddress to set
      */
-    public DHCP setServerIPAddress(int serverIPAddress) {
+    public DHCP setServerIPAddress(IPv4Address serverIPAddress) {
         this.serverIPAddress = serverIPAddress;
         return this;
     }
@@ -254,14 +257,14 @@ public class DHCP extends BasePacket {
     /**
      * @return the gatewayIPAddress
      */
-    public int getGatewayIPAddress() {
+    public IPv4Address getGatewayIPAddress() {
         return gatewayIPAddress;
     }
 
     /**
      * @param gatewayIPAddress the gatewayIPAddress to set
      */
-    public DHCP setGatewayIPAddress(int gatewayIPAddress) {
+    public DHCP setGatewayIPAddress(IPv4Address gatewayIPAddress) {
         this.gatewayIPAddress = gatewayIPAddress;
         return this;
     }
@@ -269,14 +272,14 @@ public class DHCP extends BasePacket {
     /**
      * @return the clientHardwareAddress
      */
-    public byte[] getClientHardwareAddress() {
+    public MacAddress getClientHardwareAddress() {
         return clientHardwareAddress;
     }
 
     /**
      * @param clientHardwareAddress the clientHardwareAddress to set
      */
-    public DHCP setClientHardwareAddress(byte[] clientHardwareAddress) {
+    public DHCP setClientHardwareAddress(MacAddress clientHardwareAddress) {
         this.clientHardwareAddress = clientHardwareAddress;
         return this;
     }
@@ -381,13 +384,13 @@ public class DHCP extends BasePacket {
         bb.putInt(this.transactionId);
         bb.putShort(this.seconds);
         bb.putShort(this.flags);
-        bb.putInt(this.clientIPAddress);
-        bb.putInt(this.yourIPAddress);
-        bb.putInt(this.serverIPAddress);
-        bb.putInt(this.gatewayIPAddress);
-        bb.put(this.clientHardwareAddress);
-        if (this.clientHardwareAddress.length < 16) {
-            for (int i = 0; i < (16 - this.clientHardwareAddress.length); ++i) {
+        bb.putInt(this.clientIPAddress.getInt());
+        bb.putInt(this.yourIPAddress.getInt());
+        bb.putInt(this.serverIPAddress.getInt());
+        bb.putInt(this.gatewayIPAddress.getInt());
+        bb.put(this.clientHardwareAddress.getBytes());
+        if (this.clientHardwareAddress.getLength() < 16) {
+            for (int i = 0; i < (16 - this.clientHardwareAddress.getLength()); ++i) {
                 bb.put((byte) 0x0);
             }
         }
@@ -447,14 +450,14 @@ public class DHCP extends BasePacket {
         this.transactionId = bb.getInt();
         this.seconds = bb.getShort();
         this.flags = bb.getShort();
-        this.clientIPAddress = bb.getInt();
-        this.yourIPAddress = bb.getInt();
-        this.serverIPAddress = bb.getInt();
-        this.gatewayIPAddress = bb.getInt();
+        this.clientIPAddress = IPv4Address.of(bb.getInt());
+        this.yourIPAddress = IPv4Address.of(bb.getInt());
+        this.serverIPAddress = IPv4Address.of(bb.getInt());
+        this.gatewayIPAddress = IPv4Address.of(bb.getInt());
         int hardwareAddressLength = 0xff & this.hardwareAddressLength;
-        this.clientHardwareAddress = new byte[hardwareAddressLength];
-
-        bb.get(this.clientHardwareAddress);
+        byte[] tmpMac = new byte[hardwareAddressLength];
+        bb.get(tmpMac);
+        this.clientHardwareAddress = MacAddress.of(tmpMac); /* the assumption here is that we only have MAC address HW addresses */
         for (int i = hardwareAddressLength; i < 16; ++i)
             bb.get();
         this.serverName = readString(bb, 64);

--- a/src/main/java/net/floodlightcontroller/packet/Ethernet.java
+++ b/src/main/java/net/floodlightcontroller/packet/Ethernet.java
@@ -233,7 +233,7 @@ public class Ethernet extends BasePacket {
 
     @Override
     public IPacket deserialize(byte[] data, int offset, int length) {
-        if (length <= 16)  // Ethernet packet minium should be 60, this is reasonable
+        if (length <= 16)  // Ethernet packet minimum should be 60, this is reasonable
             return null;
         ByteBuffer bb = ByteBuffer.wrap(data, offset, length);
         if (this.destinationMACAddress == null)
@@ -260,7 +260,7 @@ public class Ethernet extends BasePacket {
          * loxigen.
          */
         EthType etherType = EthType.of(bb.getShort() & 0xffff);
-        if (etherType.equals(EthType.VLAN_FRAME)) { /* In loxigen, EthType will give the same objects for a given ethertype --> shallow compare. */
+        if (etherType == EthType.VLAN_FRAME) { /* In loxigen, EthType will give the same objects for a given ethertype --> shallow compare. */
             short tci = bb.getShort();
             this.priorityCode = (byte) ((tci >> 13) & 0x07);
             this.vlanID = (short) (tci & 0x0fff);

--- a/src/main/java/net/floodlightcontroller/packet/Ethernet.java
+++ b/src/main/java/net/floodlightcontroller/packet/Ethernet.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.MacAddress;
 import org.projectfloodlight.openflow.types.VlanVid;
 
@@ -53,7 +54,7 @@ public class Ethernet extends BasePacket {
     protected MacAddress sourceMACAddress;
     protected byte priorityCode;
     protected short vlanID;
-    protected short etherType;
+    protected EthType etherType;
     protected boolean pad = false;
 
     /**
@@ -159,14 +160,14 @@ public class Ethernet extends BasePacket {
     /**
      * @return the etherType
      */
-    public short getEtherType() {
+    public EthType getEtherType() {
         return etherType;
     }
 
     /**
      * @param etherType the etherType to set
      */
-    public Ethernet setEtherType(short etherType) {
+    public Ethernet setEtherType(EthType etherType) {
         this.etherType = etherType;
         return this;
     }
@@ -218,10 +219,10 @@ public class Ethernet extends BasePacket {
         bb.put(destinationMACAddress.getBytes());
         bb.put(sourceMACAddress.getBytes());
         if (vlanID != VLAN_UNTAGGED) {
-            bb.putShort((short) 0x8100);
+            bb.putShort((short) EthType.VLAN_FRAME.getValue());
             bb.putShort((short) ((priorityCode << 13) | (vlanID & 0x0fff)));
         }
-        bb.putShort(etherType);
+        bb.putShort((short) etherType.getValue());
         if (payloadData != null)
             bb.put(payloadData);
         if (pad) {
@@ -247,23 +248,34 @@ public class Ethernet extends BasePacket {
         bb.get(srcAddr);
         this.sourceMACAddress = MacAddress.of(srcAddr);
 
-        short etherType = bb.getShort();
-        if (etherType == (short) 0x8100) {
+        /* 
+         * The ethertype is represented as 2 bytes in the packet header;
+         * however, EthType can only parse an int. Negative shorts (1 in 
+         * the most sig place b/c 2's complement) are still valid ethertypes,
+         * but it doesn't appear this way unless we treat the sign bit as
+         * part of an unsigned number. If we natively cast the short to an
+         * integer, it will sign extend into the extra bytes when in fact
+         * it should still be a positive number. We can bitmask to force the
+         * upper bytes to remain 0's. TODO this should be incorporated into
+         * loxigen.
+         */
+        EthType etherType = EthType.of(bb.getShort() & 0xffff);
+        if (etherType.equals(EthType.VLAN_FRAME)) { /* In loxigen, EthType will give the same objects for a given ethertype --> shallow compare. */
             short tci = bb.getShort();
             this.priorityCode = (byte) ((tci >> 13) & 0x07);
             this.vlanID = (short) (tci & 0x0fff);
-            etherType = bb.getShort();
+            etherType = EthType.of(bb.getShort() & 0xffff);
         } else {
             this.vlanID = VLAN_UNTAGGED;
         }
         this.etherType = etherType;
         
         IPacket payload;
-        if (Ethernet.etherTypeClassMap.containsKey(this.etherType)) {
-            Class<? extends IPacket> clazz = Ethernet.etherTypeClassMap.get(this.etherType);
+        if (Ethernet.etherTypeClassMap.containsKey((short) this.etherType.getValue())) {
+            Class<? extends IPacket> clazz = Ethernet.etherTypeClassMap.get((short) this.etherType.getValue());
             try {
                 payload = clazz.newInstance();
-                this.payload = payload.deserialize(data, bb.position(), bb.limit()-bb.position());
+                this.payload = payload.deserialize(data, bb.position(), bb.limit() - bb.position());
             } catch (PacketParsingException e) {
                 if (log.isTraceEnabled()) {
                     log.trace("Failed to parse ethernet packet {}->{}" +
@@ -347,48 +359,57 @@ public class Ethernet extends BasePacket {
         return MacAddress.of(macAddress).getBytes();
     }
     
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
-    public int hashCode() {
-        final int prime = 7867;
-        int result = super.hashCode();
-        result = prime * result + destinationMACAddress.hashCode();
-        result = prime * result + etherType;
-        result = prime * result + vlanID;
-        result = prime * result + priorityCode;
-        result = prime * result + (pad ? 1231 : 1237);
-        result = prime * result + sourceMACAddress.hashCode();
-        return result;
-    }
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime
+				* result
+				+ ((destinationMACAddress == null) ? 0 : destinationMACAddress
+						.hashCode());
+		result = prime * result
+				+ ((etherType == null) ? 0 : etherType.hashCode());
+		result = prime * result + (pad ? 1231 : 1237);
+		result = prime * result + priorityCode;
+		result = prime
+				* result
+				+ ((sourceMACAddress == null) ? 0 : sourceMACAddress.hashCode());
+		result = prime * result + vlanID;
+		return result;
+	}
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (!(obj instanceof Ethernet))
-            return false;
-        Ethernet other = (Ethernet) obj;
-        if (!destinationMACAddress.equals(other.destinationMACAddress))
-            return false;
-        if (priorityCode != other.priorityCode)
-            return false;
-        if (vlanID != other.vlanID)
-            return false;
-        if (etherType != other.etherType)
-            return false;
-        if (pad != other.pad)
-            return false;
-        if (!sourceMACAddress.equals(other.sourceMACAddress))
-            return false;
-        return true;
-    }
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Ethernet other = (Ethernet) obj;
+		if (destinationMACAddress == null) {
+			if (other.destinationMACAddress != null)
+				return false;
+		} else if (!destinationMACAddress.equals(other.destinationMACAddress))
+			return false;
+		if (etherType == null) {
+			if (other.etherType != null)
+				return false;
+		} else if (!etherType.equals(other.etherType))
+			return false;
+		if (pad != other.pad)
+			return false;
+		if (priorityCode != other.priorityCode)
+			return false;
+		if (sourceMACAddress == null) {
+			if (other.sourceMACAddress != null)
+				return false;
+		} else if (!sourceMACAddress.equals(other.sourceMACAddress))
+			return false;
+		if (vlanID != other.vlanID)
+			return false;
+		return true;
+	}
     
     /* (non-Javadoc)
      * @see java.lang.Object#toString(java.lang.Object)
@@ -410,7 +431,7 @@ public class Ethernet extends BasePacket {
             sb.append("ip");
         else if (pkt instanceof DHCP)
             sb.append("dhcp");
-        else  sb.append(this.getEtherType());
+        else  sb.append(this.getEtherType().toString());
 
         sb.append("\ndl_vlan: ");
         if (this.getVlanID() == Ethernet.VLAN_UNTAGGED)

--- a/src/main/java/net/floodlightcontroller/packet/LLDP.java
+++ b/src/main/java/net/floodlightcontroller/packet/LLDP.java
@@ -24,6 +24,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.projectfloodlight.openflow.types.EthType;
+
 /**
  * @author David Erickson (daviderickson@cs.stanford.edu)
  *
@@ -33,11 +35,11 @@ public class LLDP extends BasePacket {
     protected LLDPTLV portId;
     protected LLDPTLV ttl;
     protected List<LLDPTLV> optionalTLVList;
-    protected short ethType;
+    protected EthType ethType;
 
     public LLDP() {
         this.optionalTLVList = new ArrayList<LLDPTLV>();
-        this.ethType = Ethernet.TYPE_LLDP;
+        this.ethType = EthType.LLDP;
     }
 
     /**
@@ -209,7 +211,7 @@ public class LLDP extends BasePacket {
         str += "chassisId=" + ((this.chassisId == null) ? "null" : this.chassisId.toString());
         str += " portId=" + ((this.portId == null) ? "null" : this.portId.toString());
         str += " ttl=" + ((this.ttl == null) ? "null" : this.ttl.toString());
-        str += " etherType=" + Integer.toString(this.ethType, 16).toUpperCase();
+        str += " etherType=" + ethType.toString();
         str += " optionalTlvList=[";
         if (this.optionalTLVList != null) {
             for (LLDPTLV l : optionalTLVList) str += l.toString() + ", ";

--- a/src/main/resources/META-INF/services/net.floodlightcontroller.core.module.IFloodlightModule
+++ b/src/main/resources/META-INF/services/net.floodlightcontroller.core.module.IFloodlightModule
@@ -24,3 +24,4 @@ net.floodlightcontroller.loadbalancer.LoadBalancer
 net.floodlightcontroller.linkdiscovery.internal.LinkDiscoveryManager
 net.floodlightcontroller.devicemanager.internal.DeviceManagerImpl
 net.floodlightcontroller.firewall.Firewall
+net.floodlightcontroller.dhcpserver.DHCPServer

--- a/src/test/java/net/floodlightcontroller/core/internal/ControllerTest.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/ControllerTest.java
@@ -62,8 +62,8 @@ import net.floodlightcontroller.core.IShutdownListener;
 import net.floodlightcontroller.core.IShutdownService;
 import net.floodlightcontroller.core.internal.IOFSwitchService;
 import net.floodlightcontroller.core.test.MockSwitchManager;
-
 import net.floodlightcontroller.core.IOFSwitchBackend;
+
 import org.projectfloodlight.openflow.protocol.OFControllerRole;
 import org.projectfloodlight.openflow.protocol.OFFactories;
 import org.projectfloodlight.openflow.protocol.OFFeaturesReply;
@@ -73,6 +73,7 @@ import org.projectfloodlight.openflow.protocol.OFPacketIn;
 import org.projectfloodlight.openflow.protocol.OFPacketInReason;
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.OFBufferId;
 import org.projectfloodlight.openflow.types.OFPort;
 import org.projectfloodlight.openflow.protocol.OFPortDesc;
@@ -171,7 +172,7 @@ public class ControllerTest extends FloodlightTestCase {
         testPacket = new Ethernet()
         .setSourceMACAddress("00:44:33:22:11:00")
         .setDestinationMACAddress("00:11:22:33:44:55")
-        .setEtherType(Ethernet.TYPE_ARP)
+        .setEtherType(EthType.ARP)
         .setPayload(
                 new ARP()
                 .setHardwareType(ARP.HW_TYPE_ETHERNET)

--- a/src/test/java/net/floodlightcontroller/core/test/PacketFactory.java
+++ b/src/test/java/net/floodlightcontroller/core/test/PacketFactory.java
@@ -26,6 +26,7 @@ import org.projectfloodlight.openflow.protocol.OFPacketIn;
 import org.projectfloodlight.openflow.protocol.OFPacketInReason;
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
+import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.IpProtocol;
 import org.projectfloodlight.openflow.types.MacAddress;
 import org.projectfloodlight.openflow.types.OFPort;
@@ -135,7 +136,7 @@ public class PacketFactory {
         Ethernet requestPacket = new Ethernet();
         requestPacket.setSourceMACAddress(hostMac.getBytes())
         .setDestinationMACAddress(broadcastMac)
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
                 new IPv4()
                 .setVersion((byte)4)

--- a/src/test/java/net/floodlightcontroller/core/test/PacketFactory.java
+++ b/src/test/java/net/floodlightcontroller/core/test/PacketFactory.java
@@ -27,6 +27,7 @@ import org.projectfloodlight.openflow.protocol.OFPacketInReason;
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.types.EthType;
+import org.projectfloodlight.openflow.types.IPv4Address;
 import org.projectfloodlight.openflow.types.IpProtocol;
 import org.projectfloodlight.openflow.types.MacAddress;
 import org.projectfloodlight.openflow.types.OFPort;
@@ -163,11 +164,11 @@ public class PacketFactory {
                                 .setTransactionId(0x00003d1d)
                                 .setSeconds((short)0)
                                 .setFlags((short)0)
-                                .setClientIPAddress(0)
-                                .setYourIPAddress(0)
-                                .setServerIPAddress(0)
-                                .setGatewayIPAddress(0)
-                                .setClientHardwareAddress(hostMac.getBytes())
+                                .setClientIPAddress(IPv4Address.NONE)
+                                .setYourIPAddress(IPv4Address.NONE)
+                                .setServerIPAddress(IPv4Address.NONE)
+                                .setGatewayIPAddress(IPv4Address.NONE)
+                                .setClientHardwareAddress(hostMac)
                                 .setOptions(optionList))));
 
         return requestPacket;

--- a/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImplTest.java
+++ b/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImplTest.java
@@ -97,6 +97,7 @@ import org.projectfloodlight.openflow.protocol.OFPacketInReason;import org.proje
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.IPv4Address;
 import org.projectfloodlight.openflow.types.MacAddress;
 import org.projectfloodlight.openflow.types.OFBufferId;
@@ -233,7 +234,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		this.testARPReplyPacket_1 = new Ethernet()
 		.setSourceMACAddress("00:44:33:22:11:01")
 		.setDestinationMACAddress("00:11:22:33:44:55")
-		.setEtherType(Ethernet.TYPE_ARP)
+		.setEtherType(EthType.ARP)
 		.setVlanID((short)5)
 		.setPayload(
 				new ARP()
@@ -253,7 +254,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		this.testARPReplyPacket_2 = new Ethernet()
 		.setSourceMACAddress("00:99:88:77:66:55")
 		.setDestinationMACAddress("00:11:22:33:44:55")
-		.setEtherType(Ethernet.TYPE_ARP)
+		.setEtherType(EthType.ARP)
 		.setVlanID((short)5)
 		.setPayload(
 				new ARP()
@@ -272,7 +273,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		this.testUDPPacket = (Ethernet) new Ethernet()
 		.setSourceMACAddress("00:11:22:33:44:55")
 		.setDestinationMACAddress("00:44:33:22:11:01")
-		.setEtherType(Ethernet.TYPE_IPv4)
+		.setEtherType(EthType.IPv4)
 		.setVlanID((short)5)
 		.setPayload(
 				new IPv4()

--- a/src/test/java/net/floodlightcontroller/firewall/FirewallTest.java
+++ b/src/test/java/net/floodlightcontroller/firewall/FirewallTest.java
@@ -127,7 +127,7 @@ public class FirewallTest extends FloodlightTestCase {
         .setDestinationMACAddress("00:11:22:33:44:55")
         .setSourceMACAddress("00:44:33:22:11:00")
         .setVlanID((short) 42)
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)
@@ -143,7 +143,7 @@ public class FirewallTest extends FloodlightTestCase {
         .setDestinationMACAddress("FF:FF:FF:FF:FF:FF")
         .setSourceMACAddress("00:44:33:22:11:00")
         .setVlanID((short) 42)
-        .setEtherType(Ethernet.TYPE_ARP)
+        .setEtherType(EthType.ARP)
         .setPayload(
                 new ARP()
                 .setHardwareType(ARP.HW_TYPE_ETHERNET)
@@ -162,7 +162,7 @@ public class FirewallTest extends FloodlightTestCase {
         .setDestinationMACAddress("00:44:33:22:11:00")
         .setSourceMACAddress("00:11:22:33:44:55")
         .setVlanID((short) 42)
-        .setEtherType(Ethernet.TYPE_ARP)
+        .setEtherType(EthType.ARP)
         .setPayload(
                 new ARP()
                 .setHardwareType(ARP.HW_TYPE_ETHERNET)
@@ -181,7 +181,7 @@ public class FirewallTest extends FloodlightTestCase {
         .setDestinationMACAddress("FF:FF:FF:FF:FF:FF")
         .setSourceMACAddress("00:44:33:22:11:00")
         .setVlanID((short) 42)
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)
@@ -197,7 +197,7 @@ public class FirewallTest extends FloodlightTestCase {
         .setDestinationMACAddress("FF:FF:FF:FF:FF:FF")
         .setSourceMACAddress("00:44:33:22:11:00")
         .setVlanID((short) 42)
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)
@@ -212,7 +212,7 @@ public class FirewallTest extends FloodlightTestCase {
         .setDestinationMACAddress("00:44:33:22:11:00")
         .setSourceMACAddress("00:11:22:33:44:55")
         .setVlanID((short) 42)
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)

--- a/src/test/java/net/floodlightcontroller/forwarding/ForwardingTest.java
+++ b/src/test/java/net/floodlightcontroller/forwarding/ForwardingTest.java
@@ -198,7 +198,7 @@ public class ForwardingTest extends FloodlightTestCase {
         testPacket = new Ethernet()
             .setDestinationMACAddress("00:11:22:33:44:55")
             .setSourceMACAddress("00:44:33:22:11:00")
-            .setEtherType(Ethernet.TYPE_IPv4)
+            .setEtherType(EthType.IPv4)
             .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)

--- a/src/test/java/net/floodlightcontroller/hub/HubTest.java
+++ b/src/test/java/net/floodlightcontroller/hub/HubTest.java
@@ -52,6 +52,7 @@ import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.protocol.action.OFAction;
 import org.projectfloodlight.openflow.protocol.action.OFActionOutput;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
+import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.OFBufferId;
 import org.projectfloodlight.openflow.types.OFPort;
 
@@ -79,7 +80,7 @@ public class HubTest extends FloodlightTestCase {
         this.testPacket = new Ethernet()
             .setDestinationMACAddress("00:11:22:33:44:55")
             .setSourceMACAddress("00:44:33:22:11:00")
-            .setEtherType(Ethernet.TYPE_IPv4)
+            .setEtherType(EthType.IPv4)
             .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)

--- a/src/test/java/net/floodlightcontroller/learningswitch/LearningSwitchTest.java
+++ b/src/test/java/net/floodlightcontroller/learningswitch/LearningSwitchTest.java
@@ -101,7 +101,7 @@ public class LearningSwitchTest extends FloodlightTestCase {
             .setDestinationMACAddress("00:11:22:33:44:55")
             .setSourceMACAddress("00:44:33:22:11:00")
             .setVlanID((short) 42)
-            .setEtherType(Ethernet.TYPE_IPv4)
+            .setEtherType(EthType.IPv4)
             .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)
@@ -117,7 +117,7 @@ public class LearningSwitchTest extends FloodlightTestCase {
             .setDestinationMACAddress("FF:FF:FF:FF:FF:FF")
             .setSourceMACAddress("00:44:33:22:11:00")
             .setVlanID((short) 42)
-            .setEtherType(Ethernet.TYPE_IPv4)
+            .setEtherType(EthType.IPv4)
             .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)
@@ -133,7 +133,7 @@ public class LearningSwitchTest extends FloodlightTestCase {
             .setDestinationMACAddress("00:44:33:22:11:00")
             .setSourceMACAddress("00:11:22:33:44:55")
             .setVlanID((short) 42)
-            .setEtherType(Ethernet.TYPE_IPv4)
+            .setEtherType(EthType.IPv4)
             .setPayload(
                     new IPv4()
                     .setTtl((byte) 128)

--- a/src/test/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManagerTest.java
+++ b/src/test/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManagerTest.java
@@ -79,6 +79,7 @@ import org.projectfloodlight.openflow.protocol.OFPortDesc;
 import org.projectfloodlight.openflow.protocol.OFPortFeatures;
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.MacAddress;
 import org.projectfloodlight.openflow.types.OFBufferId;
 import org.projectfloodlight.openflow.types.OFPort;
@@ -500,7 +501,7 @@ public class LinkDiscoveryManagerTest extends FloodlightTestCase {
         .setDestinationMACAddress(dstMAC)
         .setSourceMACAddress(srcMAC)
         .setVlanID(vlan)
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)

--- a/src/test/java/net/floodlightcontroller/loadbalancer/LoadBalancerTest.java
+++ b/src/test/java/net/floodlightcontroller/loadbalancer/LoadBalancerTest.java
@@ -45,6 +45,7 @@ import org.projectfloodlight.openflow.protocol.OFMessage;
 import org.projectfloodlight.openflow.protocol.OFPacketIn;
 import org.projectfloodlight.openflow.protocol.OFPacketOut;
 import org.projectfloodlight.openflow.protocol.OFVersion;
+import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.IPv4Address;
 import org.projectfloodlight.openflow.types.IpProtocol;
 import org.projectfloodlight.openflow.types.MacAddress;
@@ -479,7 +480,7 @@ public class LoadBalancerTest extends FloodlightTestCase {
 		arpRequest1 = new Ethernet()
 		.setSourceMACAddress("00:00:00:00:00:01")
 		.setDestinationMACAddress("ff:ff:ff:ff:ff:ff")
-		.setEtherType(Ethernet.TYPE_ARP)
+		.setEtherType(EthType.ARP)
 		.setVlanID((short) 0)
 		.setPriorityCode((byte) 0)
 		.setPayload(
@@ -511,7 +512,7 @@ public class LoadBalancerTest extends FloodlightTestCase {
 		arpReply1 = new Ethernet()
 		.setSourceMACAddress(LBVip.LB_PROXY_MAC)
 		.setDestinationMACAddress(HexString.fromHexString("00:00:00:00:00:01"))
-		.setEtherType(Ethernet.TYPE_ARP)
+		.setEtherType(EthType.ARP)
 		.setVlanID((short) 0)
 		.setPriorityCode((byte) 0)
 		.setPayload(
@@ -568,7 +569,7 @@ public class LoadBalancerTest extends FloodlightTestCase {
 		icmpPacket1 = new Ethernet()
 		.setSourceMACAddress("00:00:00:00:00:01")
 		.setDestinationMACAddress(LBVip.LB_PROXY_MAC)
-		.setEtherType(Ethernet.TYPE_IPv4)
+		.setEtherType(EthType.IPv4)
 		.setVlanID((short) 0)
 		.setPriorityCode((byte) 0)
 		.setPayload(
@@ -591,7 +592,7 @@ public class LoadBalancerTest extends FloodlightTestCase {
 		icmpPacket2 = new Ethernet()
 		.setSourceMACAddress("00:00:00:00:00:02")
 		.setDestinationMACAddress(LBVip.LB_PROXY_MAC)
-		.setEtherType(Ethernet.TYPE_IPv4)
+		.setEtherType(EthType.IPv4)
 		.setVlanID((short) 0)
 		.setPriorityCode((byte) 0)
 		.setPayload(

--- a/src/test/java/net/floodlightcontroller/packet/BSNTest.java
+++ b/src/test/java/net/floodlightcontroller/packet/BSNTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 
 import org.junit.Test;
+import org.projectfloodlight.openflow.types.EthType;
 
 /**
  *
@@ -50,7 +51,7 @@ public class BSNTest {
         return (Ethernet) new Ethernet()
             .setSourceMACAddress("00:00:00:00:00:04")
             .setDestinationMACAddress("00:00:00:00:00:01")
-            .setEtherType(Ethernet.TYPE_BSN)
+            .setEtherType(EthType.of(Ethernet.TYPE_BSN & 0xffff)) /* need to treat as unsigned */
             .setPayload(new BSN(BSN.BSN_TYPE_PROBE)
 	            .setPayload(new BSNPROBE()
 		            .setSequenceId(3)
@@ -72,7 +73,8 @@ public class BSNTest {
     @Test
     public void testDeserialize() throws Exception {
         Ethernet pkt = (Ethernet) new Ethernet().deserialize(probePkt, 0, probePkt.length);
-        assertTrue(Arrays.equals(probePkt, pkt.serialize()));
+        byte[] pktarr = pkt.serialize();
+        assertTrue(Arrays.equals(probePkt, pktarr));
 
         Ethernet expected = getProbePacket();
         assertEquals(expected, pkt);

--- a/src/test/java/net/floodlightcontroller/packet/EthernetTest.java
+++ b/src/test/java/net/floodlightcontroller/packet/EthernetTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 
 import org.junit.Test;
+import org.projectfloodlight.openflow.types.EthType;
 
 /**
  * @author David Erickson (daviderickson@cs.stanford.edu)
@@ -47,7 +48,7 @@ public class EthernetTest {
         Ethernet ethernet = new Ethernet()
             .setDestinationMACAddress("de:ad:be:ef:de:ad")
             .setSourceMACAddress("be:ef:de:ad:be:ef")
-            .setEtherType((short) 0);
+            .setEtherType(EthType.of(0));
         byte[] expected = new byte[] { (byte) 0xde, (byte) 0xad, (byte) 0xbe,
                 (byte) 0xef, (byte) 0xde, (byte) 0xad, (byte) 0xbe,
                 (byte) 0xef, (byte) 0xde, (byte) 0xad, (byte) 0xbe,

--- a/src/test/java/net/floodlightcontroller/packet/LLDPTest.java
+++ b/src/test/java/net/floodlightcontroller/packet/LLDPTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 
 import org.junit.Test;
+import org.projectfloodlight.openflow.types.EthType;
 
 /**
  *
@@ -43,7 +44,7 @@ public class LLDPTest {
         .setPad(true)
         .setDestinationMACAddress("01:23:20:00:00:01")
         .setSourceMACAddress("00:12:e2:78:67:78")
-        .setEtherType(Ethernet.TYPE_LLDP)
+        .setEtherType(EthType.LLDP)
         .setPayload(
                 new LLDP()
                 .setChassisId(new LLDPTLV().setType((byte) 1).setLength((short) 7).setValue(new byte[] {0x04, 0x00, 0x12, (byte) 0xe2, 0x78, 0x67, 0x64}))

--- a/src/test/java/net/floodlightcontroller/packet/PacketTest.java
+++ b/src/test/java/net/floodlightcontroller/packet/PacketTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.projectfloodlight.openflow.types.EthType;
 
 public class PacketTest {
     protected IPacket pkt1, pkt2, pkt3, pkt4;
@@ -33,7 +34,7 @@ public class PacketTest {
         this.pkt1 = new Ethernet()
         .setDestinationMACAddress("00:11:22:33:44:55")
         .setSourceMACAddress("00:44:33:22:11:00")
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
                     new IPv4()
                     .setTtl((byte) 128)
@@ -47,7 +48,7 @@ public class PacketTest {
         this.pkt2 = new Ethernet()
         .setSourceMACAddress("00:44:33:22:11:01")
         .setDestinationMACAddress("00:11:22:33:44:55")
-        .setEtherType(Ethernet.TYPE_ARP)
+        .setEtherType(EthType.ARP)
         .setVlanID((short)5)
         .setPayload(
                     new ARP()
@@ -65,7 +66,7 @@ public class PacketTest {
         this.pkt3 = new Ethernet()
         .setSourceMACAddress("00:44:33:22:11:01")
         .setDestinationMACAddress("00:11:22:33:44:55")
-        .setEtherType(Ethernet.TYPE_ARP)
+        .setEtherType(EthType.ARP)
         .setPayload(
                     new ARP()
                     .setHardwareType(ARP.HW_TYPE_ETHERNET)
@@ -81,7 +82,7 @@ public class PacketTest {
         this.pkt4 = new Ethernet()
         .setDestinationMACAddress("FF:FF:FF:FF:FF:FF")
         .setSourceMACAddress("00:11:33:55:77:01")
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
                     new IPv4()
                     .setTtl((byte) 128)

--- a/src/test/java/net/floodlightcontroller/virtualnetwork/VirtualNetworkFilterTest.java
+++ b/src/test/java/net/floodlightcontroller/virtualnetwork/VirtualNetworkFilterTest.java
@@ -30,6 +30,7 @@ import org.projectfloodlight.openflow.protocol.OFType;
 import org.projectfloodlight.openflow.protocol.OFPacketInReason;
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.IPv4Address;
 import org.projectfloodlight.openflow.types.MacAddress;
 import org.projectfloodlight.openflow.types.OFBufferId;
@@ -156,7 +157,7 @@ public class VirtualNetworkFilterTest extends FloodlightTestCase {
         mac1ToMac2PacketIntestPacket = new Ethernet()
             .setDestinationMACAddress(mac2.getBytes())
             .setSourceMACAddress(mac1.getBytes())
-            .setEtherType(Ethernet.TYPE_IPv4)
+            .setEtherType(EthType.IPv4)
             .setPayload(
                 new IPv4()
                 .setTtl((byte) 128)
@@ -176,7 +177,7 @@ public class VirtualNetworkFilterTest extends FloodlightTestCase {
         mac1ToMac4PacketIntestPacket = new Ethernet()
         .setDestinationMACAddress(mac4.getBytes())
         .setSourceMACAddress(mac1.getBytes())
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
             new IPv4()
             .setTtl((byte) 128)
@@ -196,7 +197,7 @@ public class VirtualNetworkFilterTest extends FloodlightTestCase {
         mac1ToGwPacketIntestPacket = new Ethernet()
         .setDestinationMACAddress("00:11:33:33:44:55")
         .setSourceMACAddress(mac1.getBytes())
-        .setEtherType(Ethernet.TYPE_IPv4)
+        .setEtherType(EthType.IPv4)
         .setPayload(
             new IPv4()
             .setTtl((byte) 128)


### PR DESCRIPTION
Fixed a bug in the link discovery manager that incorrectly filtered ethertypes.
Fixed a bug in the Ethernet class that resulted in the incorrect deserialization/serialization of ethertypes that include a 1 in the most significant bit (e.g. IPv6) of the two bytes. This would cause the short container to represent it as a negative number. The container for an ethertype has been correctly changed to EthType now.

TODO: Patch Loxi to include an EthType.ofShort(short etype) function that does something like this:
ofShort(short ethtype) {
   return EthType.of(ethtype & 0xffFF);
}

Initial commit of DHCP server module in the net.floodlightcontroller.dhcpserver package. I will write up a wiki page with the possible config file parameters and how to add them to floodlightdefault.properties.

TODO: In a commit in the near future, write up unit tests for the dhcpserver package. This will hopefully help strengthen my JUnit skills.