### PR TITLE
First round of support for changing switch roles via modules and REST API.

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/OFConnection.java
+++ b/src/main/java/net/floodlightcontroller/core/OFConnection.java
@@ -143,6 +143,7 @@ public class OFConnection implements IOFConnection, IOFConnectionBackend{
 
         DeliverableListenableFuture<R> future = new DeliverableListenableFuture<R>();
         xidDeliverableMap.put(request.getXid(), future);
+        listener.messageWritten(this, request);
         write(request);
         return future;
     }
@@ -402,6 +403,12 @@ public class OFConnection implements IOFConnection, IOFConnectionBackend{
         public boolean isSwitchHandshakeComplete(IOFConnectionBackend connection) {
             return false;
         }
+
+		@Override
+		public void messageWritten(IOFConnectionBackend connection, OFMessage m) {
+			// TODO Auto-generated method stub
+			
+		}
 
     }
 

--- a/src/main/java/net/floodlightcontroller/core/OFSwitch.java
+++ b/src/main/java/net/floodlightcontroller/core/OFSwitch.java
@@ -1,19 +1,19 @@
 /**
-*    Copyright 2012, Big Switch Networks, Inc.
-*    Originally created by David Erickson, Stanford University
-*
-*    Licensed under the Apache License, Version 2.0 (the "License"); you may
-*    not use this file except in compliance with the License. You may obtain
-*    a copy of the License at
-*
-*         http://www.apache.org/licenses/LICENSE-2.0
-*
-*    Unless required by applicable law or agreed to in writing, software
-*    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-*    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-*    License for the specific language governing permissions and limitations
-*    under the License.
-**/
+ *    Copyright 2012, Big Switch Networks, Inc.
+ *    Originally created by David Erickson, Stanford University
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ **/
 
 package net.floodlightcontroller.core;
 
@@ -52,6 +52,7 @@ import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFFeaturesReply;
 import org.projectfloodlight.openflow.protocol.OFFlowWildcards;
 import org.projectfloodlight.openflow.protocol.OFMessage;
+
 import org.projectfloodlight.openflow.protocol.OFPortConfig;
 import org.projectfloodlight.openflow.protocol.OFPortDesc;
 import org.projectfloodlight.openflow.protocol.OFPortDescStatsReply;
@@ -82,1024 +83,1040 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * This is the internal representation of an openflow switch.
  */
 public class OFSwitch implements IOFSwitchBackend {
-    protected static final Logger log =
-            LoggerFactory.getLogger(OFSwitch.class);
-
-    protected final ConcurrentMap<Object, Object> attributes;
-    protected final IOFSwitchManager switchManager;
-
-    /* Switch features from initial featuresReply */
-    protected Set<OFCapabilities> capabilities;
-    protected long buffers;
-    protected Set<OFActionType> actions;
-    protected short tables;
-    protected final DatapathId datapathId;
-
-    private boolean startDriverHandshakeCalled = false;
-    private final Map<OFAuxId, IOFConnectionBackend> connections;
-    private volatile Map<URI, Map<OFAuxId, OFBsnControllerConnection>> controllerConnections;
-    protected OFFactory factory;
-
-    /**
-     * Members hidden from subclasses
-     */
-    private final PortManager portManager;
-
-    private volatile boolean connected;
-
-    private volatile OFControllerRole role;
-
-    private boolean flowTableFull = false;
-
-    protected SwitchDescription description;
-    
-    private SwitchStatus status;
-
-    public static final int OFSWITCH_APP_ID = ident(5);
-    
-    static {
-        AppCookie.registerApp(OFSwitch.OFSWITCH_APP_ID, "switch");
-    }
-
-    public OFSwitch(IOFConnectionBackend connection, @Nonnull OFFactory factory, @Nonnull IOFSwitchManager switchManager,
-            @Nonnull DatapathId datapathId) {
-        if(connection == null)
-            throw new NullPointerException("connection must not be null");
-        if(!connection.getAuxId().equals(OFAuxId.MAIN))
-            throw new IllegalArgumentException("connection must be the main connection");
-        if(factory == null)
-            throw new NullPointerException("factory must not be null");
-        if(switchManager == null)
-            throw new NullPointerException("switchManager must not be null");
-
-        this.connected = true;
-        this.factory = factory;
-        this.switchManager = switchManager;
-        this.datapathId = datapathId;
-        this.attributes = new ConcurrentHashMap<Object, Object>();
-        this.role = null;
-        this.description = new SwitchDescription();
-        this.portManager = new PortManager();
-        this.status = SwitchStatus.HANDSHAKE;
-
-        // Connections
-        this.connections = new ConcurrentHashMap<OFAuxId, IOFConnectionBackend>();
-        this.connections.put(connection.getAuxId(), connection);
-
-        // Switch's controller connection
-        this.controllerConnections = ImmutableMap.of();
-
-        // Defaults properties for an ideal switch
-        this.setAttribute(PROP_FASTWILDCARDS, EnumSet.allOf(OFFlowWildcards.class));
-        this.setAttribute(PROP_SUPPORTS_OFPP_FLOOD, Boolean.TRUE);
-        this.setAttribute(PROP_SUPPORTS_OFPP_TABLE, Boolean.TRUE);
-    }
-
-    private static int ident(int i) {
-        return i;
-    }
-
-    @Override
-    public OFFactory getOFFactory() {
-        return factory;
-    }
-
-    /**
-     * Manages the ports of this switch.
-     *
-     * Provides methods to query and update the stored ports. The class ensures
-     * that every port name and port number is unique. When updating ports
-     * the class checks if port number <-> port name mappings have change due
-     * to the update. If a new port P has number and port that are inconsistent
-     * with the previous mapping(s) the class will delete all previous ports
-     * with name or number of the new port and then add the new port.
-     *
-     * Port names are stored as-is but they are compared case-insensitive
-     *
-     * The methods that change the stored ports return a list of
-     * PortChangeEvents that represent the changes that have been applied
-     * to the port list so that IOFSwitchListeners can be notified about the
-     * changes.
-     *
-     * Implementation notes:
-     * - We keep several different representations of the ports to allow for
-     *   fast lookups
-     * - Ports are stored in unchangeable lists. When a port is modified new
-     *   data structures are allocated.
-     * - We use a read-write-lock for synchronization, so multiple readers are
-     *   allowed.
-     */
-    protected static class PortManager {
-        private final ReentrantReadWriteLock lock;
-        private List<OFPortDesc> portList;
-        private List<OFPortDesc> enabledPortList;
-        private List<OFPort> enabledPortNumbers;
-        private Map<OFPort,OFPortDesc> portsByNumber;
-        private Map<String,OFPortDesc> portsByName;
-
-        public PortManager() {
-            this.lock = new ReentrantReadWriteLock();
-            this.portList = Collections.emptyList();
-            this.enabledPortList = Collections.emptyList();
-            this.enabledPortNumbers = Collections.emptyList();
-            this.portsByName = Collections.emptyMap();
-            this.portsByNumber = Collections.emptyMap();
-        }
-
-        /**
-         * Set the internal data structure storing this switch's port
-         * to the ports specified by newPortsByNumber
-         *
-         * CALLER MUST HOLD WRITELOCK
-         *
-         * @param newPortsByNumber
-         * @throws IllegaalStateException if called without holding the
-         * writelock
-         */
-        private void updatePortsWithNewPortsByNumber(
-                Map<OFPort,OFPortDesc> newPortsByNumber) {
-            if (!lock.writeLock().isHeldByCurrentThread()) {
-                throw new IllegalStateException("Method called without " +
-                                                "holding writeLock");
-            }
-            Map<String,OFPortDesc> newPortsByName =
-                    new HashMap<String, OFPortDesc>();
-            List<OFPortDesc> newPortList =
-                    new ArrayList<OFPortDesc>();
-            List<OFPortDesc> newEnabledPortList =
-                    new ArrayList<OFPortDesc>();
-            List<OFPort> newEnabledPortNumbers = new ArrayList<OFPort>();
-
-            for(OFPortDesc p: newPortsByNumber.values()) {
-                newPortList.add(p);
-                newPortsByName.put(p.getName().toLowerCase(), p);
-                if (!p.getState().contains(OFPortState.LINK_DOWN) 
-                		&& !p.getConfig().contains(OFPortConfig.PORT_DOWN)) {
-                    newEnabledPortList.add(p);
-                    newEnabledPortNumbers.add(p.getPortNo());
-                }
-            }
-            portsByName = Collections.unmodifiableMap(newPortsByName);
-            portsByNumber =
-                    Collections.unmodifiableMap(newPortsByNumber);
-            enabledPortList =
-                    Collections.unmodifiableList(newEnabledPortList);
-            enabledPortNumbers =
-                    Collections.unmodifiableList(newEnabledPortNumbers);
-            portList = Collections.unmodifiableList(newPortList);
-        }
-
-        /**
-         * Handle a OFPortStatus delete message for the given port.
-         * Updates the internal port maps/lists of this switch and returns
-         * the PortChangeEvents caused by the delete. If the given port
-         * exists as it, it will be deleted. If the name<->number for the
-         * given port is inconsistent with the ports stored by this switch
-         * the method will delete all ports with the number or name of the
-         * given port.
-         *
-         * This method will increment error/warn counters and log
-         *
-         * @param delPort the port from the port status message that should
-         * be deleted.
-         * @return ordered collection of port changes applied to this switch
-         */
-        private OrderedCollection<PortChangeEvent>
-                handlePortStatusDelete(OFPortDesc delPort) {
-            OrderedCollection<PortChangeEvent> events =
-                    new LinkedHashSetWrapper<PortChangeEvent>();
-            lock.writeLock().lock();
-            try {
-                Map<OFPort,OFPortDesc> newPortByNumber =
-                        new HashMap<OFPort, OFPortDesc>(portsByNumber);
-                OFPortDesc prevPort =
-                        portsByNumber.get(delPort.getPortNo());
-                if (prevPort == null) {
-                    // so such port. Do we have a port with the name?
-                    prevPort = portsByName.get(delPort.getName());
-                    if (prevPort != null) {
-                        newPortByNumber.remove(prevPort.getPortNo());
-                        events.add(new PortChangeEvent(prevPort,
-                                                       PortChangeType.DELETE));
-                    }
-                } else if (prevPort.getName().equals(delPort.getName())) {
-                    // port exists with consistent name-number mapping
-                    newPortByNumber.remove(delPort.getPortNo());
-                    events.add(new PortChangeEvent(delPort,
-                                                   PortChangeType.DELETE));
-                } else {
-                    // port with same number exists but its name differs. This
-                    // is weird. The best we can do is to delete the existing
-                    // port(s) that have delPort's name and number.
-                    newPortByNumber.remove(delPort.getPortNo());
-                    events.add(new PortChangeEvent(prevPort,
-                                                   PortChangeType.DELETE));
-                    // is there another port that has delPort's name?
-                    prevPort = portsByName.get(delPort.getName().toLowerCase());
-                    if (prevPort != null) {
-                        newPortByNumber.remove(prevPort.getPortNo());
-                        events.add(new PortChangeEvent(prevPort,
-                                                       PortChangeType.DELETE));
-                    }
-                }
-                updatePortsWithNewPortsByNumber(newPortByNumber);
-                return events;
-            } finally {
-                lock.writeLock().unlock();
-            }
-        }
-
-        /**
-         * Handle a OFPortStatus message, update the internal data structures
-         * that store ports and return the list of OFChangeEvents.
-         *
-         * This method will increment error/warn counters and log
-         *
-         * @param ps
-         * @return
-         */
-        @SuppressFBWarnings(value="SF_SWITCH_FALLTHROUGH")
-        public OrderedCollection<PortChangeEvent> handlePortStatusMessage(OFPortStatus ps) {
-            if (ps == null) {
-                throw new NullPointerException("OFPortStatus message must " +
-                                               "not be null");
-            }
-            lock.writeLock().lock();
-            try {
-                OFPortDesc port = ps.getDesc();
-                OFPortReason reason = ps.getReason();
-                if (reason == null) {
-                    throw new IllegalArgumentException("Unknown PortStatus " +
-                            "reason code " + ps.getReason());
-                }
-
-                if (log.isDebugEnabled()) {
-                    log.debug("Handling OFPortStatus: {} for {}",
-                              reason, String.format("%s (%d)", port.getName(), port.getPortNo().getPortNumber()));
-                }
-
-                if (reason == OFPortReason.DELETE)
-                    return handlePortStatusDelete(port);
-
-                // We handle ADD and MODIFY the same way. Since OpenFlow
-                // doesn't specify what uniquely identifies a port the
-                // notion of ADD vs. MODIFY can also be hazy. So we just
-                // compare the new port to the existing ones.
-                Map<OFPort,OFPortDesc> newPortByNumber =
-                    new HashMap<OFPort, OFPortDesc>(portsByNumber);
-                OrderedCollection<PortChangeEvent> events = getSinglePortChanges(port);
-                for (PortChangeEvent e: events) {
-                    switch(e.type) {
-                        case DELETE:
-                            newPortByNumber.remove(e.port.getPortNo());
-                            break;
-                        case ADD:
-                            if (reason != OFPortReason.ADD) {
-                                // weird case
-                            }
-                            // fall through
-                        case DOWN:
-                        case OTHER_UPDATE:
-                        case UP:
-                            // update or add the port in the map
-                            newPortByNumber.put(e.port.getPortNo(), e.port);
-                            break;
-                    }
-                }
-                updatePortsWithNewPortsByNumber(newPortByNumber);
-                return events;
-            } finally {
-                lock.writeLock().unlock();
-            }
-
-        }
-
-        /**
-         * Given a new or modified port newPort, returns the list of
-         * PortChangeEvents to "transform" the current ports stored by
-         * this switch to include / represent the new port. The ports stored
-         * by this switch are <b>NOT</b> updated.
-         *
-         * This method acquires the readlock and is thread-safe by itself.
-         * Most callers will need to acquire the write lock before calling
-         * this method though (if the caller wants to update the ports stored
-         * by this switch)
-         *
-         * @param newPort the new or modified port.
-         * @return the list of changes
-         */
-        public OrderedCollection<PortChangeEvent>
-                getSinglePortChanges(OFPortDesc newPort) {
-            lock.readLock().lock();
-            try {
-                OrderedCollection<PortChangeEvent> events =
-                        new LinkedHashSetWrapper<PortChangeEvent>();
-                // Check if we have a port by the same number in our
-                // old map.
-                OFPortDesc prevPort =
-                        portsByNumber.get(newPort.getPortNo());
-                if (newPort.equals(prevPort)) {
-                    // nothing has changed
-                    return events;
-                }
-
-                if (prevPort != null &&
-                        prevPort.getName().equals(newPort.getName())) {
-                    // A simple modify of a exiting port
-                    // A previous port with this number exists and it's name
-                    // also matches the new port. Find the differences
-                    if ((!prevPort.getState().contains(OFPortState.LINK_DOWN) 
-                    		&& !prevPort.getConfig().contains(OFPortConfig.PORT_DOWN)) 
-                    		&& (newPort.getState().contains(OFPortState.LINK_DOWN) 
-                    		|| newPort.getConfig().contains(OFPortConfig.PORT_DOWN))) {
-                        events.add(new PortChangeEvent(newPort,
-                                                       PortChangeType.DOWN));
-                    } else if ((prevPort.getState().contains(OFPortState.LINK_DOWN) 
-                    		|| prevPort.getConfig().contains(OFPortConfig.PORT_DOWN)) 
-                    		&& (!newPort.getState().contains(OFPortState.LINK_DOWN) 
-                    		&& !newPort.getConfig().contains(OFPortConfig.PORT_DOWN))) {
-                        events.add(new PortChangeEvent(newPort,
-                                                       PortChangeType.UP));
-                    } else {
-                        events.add(new PortChangeEvent(newPort,
-                                   PortChangeType.OTHER_UPDATE));
-                    }
-                    return events;
-                }
-
-                if (prevPort != null) {
-                    // There exists a previous port with the same port
-                    // number but the port name is different (otherwise we would
-                    // never have gotten here)
-                    // Remove the port. Name-number mapping(s) have changed
-                    events.add(new PortChangeEvent(prevPort,
-                                                   PortChangeType.DELETE));
-                }
-
-                // We now need to check if there exists a previous port sharing
-                // the same name as the new/updated port.
-                prevPort = portsByName.get(newPort.getName().toLowerCase());
-                if (prevPort != null) {
-                    // There exists a previous port with the same port
-                    // name but the port number is different (otherwise we
-                    // never have gotten here).
-                    // Remove the port. Name-number mapping(s) have changed
-                    events.add(new PortChangeEvent(prevPort,
-                                                   PortChangeType.DELETE));
-                }
-
-                // We always need to add the new port. Either no previous port
-                // existed or we just deleted previous ports with inconsistent
-                // name-number mappings
-                events.add(new PortChangeEvent(newPort, PortChangeType.ADD));
-                return events;
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-
-        /**
-         * Compare the current ports of this switch to the newPorts list and
-         * return the changes that would be applied to transform the current
-         * ports to the new ports. No internal data structures are updated
-         * see {@link #compareAndUpdatePorts(List, boolean)}
-         *
-         * @param newPorts the list of new ports
-         * @return The list of differences between the current ports and
-         * newPortList
-         */
-        public OrderedCollection<PortChangeEvent>
-                comparePorts(Collection<OFPortDesc> newPorts) {
-            return compareAndUpdatePorts(newPorts, false);
-        }
-
-        /**
-         * Compare the current ports of this switch to the newPorts list and
-         * return the changes that would be applied to transform the current
-         * ports to the new ports. No internal data structures are updated
-         * see {@link #compareAndUpdatePorts(List, boolean)}
-         *
-         * @param newPorts the list of new ports
-         * @return The list of differences between the current ports and
-         * newPortList
-         */
-        public OrderedCollection<PortChangeEvent>
-                updatePorts(Collection<OFPortDesc> newPorts) {
-            return compareAndUpdatePorts(newPorts, true);
-        }
-
-        /**
-         * Compare the current ports stored in this switch instance with the
-         * new port list given and return the differences in the form of
-         * PortChangeEvents. If the doUpdate flag is true, newPortList will
-         * replace the current list of this switch (and update the port maps)
-         *
-         * Implementation note:
-         * Since this method can optionally modify the current ports and
-         * since it's not possible to upgrade a read-lock to a write-lock
-         * we need to hold the write-lock for the entire operation. If this
-         * becomes a problem and if compares() are common we can consider
-         * splitting in two methods but this requires lots of code duplication
-         *
-         * @param newPorts the list of new ports.
-         * @param doUpdate If true the newPortList will replace the current
-         * port list for this switch. If false this switch will not be changed.
-         * @return The list of differences between the current ports and
-         * newPorts
-         * @throws NullPointerException if newPortsList is null
-         * @throws IllegalArgumentException if either port names or port numbers
-         * are duplicated in the newPortsList.
-         */
-        private OrderedCollection<PortChangeEvent> compareAndUpdatePorts(
-                Collection<OFPortDesc> newPorts,
-                boolean doUpdate) {
-            if (newPorts == null) {
-                throw new NullPointerException("newPortsList must not be null");
-            }
-            lock.writeLock().lock();
-            try {
-                OrderedCollection<PortChangeEvent> events =
-                        new LinkedHashSetWrapper<PortChangeEvent>();
-
-                Map<OFPort,OFPortDesc> newPortsByNumber =
-                        new HashMap<OFPort, OFPortDesc>();
-                Map<String,OFPortDesc> newPortsByName =
-                        new HashMap<String, OFPortDesc>();
-                List<OFPortDesc> newEnabledPortList =
-                        new ArrayList<OFPortDesc>();
-                List<OFPort> newEnabledPortNumbers =
-                        new ArrayList<OFPort>();
-                List<OFPortDesc> newPortsList =
-                        new ArrayList<OFPortDesc>(newPorts);
-
-                for (OFPortDesc p: newPortsList) {
-                    if (p == null) {
-                        throw new NullPointerException("portList must not " +
-                                "contain null values");
-                    }
-
-                    // Add the port to the new maps and lists and check
-                    // that every port is unique
-                    OFPortDesc duplicatePort;
-                    duplicatePort = newPortsByNumber.put(p.getPortNo(), p);
-                    if (duplicatePort != null) {
-                        String msg = String.format("Cannot have two ports " +
-                                "with the same number: %s <-> %s",
-                                String.format("%s (%d)", p.getName(), p.getPortNo().getPortNumber()),
-                                String.format("%s (%d)", duplicatePort.getName(), duplicatePort.getPortNo().getPortNumber()));
-                        throw new IllegalArgumentException(msg);
-                    }
-                    duplicatePort =
-                            newPortsByName.put(p.getName().toLowerCase(), p);
-                    if (duplicatePort != null) {
-                        String msg = String.format("Cannot have two ports " +
-                                "with the same name: %s <-> %s",
-                                String.format("%s (%d)", p.getName(), p.getPortNo().getPortNumber()),
-                                String.format("%s (%d)", duplicatePort.getName(), duplicatePort.getPortNo().getPortNumber()));
-                        throw new IllegalArgumentException(msg);
-                    }
-                    // Enabled = not down admin (config) or phys (state)
-                    if (!p.getConfig().contains(OFPortConfig.PORT_DOWN)
-                    		&& !p.getState().contains(OFPortState.LINK_DOWN)) {
-                        newEnabledPortList.add(p);
-                        newEnabledPortNumbers.add(p.getPortNo());
-                    }
-
-                    // get changes
-                    events.addAll(getSinglePortChanges(p));
-                }
-                // find deleted ports
-                // We need to do this after looping through all the new ports
-                // to we can handle changed name<->number mappings correctly
-                // We could pull it into the loop of we address this but
-                // it's probably not worth it
-                for (OFPortDesc oldPort: this.portList) {
-                    if (!newPortsByNumber.containsKey(oldPort.getPortNo())) {
-                        PortChangeEvent ev =
-                                new PortChangeEvent(oldPort,
-                                                    PortChangeType.DELETE);
-                        events.add(ev);
-                    }
-                }
-
-
-                if (doUpdate) {
-                    portsByName = Collections.unmodifiableMap(newPortsByName);
-                    portsByNumber =
-                            Collections.unmodifiableMap(newPortsByNumber);
-                    enabledPortList =
-                            Collections.unmodifiableList(newEnabledPortList);
-                    enabledPortNumbers =
-                            Collections.unmodifiableList(newEnabledPortNumbers);
-                    portList = Collections.unmodifiableList(newPortsList);
-                }
-                return events;
-            } finally {
-                lock.writeLock().unlock();
-            }
-        }
-
-        public OFPortDesc getPort(String name) {
-            if (name == null) {
-                throw new NullPointerException("Port name must not be null");
-            }
-            lock.readLock().lock();
-            try {
-                return portsByName.get(name.toLowerCase());
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-
-        public OFPortDesc getPort(OFPort portNumber) {
-            lock.readLock().lock();
-            try {
-                return portsByNumber.get(portNumber);
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-
-        public List<OFPortDesc> getPorts() {
-            lock.readLock().lock();
-            try {
-                return portList;
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-
-        public List<OFPortDesc> getEnabledPorts() {
-            lock.readLock().lock();
-            try {
-                return enabledPortList;
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-
-        public List<OFPort> getEnabledPortNumbers() {
-            lock.readLock().lock();
-            try {
-                return enabledPortNumbers;
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-    }
-
-    @Override
-    public boolean attributeEquals(String name, Object other) {
-        Object attr = this.attributes.get(name);
-        if (attr == null)
-            return false;
-        return attr.equals(other);
-    }
-
-    @Override
-    public Object getAttribute(String name) {
-        // returns null if key doesn't exist
-        return this.attributes.get(name);
-    }
-
-    @Override
-    public void setAttribute(String name, Object value) {
-        this.attributes.put(name, value);
-        return;
-    }
-
-    @Override
-    public Object removeAttribute(String name) {
-        return this.attributes.remove(name);
-    }
-
-    @Override
-    public boolean hasAttribute(String name) {
-        return this.attributes.containsKey(name);
-    }
-
-    @Override
-    public void registerConnection(IOFConnectionBackend connection) {
-        this.connections.put(connection.getAuxId(), connection);
-    }
-
-
-    @Override
-    public ImmutableList<IOFConnection> getConnections() {
-        return ImmutableList.<IOFConnection> copyOf(this.connections.values());
-    }
-
-    @Override
-    public void removeConnections() {
-        this.connections.clear();
-    }
-
-    @Override
-    public void removeConnection(IOFConnectionBackend connection) {
-        this.connections.remove(connection.getAuxId());
-    }
-
-    @Override
-    public void write(OFMessage m) {
-    	log.trace("Channel: {}, Connected: {}", connections.get(OFAuxId.MAIN).getRemoteInetAddress(), connections.get(OFAuxId.MAIN).isConnected());
-        connections.get(OFAuxId.MAIN).write(m);
-    }
-
-    /**
-     * Gets a connection specified by aux Id.
-     * @param auxId the specified aux id for the connection desired.
-     * @return the aux connection specified by the auxId
-     */
-    public IOFConnection getConnection(OFAuxId auxId) {
-        IOFConnection connection = this.connections.get(auxId);
-        if(connection == null){
-            throw new IllegalArgumentException("OF Connection for " + this + " with " + auxId + " does not exist.");
-        }
-        return connection;
-    }
-
-    public IOFConnection getConnection(LogicalOFMessageCategory category) {
-        if(switchManager.isCategoryRegistered(category)){
-            return getConnection(category.getAuxId());
-        }
-        else{
-            throw new IllegalArgumentException(category + " is not registered with the floodlight provider service.");
-        }
-    }
-
-    @Override
-    public void write(OFMessage m, LogicalOFMessageCategory category) {
-        this.getConnection(category).write(m);
-    }
-
-    @Override
-    public void write(Iterable<OFMessage> msglist, LogicalOFMessageCategory category) {
-        this.getConnection(category).write(msglist);
-    }
-
-    @Override
-    public OFConnection getConnectionByCategory(LogicalOFMessageCategory category){
-        return (OFConnection) this.getConnection(category);
-    }
-
-    @Override
-    public <R extends OFMessage> ListenableFuture<R> writeRequest(OFRequest<R> request, LogicalOFMessageCategory category) {
-        return getConnection(category).writeRequest(request);
-    }
-
-    @Override
-    public <R extends OFMessage> ListenableFuture<R> writeRequest(OFRequest<R> request) {
-        return connections.get(OFAuxId.MAIN).writeRequest(request);
-    }
-
-    @Override
-    @LogMessageDoc(level="WARN",
-                   message="Sending OF message that modifies switch " +
-                           "state while in the slave role: {switch}",
-                   explanation="An application has sent a message to a switch " +
-                           "that is not valid when the switch is in a slave role",
-                   recommendation=LogMessageDoc.REPORT_CONTROLLER_BUG)
-    public void write(Iterable<OFMessage> msglist) {
-        connections.get(OFAuxId.MAIN).write(msglist);
-    }
-
-    @Override
-    public void disconnect() {
-
-        // Iterate through connections and perform cleanup
-        for(Entry<OFAuxId, IOFConnectionBackend> entry : this.connections.entrySet()){
-            entry.getValue().disconnect();
-            this.connections.remove(entry.getKey());
-        }
-        log.debug("~~~~~~~SWITCH DISCONNECTED~~~~~~");
-        // Remove all counters from the store
-        connected = false;
-    }
-
-    @Override
-    public void setFeaturesReply(OFFeaturesReply featuresReply) {
-        if (portManager.getPorts().isEmpty() && featuresReply.getVersion().compareTo(OFVersion.OF_13) < 0) {
-            /* ports are updated via port status message, so we
-             * only fill in ports on initial connection.
-             */
-            List<OFPortDesc> OFPortDescs = featuresReply.getPorts();
-            portManager.updatePorts(OFPortDescs);
-        }
-        this.capabilities = featuresReply.getCapabilities();
-        this.buffers = featuresReply.getNBuffers();
-
-        if (featuresReply.getVersion().compareTo(OFVersion.OF_13) < 0 ) {
-            // FIXME:LOJI: OF1.3 has per table actions. This needs to be modeled / handled here
-            this.actions = featuresReply.getActions();
-        }
-        this.tables = featuresReply.getNTables();
-    }
-
-    @Override
-    public void setPortDescStats(OFPortDescStatsReply reply) {
-        /* ports are updated via port status message, so we
-         * only fill in ports on initial connection.
-         */
-        List<OFPortDesc> OFPortDescs = reply.getEntries();
-        portManager.updatePorts(OFPortDescs);
-    }
-
-    @Override
-    public Collection<OFPortDesc> getEnabledPorts() {
-        return portManager.getEnabledPorts();
-    }
-
-    @Override
-    public Collection<OFPort> getEnabledPortNumbers() {
-        return portManager.getEnabledPortNumbers();
-    }
-
-    @Override
-    public OFPortDesc getPort(OFPort portNumber) {
-        return portManager.getPort(portNumber);
-    }
-
-    @Override
-    public OFPortDesc getPort(String portName) {
-        return portManager.getPort(portName);
-    }
-
-    @Override
-    public OrderedCollection<PortChangeEvent>
-            processOFPortStatus(OFPortStatus ps) {
-        return portManager.handlePortStatusMessage(ps);
-    }
-
-    @Override
-    public Collection<OFPortDesc> getSortedPorts() {
-        List<OFPortDesc> sortedPorts =
-                new ArrayList<OFPortDesc>(portManager.getPorts());
-        Collections.sort(sortedPorts, new Comparator<OFPortDesc>() {
-            @Override
-            public int compare(OFPortDesc o1, OFPortDesc o2) {
-                String name1 = o1.getName();
-                String name2 = o2.getName();
-                return name1.compareToIgnoreCase(name2);
-            }
-        });
-        return sortedPorts;
-    }
-
-    @Override
-    public Collection<OFPortDesc> getPorts() {
-        return portManager.getPorts();
-    }
-
-    @Override
-    public OrderedCollection<PortChangeEvent>
-            comparePorts(Collection<OFPortDesc> ports) {
-        return portManager.comparePorts(ports);
-    }
-
-    @Override
-    public OrderedCollection<PortChangeEvent>
-            setPorts(Collection<OFPortDesc> ports) {
-        return portManager.updatePorts(ports);
-    }
-
-    @Override
-    public boolean portEnabled(OFPort portNumber) {
-        OFPortDesc p = portManager.getPort(portNumber);
-        if (p == null) return false;
-        return (!p.getState().contains(OFPortState.BLOCKED) && !p.getState().contains(OFPortState.LINK_DOWN) && !p.getState().contains(OFPortState.STP_BLOCK));
-    }
-
-    @Override
-    public boolean portEnabled(String portName) {
-        OFPortDesc p = portManager.getPort(portName);
-        if (p == null) return false;
-        return (!p.getState().contains(OFPortState.BLOCKED) && !p.getState().contains(OFPortState.LINK_DOWN) && !p.getState().contains(OFPortState.STP_BLOCK));
-    }
-
-    @Override
-    public DatapathId getId() {
-        if (datapathId == null)
-            throw new RuntimeException("Features reply has not yet been set");
-        return datapathId;
-    }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return "OFSwitchBase DPID[" + ((datapathId != null) ? datapathId.toString() : "?") + "]";
-    }
-
-    @Override
-    public ConcurrentMap<Object, Object> getAttributes() {
-        return this.attributes;
-    }
-
-    @Override
-    public Date getConnectedSince() {
-        return this.connections.get(OFAuxId.MAIN).getConnectedSince();
-    }
-
-    @Override
-    public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request) {
-        return connections.get(OFAuxId.MAIN).writeStatsRequest(request);
-    }
-
-    @Override
-    public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request, LogicalOFMessageCategory category) {
-        return getConnection(category).writeStatsRequest(request);
-    }
-
-    @Override
-    public void cancelAllPendingRequests() {
-        for(Entry<OFAuxId, IOFConnectionBackend> entry : this.connections.entrySet()){
-            entry.getValue().cancelAllPendingRequests();
-        }
-    }
-
-    // If any connections are down consider a switch disconnected
-    @Override
-    public boolean isConnected() {
-        return connected;
-    }
-
-    @Override
-    public boolean isActive() {
-        // no lock needed since we use volatile
-        return isConnected() && this.role == OFControllerRole.ROLE_MASTER;
-    }
-
-    @Override
-    public OFControllerRole getControllerRole() {
-        return role;
-    }
-
-    @Override
-    public void setControllerRole(OFControllerRole role) {
-        this.role = role;
-    }
-
-    @Override
-    public void flush() {
-        for(Entry<OFAuxId, IOFConnectionBackend> entry : this.connections.entrySet()){
-            entry.getValue().flush();
-        }
-    }
-
-    /**
-     * Get the IP Address for the switch
-     * @return the inet address
-     */
-    @Override
-    public SocketAddress getInetAddress() {
-        return connections.get(OFAuxId.MAIN).getRemoteInetAddress();
-    }
-
-    @Override
-    public long getBuffers() {
-        return buffers;
-    }
-
-
-    @Override
-    public Set<OFActionType> getActions() {
-        return actions;
-    }
-
-
-    @Override
-    public Set<OFCapabilities> getCapabilities() {
-        return capabilities;
-    }
-
-
-    @Override
-    public short getTables() {
-        return tables;
-    }
-
-    @Override
-    public SwitchDescription getSwitchDescription() {
-        return description;
-    }
-
-    @Override
-    @LogMessageDoc(level="WARN",
-        message="Switch {switch} flow table is full",
-        explanation="The controller received flow table full " +
-                "message from the switch, could be caused by increased " +
-                "traffic pattern",
-                recommendation=LogMessageDoc.REPORT_CONTROLLER_BUG)
-    public void setTableFull(boolean isFull) {
-        if (isFull && !flowTableFull) {
-            switchManager.addSwitchEvent(this.datapathId,
-                    "SWITCH_FLOW_TABLE_FULL " +
-                    "Table full error from switch", false);
-            log.warn("Switch {} flow table is full", datapathId.toString());
-        }
-        flowTableFull = isFull;
-    }
-
-    @Override
-    public void startDriverHandshake() {
-        if (startDriverHandshakeCalled)
-            throw new SwitchDriverSubHandshakeAlreadyStarted();
-        startDriverHandshakeCalled = true;
-    }
-
-    @Override
-    public boolean isDriverHandshakeComplete() {
-        if (!startDriverHandshakeCalled)
-            throw new SwitchDriverSubHandshakeNotStarted();
-        return true;
-    }
-
-    @Override
-    public void processDriverHandshakeMessage(OFMessage m) {
-        if (startDriverHandshakeCalled)
-            throw new SwitchDriverSubHandshakeCompleted(m);
-        else
-            throw new SwitchDriverSubHandshakeNotStarted();
-    }
-
-    @Override
-    public void setSwitchProperties(SwitchDescription description) {
-        this.description = description;
-    }
-
-
-    @Override
-    public SwitchStatus getStatus() {
-        return status;
-    }
-
-    @Override
-    public void setStatus(SwitchStatus switchStatus) {
-        this.status = switchStatus;
-    }
-
-    @Override
-    public void updateControllerConnections(OFBsnControllerConnectionsReply controllerCxnsReply) {
-
-        // Instantiate clean map, can't use a builder here since we need to call temp.get()
-        Map<URI,Map<OFAuxId, OFBsnControllerConnection>> temp = new ConcurrentHashMap<URI,Map<OFAuxId, OFBsnControllerConnection>>();
-
-        List<OFBsnControllerConnection> controllerCxnUpdates = controllerCxnsReply.getConnections();
-        for(OFBsnControllerConnection update : controllerCxnUpdates) {
-            URI uri = URI.create(update.getUri());
-
-            Map<OFAuxId, OFBsnControllerConnection> cxns = temp.get(uri);
-
-            // Add to nested map
-            if(cxns != null){
-                cxns.put(update.getAuxiliaryId(), update);
-            } else{
-                cxns = new ConcurrentHashMap<OFAuxId, OFBsnControllerConnection>();
-                cxns.put(update.getAuxiliaryId(), update);
-                temp.put(uri, cxns);
-            }
-        }
-
-        this.controllerConnections = ImmutableMap.<URI,Map<OFAuxId, OFBsnControllerConnection>>copyOf(temp);
-    }
-
-    @Override
-    public boolean hasAnotherMaster() {
-
-        //TODO: refactor get connection to not throw illegal arg exceptions
-        IOFConnection mainCxn = this.getConnection(OFAuxId.MAIN);
-
-        if(mainCxn != null) {
-
-            // Determine the local URI
-            InetSocketAddress address = (InetSocketAddress) mainCxn.getLocalInetAddress();
-            URI localURI = URIUtil.createURI(address.getHostName(), address.getPort());
-
-            for(Entry<URI,Map<OFAuxId, OFBsnControllerConnection>> entry : this.controllerConnections.entrySet()) {
-
-                // Don't check our own controller connections
-                URI uri = entry.getKey();
-                if(!localURI.equals(uri)){
-
-                    // We only care for the MAIN connection
-                    Map<OFAuxId, OFBsnControllerConnection> cxns = this.controllerConnections.get(uri);
-                    OFBsnControllerConnection controllerCxn = cxns.get(OFAuxId.MAIN);
-
-                    if(controllerCxn != null) {
-                        // If the controller id disconnected or not master we know it is not connected
-                        if(controllerCxn.getState() == OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED
-                                && controllerCxn.getRole() == OFControllerRole.ROLE_MASTER){
-                            return true;
-                        }
-                    } else {
-                        log.warn("Unable to find controller connection with aux id "
-                                + "MAIN for switch {} on controller with URI {}.",
-                                  this, uri);
-                    }
-                }
-            }
-        }
-       return false;
-    }
+	protected static final Logger log =
+			LoggerFactory.getLogger(OFSwitch.class);
+
+	protected final ConcurrentMap<Object, Object> attributes;
+	protected final IOFSwitchManager switchManager;
+
+	/* Switch features from initial featuresReply */
+	protected Set<OFCapabilities> capabilities;
+	protected long buffers;
+	protected Set<OFActionType> actions;
+	protected short tables;
+	protected final DatapathId datapathId;
+
+	private boolean startDriverHandshakeCalled = false;
+	private final Map<OFAuxId, IOFConnectionBackend> connections;
+	private volatile Map<URI, Map<OFAuxId, OFBsnControllerConnection>> controllerConnections;
+	protected OFFactory factory;
+
+	/**
+	 * Members hidden from subclasses
+	 */
+	private final PortManager portManager;
+
+	private volatile boolean connected;
+
+	private volatile OFControllerRole role;
+
+	private boolean flowTableFull = false;
+
+	protected SwitchDescription description;
+
+	private SwitchStatus status;
+
+	public static final int OFSWITCH_APP_ID = ident(5);
+
+	static {
+		AppCookie.registerApp(OFSwitch.OFSWITCH_APP_ID, "switch");
+	}
+
+	public OFSwitch(IOFConnectionBackend connection, @Nonnull OFFactory factory, @Nonnull IOFSwitchManager switchManager,
+			@Nonnull DatapathId datapathId) {
+		if(connection == null)
+			throw new NullPointerException("connection must not be null");
+		if(!connection.getAuxId().equals(OFAuxId.MAIN))
+			throw new IllegalArgumentException("connection must be the main connection");
+		if(factory == null)
+			throw new NullPointerException("factory must not be null");
+		if(switchManager == null)
+			throw new NullPointerException("switchManager must not be null");
+
+		this.connected = true;
+		this.factory = factory;
+		this.switchManager = switchManager;
+		this.datapathId = datapathId;
+		this.attributes = new ConcurrentHashMap<Object, Object>();
+		this.role = null;
+		this.description = new SwitchDescription();
+		this.portManager = new PortManager();
+		this.status = SwitchStatus.HANDSHAKE;
+
+		// Connections
+		this.connections = new ConcurrentHashMap<OFAuxId, IOFConnectionBackend>();
+		this.connections.put(connection.getAuxId(), connection);
+
+		// Switch's controller connection
+		this.controllerConnections = ImmutableMap.of();
+
+		// Defaults properties for an ideal switch
+		this.setAttribute(PROP_FASTWILDCARDS, EnumSet.allOf(OFFlowWildcards.class));
+		this.setAttribute(PROP_SUPPORTS_OFPP_FLOOD, Boolean.TRUE);
+		this.setAttribute(PROP_SUPPORTS_OFPP_TABLE, Boolean.TRUE);
+	}
+
+	private static int ident(int i) {
+		return i;
+	}
+
+	@Override
+	public OFFactory getOFFactory() {
+		return factory;
+	}
+
+	/**
+	 * Manages the ports of this switch.
+	 *
+	 * Provides methods to query and update the stored ports. The class ensures
+	 * that every port name and port number is unique. When updating ports
+	 * the class checks if port number <-> port name mappings have change due
+	 * to the update. If a new port P has number and port that are inconsistent
+	 * with the previous mapping(s) the class will delete all previous ports
+	 * with name or number of the new port and then add the new port.
+	 *
+	 * Port names are stored as-is but they are compared case-insensitive
+	 *
+	 * The methods that change the stored ports return a list of
+	 * PortChangeEvents that represent the changes that have been applied
+	 * to the port list so that IOFSwitchListeners can be notified about the
+	 * changes.
+	 *
+	 * Implementation notes:
+	 * - We keep several different representations of the ports to allow for
+	 *   fast lookups
+	 * - Ports are stored in unchangeable lists. When a port is modified new
+	 *   data structures are allocated.
+	 * - We use a read-write-lock for synchronization, so multiple readers are
+	 *   allowed.
+	 */
+	protected static class PortManager {
+		private final ReentrantReadWriteLock lock;
+		private List<OFPortDesc> portList;
+		private List<OFPortDesc> enabledPortList;
+		private List<OFPort> enabledPortNumbers;
+		private Map<OFPort,OFPortDesc> portsByNumber;
+		private Map<String,OFPortDesc> portsByName;
+
+		public PortManager() {
+			this.lock = new ReentrantReadWriteLock();
+			this.portList = Collections.emptyList();
+			this.enabledPortList = Collections.emptyList();
+			this.enabledPortNumbers = Collections.emptyList();
+			this.portsByName = Collections.emptyMap();
+			this.portsByNumber = Collections.emptyMap();
+		}
+
+		/**
+		 * Set the internal data structure storing this switch's port
+		 * to the ports specified by newPortsByNumber
+		 *
+		 * CALLER MUST HOLD WRITELOCK
+		 *
+		 * @param newPortsByNumber
+		 * @throws IllegaalStateException if called without holding the
+		 * writelock
+		 */
+		private void updatePortsWithNewPortsByNumber(
+				Map<OFPort,OFPortDesc> newPortsByNumber) {
+			if (!lock.writeLock().isHeldByCurrentThread()) {
+				throw new IllegalStateException("Method called without " +
+						"holding writeLock");
+			}
+			Map<String,OFPortDesc> newPortsByName =
+					new HashMap<String, OFPortDesc>();
+			List<OFPortDesc> newPortList =
+					new ArrayList<OFPortDesc>();
+			List<OFPortDesc> newEnabledPortList =
+					new ArrayList<OFPortDesc>();
+			List<OFPort> newEnabledPortNumbers = new ArrayList<OFPort>();
+
+			for(OFPortDesc p: newPortsByNumber.values()) {
+				newPortList.add(p);
+				newPortsByName.put(p.getName().toLowerCase(), p);
+				if (!p.getState().contains(OFPortState.LINK_DOWN) 
+						&& !p.getConfig().contains(OFPortConfig.PORT_DOWN)) {
+					newEnabledPortList.add(p);
+					newEnabledPortNumbers.add(p.getPortNo());
+				}
+			}
+			portsByName = Collections.unmodifiableMap(newPortsByName);
+			portsByNumber =
+					Collections.unmodifiableMap(newPortsByNumber);
+			enabledPortList =
+					Collections.unmodifiableList(newEnabledPortList);
+			enabledPortNumbers =
+					Collections.unmodifiableList(newEnabledPortNumbers);
+			portList = Collections.unmodifiableList(newPortList);
+		}
+
+		/**
+		 * Handle a OFPortStatus delete message for the given port.
+		 * Updates the internal port maps/lists of this switch and returns
+		 * the PortChangeEvents caused by the delete. If the given port
+		 * exists as it, it will be deleted. If the name<->number for the
+		 * given port is inconsistent with the ports stored by this switch
+		 * the method will delete all ports with the number or name of the
+		 * given port.
+		 *
+		 * This method will increment error/warn counters and log
+		 *
+		 * @param delPort the port from the port status message that should
+		 * be deleted.
+		 * @return ordered collection of port changes applied to this switch
+		 */
+		private OrderedCollection<PortChangeEvent>
+		handlePortStatusDelete(OFPortDesc delPort) {
+			OrderedCollection<PortChangeEvent> events =
+					new LinkedHashSetWrapper<PortChangeEvent>();
+			lock.writeLock().lock();
+			try {
+				Map<OFPort,OFPortDesc> newPortByNumber =
+						new HashMap<OFPort, OFPortDesc>(portsByNumber);
+				OFPortDesc prevPort =
+						portsByNumber.get(delPort.getPortNo());
+				if (prevPort == null) {
+					// so such port. Do we have a port with the name?
+					prevPort = portsByName.get(delPort.getName());
+					if (prevPort != null) {
+						newPortByNumber.remove(prevPort.getPortNo());
+						events.add(new PortChangeEvent(prevPort,
+								PortChangeType.DELETE));
+					}
+				} else if (prevPort.getName().equals(delPort.getName())) {
+					// port exists with consistent name-number mapping
+					newPortByNumber.remove(delPort.getPortNo());
+					events.add(new PortChangeEvent(delPort,
+							PortChangeType.DELETE));
+				} else {
+					// port with same number exists but its name differs. This
+					// is weird. The best we can do is to delete the existing
+					// port(s) that have delPort's name and number.
+					newPortByNumber.remove(delPort.getPortNo());
+					events.add(new PortChangeEvent(prevPort,
+							PortChangeType.DELETE));
+					// is there another port that has delPort's name?
+					prevPort = portsByName.get(delPort.getName().toLowerCase());
+					if (prevPort != null) {
+						newPortByNumber.remove(prevPort.getPortNo());
+						events.add(new PortChangeEvent(prevPort,
+								PortChangeType.DELETE));
+					}
+				}
+				updatePortsWithNewPortsByNumber(newPortByNumber);
+				return events;
+			} finally {
+				lock.writeLock().unlock();
+			}
+		}
+
+		/**
+		 * Handle a OFPortStatus message, update the internal data structures
+		 * that store ports and return the list of OFChangeEvents.
+		 *
+		 * This method will increment error/warn counters and log
+		 *
+		 * @param ps
+		 * @return
+		 */
+		@SuppressFBWarnings(value="SF_SWITCH_FALLTHROUGH")
+		public OrderedCollection<PortChangeEvent> handlePortStatusMessage(OFPortStatus ps) {
+			if (ps == null) {
+				throw new NullPointerException("OFPortStatus message must " +
+						"not be null");
+			}
+			lock.writeLock().lock();
+			try {
+				OFPortDesc port = ps.getDesc();
+				OFPortReason reason = ps.getReason();
+				if (reason == null) {
+					throw new IllegalArgumentException("Unknown PortStatus " +
+							"reason code " + ps.getReason());
+				}
+
+				if (log.isDebugEnabled()) {
+					log.debug("Handling OFPortStatus: {} for {}",
+							reason, String.format("%s (%d)", port.getName(), port.getPortNo().getPortNumber()));
+				}
+
+				if (reason == OFPortReason.DELETE)
+					return handlePortStatusDelete(port);
+
+				// We handle ADD and MODIFY the same way. Since OpenFlow
+				// doesn't specify what uniquely identifies a port the
+				// notion of ADD vs. MODIFY can also be hazy. So we just
+				// compare the new port to the existing ones.
+				Map<OFPort,OFPortDesc> newPortByNumber =
+						new HashMap<OFPort, OFPortDesc>(portsByNumber);
+				OrderedCollection<PortChangeEvent> events = getSinglePortChanges(port);
+				for (PortChangeEvent e: events) {
+					switch(e.type) {
+					case DELETE:
+						newPortByNumber.remove(e.port.getPortNo());
+						break;
+					case ADD:
+						if (reason != OFPortReason.ADD) {
+							// weird case
+						}
+						// fall through
+					case DOWN:
+					case OTHER_UPDATE:
+					case UP:
+						// update or add the port in the map
+						newPortByNumber.put(e.port.getPortNo(), e.port);
+						break;
+					}
+				}
+				updatePortsWithNewPortsByNumber(newPortByNumber);
+				return events;
+			} finally {
+				lock.writeLock().unlock();
+			}
+
+		}
+
+		/**
+		 * Given a new or modified port newPort, returns the list of
+		 * PortChangeEvents to "transform" the current ports stored by
+		 * this switch to include / represent the new port. The ports stored
+		 * by this switch are <b>NOT</b> updated.
+		 *
+		 * This method acquires the readlock and is thread-safe by itself.
+		 * Most callers will need to acquire the write lock before calling
+		 * this method though (if the caller wants to update the ports stored
+		 * by this switch)
+		 *
+		 * @param newPort the new or modified port.
+		 * @return the list of changes
+		 */
+		public OrderedCollection<PortChangeEvent>
+		getSinglePortChanges(OFPortDesc newPort) {
+			lock.readLock().lock();
+			try {
+				OrderedCollection<PortChangeEvent> events =
+						new LinkedHashSetWrapper<PortChangeEvent>();
+				// Check if we have a port by the same number in our
+				// old map.
+				OFPortDesc prevPort =
+						portsByNumber.get(newPort.getPortNo());
+				if (newPort.equals(prevPort)) {
+					// nothing has changed
+					return events;
+				}
+
+				if (prevPort != null &&
+						prevPort.getName().equals(newPort.getName())) {
+					// A simple modify of a exiting port
+					// A previous port with this number exists and it's name
+					// also matches the new port. Find the differences
+					if ((!prevPort.getState().contains(OFPortState.LINK_DOWN) 
+							&& !prevPort.getConfig().contains(OFPortConfig.PORT_DOWN)) 
+							&& (newPort.getState().contains(OFPortState.LINK_DOWN) 
+									|| newPort.getConfig().contains(OFPortConfig.PORT_DOWN))) {
+						events.add(new PortChangeEvent(newPort,
+								PortChangeType.DOWN));
+					} else if ((prevPort.getState().contains(OFPortState.LINK_DOWN) 
+							|| prevPort.getConfig().contains(OFPortConfig.PORT_DOWN)) 
+							&& (!newPort.getState().contains(OFPortState.LINK_DOWN) 
+									&& !newPort.getConfig().contains(OFPortConfig.PORT_DOWN))) {
+						events.add(new PortChangeEvent(newPort,
+								PortChangeType.UP));
+					} else {
+						events.add(new PortChangeEvent(newPort,
+								PortChangeType.OTHER_UPDATE));
+					}
+					return events;
+				}
+
+				if (prevPort != null) {
+					// There exists a previous port with the same port
+					// number but the port name is different (otherwise we would
+					// never have gotten here)
+					// Remove the port. Name-number mapping(s) have changed
+					events.add(new PortChangeEvent(prevPort,
+							PortChangeType.DELETE));
+				}
+
+				// We now need to check if there exists a previous port sharing
+				// the same name as the new/updated port.
+				prevPort = portsByName.get(newPort.getName().toLowerCase());
+				if (prevPort != null) {
+					// There exists a previous port with the same port
+					// name but the port number is different (otherwise we
+					// never have gotten here).
+					// Remove the port. Name-number mapping(s) have changed
+					events.add(new PortChangeEvent(prevPort,
+							PortChangeType.DELETE));
+				}
+
+				// We always need to add the new port. Either no previous port
+				// existed or we just deleted previous ports with inconsistent
+				// name-number mappings
+				events.add(new PortChangeEvent(newPort, PortChangeType.ADD));
+				return events;
+			} finally {
+				lock.readLock().unlock();
+			}
+		}
+
+		/**
+		 * Compare the current ports of this switch to the newPorts list and
+		 * return the changes that would be applied to transform the current
+		 * ports to the new ports. No internal data structures are updated
+		 * see {@link #compareAndUpdatePorts(List, boolean)}
+		 *
+		 * @param newPorts the list of new ports
+		 * @return The list of differences between the current ports and
+		 * newPortList
+		 */
+		public OrderedCollection<PortChangeEvent>
+		comparePorts(Collection<OFPortDesc> newPorts) {
+			return compareAndUpdatePorts(newPorts, false);
+		}
+
+		/**
+		 * Compare the current ports of this switch to the newPorts list and
+		 * return the changes that would be applied to transform the current
+		 * ports to the new ports. No internal data structures are updated
+		 * see {@link #compareAndUpdatePorts(List, boolean)}
+		 *
+		 * @param newPorts the list of new ports
+		 * @return The list of differences between the current ports and
+		 * newPortList
+		 */
+		public OrderedCollection<PortChangeEvent>
+		updatePorts(Collection<OFPortDesc> newPorts) {
+			return compareAndUpdatePorts(newPorts, true);
+		}
+
+		/**
+		 * Compare the current ports stored in this switch instance with the
+		 * new port list given and return the differences in the form of
+		 * PortChangeEvents. If the doUpdate flag is true, newPortList will
+		 * replace the current list of this switch (and update the port maps)
+		 *
+		 * Implementation note:
+		 * Since this method can optionally modify the current ports and
+		 * since it's not possible to upgrade a read-lock to a write-lock
+		 * we need to hold the write-lock for the entire operation. If this
+		 * becomes a problem and if compares() are common we can consider
+		 * splitting in two methods but this requires lots of code duplication
+		 *
+		 * @param newPorts the list of new ports.
+		 * @param doUpdate If true the newPortList will replace the current
+		 * port list for this switch. If false this switch will not be changed.
+		 * @return The list of differences between the current ports and
+		 * newPorts
+		 * @throws NullPointerException if newPortsList is null
+		 * @throws IllegalArgumentException if either port names or port numbers
+		 * are duplicated in the newPortsList.
+		 */
+		private OrderedCollection<PortChangeEvent> compareAndUpdatePorts(
+				Collection<OFPortDesc> newPorts,
+				boolean doUpdate) {
+			if (newPorts == null) {
+				throw new NullPointerException("newPortsList must not be null");
+			}
+			lock.writeLock().lock();
+			try {
+				OrderedCollection<PortChangeEvent> events =
+						new LinkedHashSetWrapper<PortChangeEvent>();
+
+				Map<OFPort,OFPortDesc> newPortsByNumber =
+						new HashMap<OFPort, OFPortDesc>();
+				Map<String,OFPortDesc> newPortsByName =
+						new HashMap<String, OFPortDesc>();
+				List<OFPortDesc> newEnabledPortList =
+						new ArrayList<OFPortDesc>();
+				List<OFPort> newEnabledPortNumbers =
+						new ArrayList<OFPort>();
+				List<OFPortDesc> newPortsList =
+						new ArrayList<OFPortDesc>(newPorts);
+
+				for (OFPortDesc p: newPortsList) {
+					if (p == null) {
+						throw new NullPointerException("portList must not " +
+								"contain null values");
+					}
+
+					// Add the port to the new maps and lists and check
+					// that every port is unique
+					OFPortDesc duplicatePort;
+					duplicatePort = newPortsByNumber.put(p.getPortNo(), p);
+					if (duplicatePort != null) {
+						String msg = String.format("Cannot have two ports " +
+								"with the same number: %s <-> %s",
+								String.format("%s (%d)", p.getName(), p.getPortNo().getPortNumber()),
+								String.format("%s (%d)", duplicatePort.getName(), duplicatePort.getPortNo().getPortNumber()));
+						throw new IllegalArgumentException(msg);
+					}
+					duplicatePort =
+							newPortsByName.put(p.getName().toLowerCase(), p);
+					if (duplicatePort != null) {
+						String msg = String.format("Cannot have two ports " +
+								"with the same name: %s <-> %s",
+								String.format("%s (%d)", p.getName(), p.getPortNo().getPortNumber()),
+								String.format("%s (%d)", duplicatePort.getName(), duplicatePort.getPortNo().getPortNumber()));
+						throw new IllegalArgumentException(msg);
+					}
+					// Enabled = not down admin (config) or phys (state)
+					if (!p.getConfig().contains(OFPortConfig.PORT_DOWN)
+							&& !p.getState().contains(OFPortState.LINK_DOWN)) {
+						newEnabledPortList.add(p);
+						newEnabledPortNumbers.add(p.getPortNo());
+					}
+
+					// get changes
+					events.addAll(getSinglePortChanges(p));
+				}
+				// find deleted ports
+				// We need to do this after looping through all the new ports
+				// to we can handle changed name<->number mappings correctly
+				// We could pull it into the loop of we address this but
+				// it's probably not worth it
+				for (OFPortDesc oldPort: this.portList) {
+					if (!newPortsByNumber.containsKey(oldPort.getPortNo())) {
+						PortChangeEvent ev =
+								new PortChangeEvent(oldPort,
+										PortChangeType.DELETE);
+						events.add(ev);
+					}
+				}
+
+
+				if (doUpdate) {
+					portsByName = Collections.unmodifiableMap(newPortsByName);
+					portsByNumber =
+							Collections.unmodifiableMap(newPortsByNumber);
+					enabledPortList =
+							Collections.unmodifiableList(newEnabledPortList);
+					enabledPortNumbers =
+							Collections.unmodifiableList(newEnabledPortNumbers);
+					portList = Collections.unmodifiableList(newPortsList);
+				}
+				return events;
+			} finally {
+				lock.writeLock().unlock();
+			}
+		}
+
+		public OFPortDesc getPort(String name) {
+			if (name == null) {
+				throw new NullPointerException("Port name must not be null");
+			}
+			lock.readLock().lock();
+			try {
+				return portsByName.get(name.toLowerCase());
+			} finally {
+				lock.readLock().unlock();
+			}
+		}
+
+		public OFPortDesc getPort(OFPort portNumber) {
+			lock.readLock().lock();
+			try {
+				return portsByNumber.get(portNumber);
+			} finally {
+				lock.readLock().unlock();
+			}
+		}
+
+		public List<OFPortDesc> getPorts() {
+			lock.readLock().lock();
+			try {
+				return portList;
+			} finally {
+				lock.readLock().unlock();
+			}
+		}
+
+		public List<OFPortDesc> getEnabledPorts() {
+			lock.readLock().lock();
+			try {
+				return enabledPortList;
+			} finally {
+				lock.readLock().unlock();
+			}
+		}
+
+		public List<OFPort> getEnabledPortNumbers() {
+			lock.readLock().lock();
+			try {
+				return enabledPortNumbers;
+			} finally {
+				lock.readLock().unlock();
+			}
+		}
+	}
+
+	@Override
+	public boolean attributeEquals(String name, Object other) {
+		Object attr = this.attributes.get(name);
+		if (attr == null)
+			return false;
+		return attr.equals(other);
+	}
+
+	@Override
+	public Object getAttribute(String name) {
+		// returns null if key doesn't exist
+		return this.attributes.get(name);
+	}
+
+	@Override
+	public void setAttribute(String name, Object value) {
+		this.attributes.put(name, value);
+		return;
+	}
+
+	@Override
+	public Object removeAttribute(String name) {
+		return this.attributes.remove(name);
+	}
+
+	@Override
+	public boolean hasAttribute(String name) {
+		return this.attributes.containsKey(name);
+	}
+
+	@Override
+	public void registerConnection(IOFConnectionBackend connection) {
+		this.connections.put(connection.getAuxId(), connection);
+	}
+
+
+	@Override
+	public ImmutableList<IOFConnection> getConnections() {
+		return ImmutableList.<IOFConnection> copyOf(this.connections.values());
+	}
+
+	@Override
+	public void removeConnections() {
+		this.connections.clear();
+	}
+
+	@Override
+	public void removeConnection(IOFConnectionBackend connection) {
+		this.connections.remove(connection.getAuxId());
+	}
+
+	@Override
+	public void write(OFMessage m) {
+		log.trace("Channel: {}, Connected: {}", connections.get(OFAuxId.MAIN).getRemoteInetAddress(), connections.get(OFAuxId.MAIN).isConnected());
+		if (isActive()) {
+			connections.get(OFAuxId.MAIN).write(m);
+		} else {
+			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
+		}
+	}
+
+	/**
+	 * Gets a connection specified by aux Id.
+	 * @param auxId the specified aux id for the connection desired.
+	 * @return the aux connection specified by the auxId
+	 */
+	public IOFConnection getConnection(OFAuxId auxId) {
+		IOFConnection connection = this.connections.get(auxId);
+		if(connection == null){
+			throw new IllegalArgumentException("OF Connection for " + this + " with " + auxId + " does not exist.");
+		}
+		return connection;
+	}
+
+	public IOFConnection getConnection(LogicalOFMessageCategory category) {
+		if(switchManager.isCategoryRegistered(category)){
+			return getConnection(category.getAuxId());
+		}
+		else{
+			throw new IllegalArgumentException(category + " is not registered with the floodlight provider service.");
+		}
+	}
+
+	@Override
+	public void write(OFMessage m, LogicalOFMessageCategory category) {
+		if (isActive()) {
+			this.getConnection(category).write(m);
+		} else {
+			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
+		}
+	}
+
+	@Override
+	public void write(Iterable<OFMessage> msglist, LogicalOFMessageCategory category) {
+		if (isActive()) {
+			this.getConnection(category).write(msglist);
+		} else {
+			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
+		}
+	}
+
+	@Override
+	public OFConnection getConnectionByCategory(LogicalOFMessageCategory category){
+		return (OFConnection) this.getConnection(category);
+	}
+
+	@Override
+	public <R extends OFMessage> ListenableFuture<R> writeRequest(OFRequest<R> request, LogicalOFMessageCategory category) {
+		return getConnection(category).writeRequest(request);
+	}
+
+	@Override
+	public <R extends OFMessage> ListenableFuture<R> writeRequest(OFRequest<R> request) {
+		return connections.get(OFAuxId.MAIN).writeRequest(request);
+	}
+
+	@Override
+	@LogMessageDoc(level="WARN",
+	message="Sending OF message that modifies switch " +
+			"state while in the slave role: {switch}",
+			explanation="An application has sent a message to a switch " +
+					"that is not valid when the switch is in a slave role",
+					recommendation=LogMessageDoc.REPORT_CONTROLLER_BUG)
+	public void write(Iterable<OFMessage> msglist) {
+		if (isActive()) {
+			connections.get(OFAuxId.MAIN).write(msglist);
+		} else {
+			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
+		}
+	}
+
+	@Override
+	public void disconnect() {
+
+		// Iterate through connections and perform cleanup
+		for(Entry<OFAuxId, IOFConnectionBackend> entry : this.connections.entrySet()){
+			entry.getValue().disconnect();
+			this.connections.remove(entry.getKey());
+		}
+		log.debug("~~~~~~~SWITCH DISCONNECTED~~~~~~");
+		// Remove all counters from the store
+		connected = false;
+	}
+
+	@Override
+	public void setFeaturesReply(OFFeaturesReply featuresReply) {
+		if (portManager.getPorts().isEmpty() && featuresReply.getVersion().compareTo(OFVersion.OF_13) < 0) {
+			/* ports are updated via port status message, so we
+			 * only fill in ports on initial connection.
+			 */
+			List<OFPortDesc> OFPortDescs = featuresReply.getPorts();
+			portManager.updatePorts(OFPortDescs);
+		}
+		this.capabilities = featuresReply.getCapabilities();
+		this.buffers = featuresReply.getNBuffers();
+
+		if (featuresReply.getVersion().compareTo(OFVersion.OF_13) < 0 ) {
+			// FIXME:LOJI: OF1.3 has per table actions. This needs to be modeled / handled here
+			this.actions = featuresReply.getActions();
+		}
+		this.tables = featuresReply.getNTables();
+	}
+
+	@Override
+	public void setPortDescStats(OFPortDescStatsReply reply) {
+		/* ports are updated via port status message, so we
+		 * only fill in ports on initial connection.
+		 */
+		List<OFPortDesc> OFPortDescs = reply.getEntries();
+		portManager.updatePorts(OFPortDescs);
+	}
+
+	@Override
+	public Collection<OFPortDesc> getEnabledPorts() {
+		return portManager.getEnabledPorts();
+	}
+
+	@Override
+	public Collection<OFPort> getEnabledPortNumbers() {
+		return portManager.getEnabledPortNumbers();
+	}
+
+	@Override
+	public OFPortDesc getPort(OFPort portNumber) {
+		return portManager.getPort(portNumber);
+	}
+
+	@Override
+	public OFPortDesc getPort(String portName) {
+		return portManager.getPort(portName);
+	}
+
+	@Override
+	public OrderedCollection<PortChangeEvent>
+	processOFPortStatus(OFPortStatus ps) {
+		return portManager.handlePortStatusMessage(ps);
+	}
+
+	@Override
+	public Collection<OFPortDesc> getSortedPorts() {
+		List<OFPortDesc> sortedPorts =
+				new ArrayList<OFPortDesc>(portManager.getPorts());
+		Collections.sort(sortedPorts, new Comparator<OFPortDesc>() {
+			@Override
+			public int compare(OFPortDesc o1, OFPortDesc o2) {
+				String name1 = o1.getName();
+				String name2 = o2.getName();
+				return name1.compareToIgnoreCase(name2);
+			}
+		});
+		return sortedPorts;
+	}
+
+	@Override
+	public Collection<OFPortDesc> getPorts() {
+		return portManager.getPorts();
+	}
+
+	@Override
+	public OrderedCollection<PortChangeEvent>
+	comparePorts(Collection<OFPortDesc> ports) {
+		return portManager.comparePorts(ports);
+	}
+
+	@Override
+	public OrderedCollection<PortChangeEvent>
+	setPorts(Collection<OFPortDesc> ports) {
+		return portManager.updatePorts(ports);
+	}
+
+	@Override
+	public boolean portEnabled(OFPort portNumber) {
+		OFPortDesc p = portManager.getPort(portNumber);
+		if (p == null) return false;
+		return (!p.getState().contains(OFPortState.BLOCKED) && !p.getState().contains(OFPortState.LINK_DOWN) && !p.getState().contains(OFPortState.STP_BLOCK));
+	}
+
+	@Override
+	public boolean portEnabled(String portName) {
+		OFPortDesc p = portManager.getPort(portName);
+		if (p == null) return false;
+		return (!p.getState().contains(OFPortState.BLOCKED) && !p.getState().contains(OFPortState.LINK_DOWN) && !p.getState().contains(OFPortState.STP_BLOCK));
+	}
+
+	@Override
+	public DatapathId getId() {
+		if (datapathId == null)
+			throw new RuntimeException("Features reply has not yet been set");
+		return datapathId;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return "OFSwitchBase DPID[" + ((datapathId != null) ? datapathId.toString() : "?") + "]";
+	}
+
+	@Override
+	public ConcurrentMap<Object, Object> getAttributes() {
+		return this.attributes;
+	}
+
+	@Override
+	public Date getConnectedSince() {
+		return this.connections.get(OFAuxId.MAIN).getConnectedSince();
+	}
+
+	@Override
+	public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request) {
+		return connections.get(OFAuxId.MAIN).writeStatsRequest(request);
+	}
+
+	@Override
+	public <REPLY extends OFStatsReply> ListenableFuture<List<REPLY>> writeStatsRequest(OFStatsRequest<REPLY> request, LogicalOFMessageCategory category) {
+		return getConnection(category).writeStatsRequest(request);
+	}
+
+	@Override
+	public void cancelAllPendingRequests() {
+		for(Entry<OFAuxId, IOFConnectionBackend> entry : this.connections.entrySet()){
+			entry.getValue().cancelAllPendingRequests();
+		}
+	}
+
+	// If any connections are down consider a switch disconnected
+	@Override
+	public boolean isConnected() {
+		return connected;
+	}
+
+	@Override
+	public boolean isActive() {
+		// no lock needed since we use volatile
+		return isConnected() && (this.role == OFControllerRole.ROLE_MASTER || this.role == OFControllerRole.ROLE_EQUAL);
+	}
+
+	@Override
+	public OFControllerRole getControllerRole() {
+		return role;
+	}
+
+	@Override
+	public void setControllerRole(OFControllerRole role) {
+		this.role = role;
+	}
+
+	@Override
+	public void flush() {
+		for(Entry<OFAuxId, IOFConnectionBackend> entry : this.connections.entrySet()){
+			entry.getValue().flush();
+		}
+	}
+
+	/**
+	 * Get the IP Address for the switch
+	 * @return the inet address
+	 */
+	@Override
+	public SocketAddress getInetAddress() {
+		return connections.get(OFAuxId.MAIN).getRemoteInetAddress();
+	}
+
+	@Override
+	public long getBuffers() {
+		return buffers;
+	}
+
+
+	@Override
+	public Set<OFActionType> getActions() {
+		return actions;
+	}
+
+
+	@Override
+	public Set<OFCapabilities> getCapabilities() {
+		return capabilities;
+	}
+
+
+	@Override
+	public short getTables() {
+		return tables;
+	}
+
+	@Override
+	public SwitchDescription getSwitchDescription() {
+		return description;
+	}
+
+	@Override
+	@LogMessageDoc(level="WARN",
+	message="Switch {switch} flow table is full",
+	explanation="The controller received flow table full " +
+			"message from the switch, could be caused by increased " +
+			"traffic pattern",
+			recommendation=LogMessageDoc.REPORT_CONTROLLER_BUG)
+	public void setTableFull(boolean isFull) {
+		if (isFull && !flowTableFull) {
+			switchManager.addSwitchEvent(this.datapathId,
+					"SWITCH_FLOW_TABLE_FULL " +
+							"Table full error from switch", false);
+			log.warn("Switch {} flow table is full", datapathId.toString());
+		}
+		flowTableFull = isFull;
+	}
+
+	@Override
+	public void startDriverHandshake() {
+		if (startDriverHandshakeCalled)
+			throw new SwitchDriverSubHandshakeAlreadyStarted();
+		startDriverHandshakeCalled = true;
+	}
+
+	@Override
+	public boolean isDriverHandshakeComplete() {
+		if (!startDriverHandshakeCalled)
+			throw new SwitchDriverSubHandshakeNotStarted();
+		return true;
+	}
+
+	@Override
+	public void processDriverHandshakeMessage(OFMessage m) {
+		if (startDriverHandshakeCalled)
+			throw new SwitchDriverSubHandshakeCompleted(m);
+		else
+			throw new SwitchDriverSubHandshakeNotStarted();
+	}
+
+	@Override
+	public void setSwitchProperties(SwitchDescription description) {
+		this.description = description;
+	}
+
+
+	@Override
+	public SwitchStatus getStatus() {
+		return status;
+	}
+
+	@Override
+	public void setStatus(SwitchStatus switchStatus) {
+		this.status = switchStatus;
+	}
+
+	@Override
+	public void updateControllerConnections(OFBsnControllerConnectionsReply controllerCxnsReply) {
+
+		// Instantiate clean map, can't use a builder here since we need to call temp.get()
+		Map<URI,Map<OFAuxId, OFBsnControllerConnection>> temp = new ConcurrentHashMap<URI,Map<OFAuxId, OFBsnControllerConnection>>();
+
+		List<OFBsnControllerConnection> controllerCxnUpdates = controllerCxnsReply.getConnections();
+		for(OFBsnControllerConnection update : controllerCxnUpdates) {
+			URI uri = URI.create(update.getUri());
+
+			Map<OFAuxId, OFBsnControllerConnection> cxns = temp.get(uri);
+
+			// Add to nested map
+			if(cxns != null){
+				cxns.put(update.getAuxiliaryId(), update);
+			} else{
+				cxns = new ConcurrentHashMap<OFAuxId, OFBsnControllerConnection>();
+				cxns.put(update.getAuxiliaryId(), update);
+				temp.put(uri, cxns);
+			}
+		}
+
+		this.controllerConnections = ImmutableMap.<URI,Map<OFAuxId, OFBsnControllerConnection>>copyOf(temp);
+	}
+
+	@Override
+	public boolean hasAnotherMaster() {
+
+		//TODO: refactor get connection to not throw illegal arg exceptions
+		IOFConnection mainCxn = this.getConnection(OFAuxId.MAIN);
+
+		if(mainCxn != null) {
+
+			// Determine the local URI
+			InetSocketAddress address = (InetSocketAddress) mainCxn.getLocalInetAddress();
+			URI localURI = URIUtil.createURI(address.getHostName(), address.getPort());
+
+			for(Entry<URI,Map<OFAuxId, OFBsnControllerConnection>> entry : this.controllerConnections.entrySet()) {
+
+				// Don't check our own controller connections
+				URI uri = entry.getKey();
+				if(!localURI.equals(uri)){
+
+					// We only care for the MAIN connection
+					Map<OFAuxId, OFBsnControllerConnection> cxns = this.controllerConnections.get(uri);
+					OFBsnControllerConnection controllerCxn = cxns.get(OFAuxId.MAIN);
+
+					if(controllerCxn != null) {
+						// If the controller id disconnected or not master we know it is not connected
+						if(controllerCxn.getState() == OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED
+								&& controllerCxn.getRole() == OFControllerRole.ROLE_MASTER){
+							return true;
+						}
+					} else {
+						log.warn("Unable to find controller connection with aux id "
+								+ "MAIN for switch {} on controller with URI {}.",
+								this, uri);
+					}
+				}
+			}
+		}
+		return false;
+	}
 }

--- a/src/main/java/net/floodlightcontroller/core/internal/IOFConnectionListener.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/IOFConnectionListener.java
@@ -7,6 +7,18 @@ public interface IOFConnectionListener {
     void connectionClosed(IOFConnectionBackend connection);
 
     void messageReceived(IOFConnectionBackend connection, OFMessage m);
-
+    
+    /**
+     * Primarily for role requests, we need a way to tell the OFSwitchHandshakeHandler
+     * that we've just sent a message (from e.g. a module). In this way, it'll list the
+     * request as pending and be able to receive and process the reply 
+     * from messageReceived() later when the reply with the correct XID comes in. This
+     * will ensure the OFSwitchHandshakeHandler is always in the correct state.
+     * 
+     * @param connection
+     * @param m
+     */
+    void messageWritten(IOFConnectionBackend connection, OFMessage m);
+	
     boolean isSwitchHandshakeComplete(IOFConnectionBackend connection);
 }

--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitchHandshakeHandler.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitchHandshakeHandler.java
@@ -101,7 +101,7 @@ public class OFSwitchHandshakeHandler implements IOFConnectionListener {
 	private final OFFeaturesReply featuresReply;
 	private final Timer timer;
 	
-	private volatile boolean visitedMaster = false;
+	private volatile OFControllerRole initialRole = null;
 
 	private final ArrayList<OFPortStatus> pendingPortStatusMsg;
 
@@ -1234,8 +1234,8 @@ public class OFSwitchHandshakeHandler implements IOFConnectionListener {
 			if (OFSwitchManager.clearTablesOnEachTransitionToMaster) {
 				log.info("Clearing flow tables of {} on recent transition to MASTER.", sw.getId().toString());
 				clearAllTables();
-			} else if (OFSwitchManager.clearTablesOnInitialConnectAsMaster && !visitedMaster) {
-				visitedMaster = true;
+			} else if (OFSwitchManager.clearTablesOnInitialConnectAsMaster && initialRole == null) { /* don't do it if we were slave first */
+				initialRole = OFControllerRole.ROLE_MASTER;
 				log.info("Clearing flow tables of {} on initial role as MASTER.", sw.getId().toString());
 				clearAllTables();
 			}
@@ -1367,6 +1367,9 @@ public class OFSwitchHandshakeHandler implements IOFConnectionListener {
 		@Override
 		void enterState() {
 			setSwitchStatus(SwitchStatus.SLAVE);
+			if (initialRole == null) {
+				initialRole = OFControllerRole.ROLE_SLAVE;
+			}
 		}
 
 		@Override

--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitchManager.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitchManager.java
@@ -93,6 +93,9 @@ public class OFSwitchManager implements IOFSwitchManager, INewOFConnectionListen
 	private static String keyStorePassword;
 	private static String keyStore;
 	private static boolean useSsl = false;
+	
+	protected static boolean clearTablesOnInitialConnectAsMaster = false;
+	protected static boolean clearTablesOnEachTransitionToMaster = false;
 
 	private ConcurrentHashMap<DatapathId, OFSwitchHandshakeHandler> switchHandlers;
 	private ConcurrentHashMap<DatapathId, IOFSwitchBackend> switches;
@@ -681,6 +684,36 @@ public class OFSwitchManager implements IOFSwitchManager, INewOFConnectionListen
 			OFSwitchManager.useSsl = true;
 			OFSwitchManager.keyStore = path;
 			OFSwitchManager.keyStorePassword = (pass == null ? "" : pass);
+		}
+		
+		/*
+		 * Get config to define what to do when a switch connects.
+		 * 
+		 * If a field is blank or unspecified, it will default
+		 */
+		String clearInitial = configParams.get("clearTablesOnInitialHandshakeAsMaster");
+		String clearLater = configParams.get("clearTablesOnEachTransitionToMaster");
+		
+		if (clearInitial == null || clearInitial.isEmpty() || 
+				(!clearInitial.equalsIgnoreCase("yes") && !clearInitial.equalsIgnoreCase("true") &&
+				!clearInitial.equalsIgnoreCase("yep") && !clearInitial.equalsIgnoreCase("ja") &&
+				!clearInitial.equalsIgnoreCase("stimmt"))) {
+			log.warn("Clear switch flow tables on initial handshake as master: FALSE");
+			OFSwitchManager.clearTablesOnInitialConnectAsMaster = false;
+		} else {
+			log.warn("Clear switch flow tables on initial handshake as master: TRUE");
+			OFSwitchManager.clearTablesOnInitialConnectAsMaster = true;
+		}
+		
+		if (clearLater == null || clearLater.isEmpty() || 
+				(!clearLater.equalsIgnoreCase("yes") && !clearLater.equalsIgnoreCase("true") &&
+				!clearLater.equalsIgnoreCase("yep") && !clearLater.equalsIgnoreCase("ja") &&
+				!clearLater.equalsIgnoreCase("stimmt"))) {
+			log.warn("Clear switch flow tables on each transition to master: FALSE");
+			OFSwitchManager.clearTablesOnEachTransitionToMaster = false;
+		} else {
+			log.warn("Clear switch flow tables on each transition to master: TRUE");
+			OFSwitchManager.clearTablesOnEachTransitionToMaster = true;
 		}
 	}
 

--- a/src/main/java/net/floodlightcontroller/core/internal/RoleManager.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/RoleManager.java
@@ -30,7 +30,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * switch(-channel) so it can notify the switches of role changes.
  *
  * We need to ensure that every connected switch is always send the
- * correct role. Therefore, switch add, sending of the intial role, and
+ * correct role. Therefore, switch add, sending of the initial role, and
  * changing role need to use mutexes to ensure this. This has the ugly
  * side-effect of requiring calls between controller and OFChannelHandler
  *

--- a/src/main/java/net/floodlightcontroller/core/internal/RoleManager.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/RoleManager.java
@@ -125,7 +125,6 @@ public class RoleManager {
         currentRoleInfo =
                 new RoleInfo(role, roleChangeDescription, new Date());
 
-        // NOTE: HARoleUpdate will terminate floodlight on transition to STANDBY
         controller.addUpdateToQueue(new HARoleUpdate(role));
         controller.addUpdateToQueue(new SwitchRoleUpdate(role));
 

--- a/src/main/java/net/floodlightcontroller/core/web/ControllerRoleResource.java
+++ b/src/main/java/net/floodlightcontroller/core/web/ControllerRoleResource.java
@@ -16,6 +16,10 @@
 
 package net.floodlightcontroller.core.web;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.restlet.data.Status;
 import org.restlet.resource.ServerResource;
 
@@ -29,49 +33,112 @@ import org.restlet.resource.Post;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+
 public class ControllerRoleResource extends ServerResource {
 
     protected static Logger log = LoggerFactory.getLogger(ControllerRoleResource.class);
+    
+    private static final String STR_ACTIVE = "ACTIVE";
+    private static final String STR_STANDBY = "STANDBY";
+    private static final String STR_ROLE = "role";
+    private static final String STR_ROLE_CHANGE_DESC = "role-change-description";
+    private static final String STR_ROLE_CHANGE_DATE_TIME = "role-change-date-time";
 
     @Get("json")
-    public RoleInfo getRole() {
+    public Map<String, String> getRole() {
         IFloodlightProviderService floodlightProvider =
                 (IFloodlightProviderService)getContext().getAttributes().
                     get(IFloodlightProviderService.class.getCanonicalName());
-        return floodlightProvider.getRoleInfo();
+        Map<String, String> retValue = new HashMap<String, String>();
+        RoleInfo ri = floodlightProvider.getRoleInfo();
+        retValue.put(STR_ROLE, ri.getRole().toString());
+        retValue.put(STR_ROLE_CHANGE_DESC, ri.getRoleChangeDescription());
+        retValue.put(STR_ROLE_CHANGE_DATE_TIME, ri.getRoleChangeDateTime().toString());
+        return retValue;
     }
 
-    @Post("json")
+    @Post
     @LogMessageDoc(level="WARN",
                    message="Invalid role value specified in REST API to " +
                       "set controller role",
                    explanation="An HA role change request was malformed.",
                    recommendation=LogMessageDoc.CHECK_CONTROLLER)
-    public void setRole(RoleInfo roleInfo) {
-        //Role role = Role.lookupRole(roleInfo.getRole());
-        HARole role = null;
-        try {
-            role = roleInfo.getRole();
-        }
-        catch (IllegalArgumentException e) {
-            // The role value in the REST call didn't match a valid
-            // role name, so just leave the role as null and handle
-            // the error below.
-        }
-        if (role == null) {
-            log.warn ("Invalid role value specified in REST API to " +
-            		  "set controller role");
-            setStatus(Status.CLIENT_ERROR_BAD_REQUEST, "Invalid role value");
-            return;
-        }
-        String roleChangeDescription = roleInfo.getRoleChangeDescription();
-        if (roleChangeDescription == null)
-            roleChangeDescription = "<none>";
+    public Map<String, String> setRole(String json) {
+    	Map<String, String> retValue = new HashMap<String, String>();
 
         IFloodlightProviderService floodlightProvider =
                 (IFloodlightProviderService)getContext().getAttributes().
                     get(IFloodlightProviderService.class.getCanonicalName());
+        
+		MappingJsonFactory f = new MappingJsonFactory();
+		JsonParser jp = null;
+		String role = null;
+		String roleChangeDesc = null;
+		
+		retValue.put("TBD", "Not yet implemented");
+		return retValue;
+		/*
+		try {
+			try {
+				jp = f.createJsonParser(json);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
 
-        floodlightProvider.setRole(role, roleChangeDescription);
+
+			jp.nextToken();
+			if (jp.getCurrentToken() != JsonToken.START_OBJECT) {
+				throw new IOException("Expected START_OBJECT");
+			}
+
+			while (jp.nextToken() != JsonToken.END_OBJECT) {
+				if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {
+					throw new IOException("Expected FIELD_NAME");
+				}
+
+				String n = jp.getCurrentName().toLowerCase();
+				jp.nextToken();
+
+				switch (n) {
+				case STR_ROLE:
+					role = jp.getText();
+					break;
+				case STR_ROLE_CHANGE_DESC:
+					roleChangeDesc = jp.getText();
+					break;
+				default:
+					retValue.put("ERROR", "Unrecognized JSON key.");
+					break;
+				}
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+			retValue.put("ERROR", "Caught IOException while parsing JSON POST request in role request.");
+		}
+    
+        HARole harole = null;
+        try {
+        	harole = HARole.valueOfBackwardsCompatible(role);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            // The role value in the REST call didn't match a valid
+            // role name, so just leave the role as null and handle
+            // the error below.
+        }
+
+        if (roleChangeDesc == null) {
+            roleChangeDesc = "<none>";
+        }
+
+        floodlightProvider.setRole(harole, roleChangeDesc);
+        
+        RoleInfo ri = floodlightProvider.getRoleInfo();
+        retValue.put(STR_ROLE, ri.getRole().toString());
+        retValue.put(STR_ROLE_CHANGE_DESC, ri.getRoleChangeDescription());
+        retValue.put(STR_ROLE_CHANGE_DATE_TIME, ri.getRoleChangeDateTime().toString());
+        
+		return retValue;*/
     }
 }

--- a/src/main/java/net/floodlightcontroller/core/web/CoreWebRoutable.java
+++ b/src/main/java/net/floodlightcontroller/core/web/CoreWebRoutable.java
@@ -37,6 +37,7 @@ public class CoreWebRoutable implements RestletRoutable {
 	public static final String STR_CTR_MODULE = "counterModule";
 	public static final String STR_LAYER = "layer";
 	public static final String STR_ALL = "all";
+	public static final String STR_ROLE = "role";
 	
     @Override
     public String basePath() {

--- a/src/main/java/net/floodlightcontroller/core/web/SwitchRoleResource.java
+++ b/src/main/java/net/floodlightcontroller/core/web/SwitchRoleResource.java
@@ -16,10 +16,23 @@
 
 package net.floodlightcontroller.core.web;
 
+import java.io.IOException;
+import java.lang.Thread.State;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.projectfloodlight.openflow.protocol.OFControllerRole;
+import org.projectfloodlight.openflow.protocol.OFFactories;
+import org.projectfloodlight.openflow.protocol.OFNiciraControllerRole;
+import org.projectfloodlight.openflow.protocol.OFNiciraControllerRoleReply;
+import org.projectfloodlight.openflow.protocol.OFRoleReply;
+import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.U64;
+import org.restlet.resource.Post;
 import org.restlet.resource.ServerResource;
 
 import net.floodlightcontroller.core.IOFSwitch;
@@ -29,31 +42,275 @@ import org.restlet.resource.Get;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.google.common.util.concurrent.ListenableFuture;
+
 public class SwitchRoleResource extends ServerResource {
 
-    protected static Logger log = LoggerFactory.getLogger(SwitchRoleResource.class);
+	protected static Logger log = LoggerFactory.getLogger(SwitchRoleResource.class);
 
-    @Get("json")
-    public Object getRole() {
-    	IOFSwitchService switchService =
-                (IOFSwitchService)getContext().getAttributes().
-                    get(IOFSwitchService.class.getCanonicalName());
+	private static final String STR_ROLE_PREFIX = "ROLE_"; /* enum OFControllerRole is ROLE_XXX, so trim the ROLE_ when printing */
+	private static final String STR_ROLE_MASTER = "MASTER"; /* these are all assumed uppercase within this class */
+	private static final String STR_ROLE_SLAVE = "SLAVE";
+	private static final String STR_ROLE_EQUAL = "EQUAL";
+	private static final String STR_ROLE_OTHER = "OTHER";
 
-        String switchId = (String) getRequestAttributes().get(CoreWebRoutable.STR_SWITCH_ID);
+	@Get("json")
+	public Map<String, String> getRole() {
+		IOFSwitchService switchService =
+				(IOFSwitchService)getContext().getAttributes().
+				get(IOFSwitchService.class.getCanonicalName());
 
-        if (switchId.equalsIgnoreCase(CoreWebRoutable.STR_ALL)) {
-            HashMap<String, OFControllerRole> model = new HashMap<String, OFControllerRole>();
-            for (IOFSwitch sw: switchService.getAllSwitchMap().values()) {
-                switchId = sw.getId().toString();
-                model.put(switchId, sw.getControllerRole());
-            }
-            return model;
-        }
+		String switchId = (String) getRequestAttributes().get(CoreWebRoutable.STR_SWITCH_ID);
+		HashMap<String, String> model = new HashMap<String, String>();
 
-        DatapathId dpid = DatapathId.of(switchId);
-        IOFSwitch sw = switchService.getSwitch(dpid);
-        if (sw == null)
-            return null;
-        return sw.getControllerRole();
-    }
+		if (switchId.equalsIgnoreCase(CoreWebRoutable.STR_ALL)) {
+			for (IOFSwitch sw: switchService.getAllSwitchMap().values()) {
+				switchId = sw.getId().toString();
+				model.put(switchId, sw.getControllerRole().toString().replaceFirst(STR_ROLE_PREFIX, "")); 
+			}
+			return model;
+		} else {
+			try {
+				DatapathId dpid = DatapathId.of(switchId);
+				IOFSwitch sw = switchService.getSwitch(dpid);
+				if (sw == null) {
+					model.put("ERROR", "Switch Manager could not locate switch DPID " + dpid.toString());
+					return model;
+				} else {
+					model.put(dpid.toString(), sw.getControllerRole().toString().replaceFirst(STR_ROLE_PREFIX, ""));
+					return model;
+				}
+			} catch (Exception e) {
+				model.put("ERROR", "Could not parse switch DPID " + switchId);
+				return model;
+			}	
+		}
+	}
+
+	/* for some reason @Post("json") isn't working here... */
+	@Post
+	public Map<String, String> setRole(String json) {
+		IOFSwitchService switchService =
+				(IOFSwitchService)getContext().getAttributes().
+				get(IOFSwitchService.class.getCanonicalName());
+		Map<String, String> retValue = new HashMap<String, String>();
+
+		String switchId = (String) getRequestAttributes().get(CoreWebRoutable.STR_SWITCH_ID);
+
+		MappingJsonFactory f = new MappingJsonFactory();
+		JsonParser jp = null;
+		String role = null;
+
+		try {
+			try {
+				jp = f.createJsonParser(json);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+
+
+			jp.nextToken();
+			if (jp.getCurrentToken() != JsonToken.START_OBJECT) {
+				throw new IOException("Expected START_OBJECT");
+			}
+
+			while (jp.nextToken() != JsonToken.END_OBJECT) {
+				if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {
+					throw new IOException("Expected FIELD_NAME");
+				}
+
+				String n = jp.getCurrentName().toLowerCase();
+				jp.nextToken();
+
+				switch (n) {
+				case CoreWebRoutable.STR_ROLE:
+					role = jp.getText();
+
+					if (switchId.equalsIgnoreCase(CoreWebRoutable.STR_ALL)) {
+						for (IOFSwitch sw: switchService.getAllSwitchMap().values()) {
+							List<SetConcurrentRoleThread> activeThreads = new ArrayList<SetConcurrentRoleThread>(switchService.getAllSwitchMap().size());
+							List<SetConcurrentRoleThread> pendingRemovalThreads = new ArrayList<SetConcurrentRoleThread>();
+							SetConcurrentRoleThread t;
+							t = new SetConcurrentRoleThread(sw, parseRole(role));
+							activeThreads.add(t);
+							t.start();
+
+							// Join all the threads after the timeout. Set a hard timeout
+							// of 12 seconds for the threads to finish. If the thread has not
+							// finished the switch has not replied yet and therefore we won't
+							// add the switch's stats to the reply.
+							for (int iSleepCycles = 0; iSleepCycles < 12; iSleepCycles++) {
+								for (SetConcurrentRoleThread curThread : activeThreads) {
+									if (curThread.getState() == State.TERMINATED) {
+										retValue.put(curThread.getSwitch().getId().toString(), 
+												(curThread.getRoleReply() == null ? 
+														"Error communicating with switch. Role not changed." 
+														: curThread.getRoleReply().getRole().toString().replaceFirst(STR_ROLE_PREFIX, "")
+														)
+												);
+										pendingRemovalThreads.add(curThread);
+									}
+								}
+
+								// remove the threads that have completed the queries to the switches
+								for (SetConcurrentRoleThread curThread : pendingRemovalThreads) {
+									activeThreads.remove(curThread);
+								}
+								// clear the list so we don't try to double remove them
+								pendingRemovalThreads.clear();
+
+								// if we are done finish early so we don't always get the worst case
+								if (activeThreads.isEmpty()) {
+									break;
+								}
+
+								// sleep for 1 s here
+								try {
+									Thread.sleep(1000);
+								} catch (InterruptedException e) {
+									log.error("Interrupted while waiting for role replies", e);
+									retValue.put("ERROR", "Thread sleep interrupted while waiting for role replies.");
+								}
+
+							}
+						}
+					} else {
+						/* Must be a specific switch DPID then. */
+						try {
+							DatapathId dpid = DatapathId.of(switchId);
+							IOFSwitch sw = switchService.getSwitch(dpid);
+							if (sw == null) {
+								retValue.put("ERROR", "Switch Manager could not locate switch DPID " + dpid.toString());
+							} else {
+								OFRoleReply reply = setSwitchRole(sw, parseRole(role));
+								retValue.put(sw.getId().toString(), 
+										(reply == null ? 
+												"Error communicating with switch. Role not changed." 
+												: reply.getRole().toString().replaceFirst(STR_ROLE_PREFIX, "")
+												)
+										);
+							}
+						} catch (Exception e) {
+							retValue.put("ERROR", "Could not parse switch DPID " + switchId);
+						}	
+					}
+					break;
+				default:
+					retValue.put("ERROR", "Unrecognized JSON key.");
+					break;
+				}
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+			retValue.put("ERROR", "Caught IOException while parsing JSON POST request in role request.");
+		}
+		return retValue;
+	}
+
+	protected class SetConcurrentRoleThread extends Thread {
+		private OFRoleReply switchReply;
+		private OFControllerRole role;
+		private IOFSwitch sw;
+
+		public SetConcurrentRoleThread(IOFSwitch sw, OFControllerRole role) {
+			this.sw = sw;
+			this.switchReply = null;
+			this.role = role;
+		}
+
+		public OFRoleReply getRoleReply() {
+			return switchReply;
+		}
+
+		public IOFSwitch getSwitch() {
+			return sw;
+		}
+
+		public OFControllerRole getRole() {
+			return role;
+		}
+
+		@Override
+		public void run() {
+			switchReply = setSwitchRole(sw, role);
+		}
+	}
+
+	private static OFRoleReply setSwitchRole(IOFSwitch sw, OFControllerRole role) {
+		try {	
+			if (sw.getOFFactory().getVersion().compareTo(OFVersion.OF_12) < 0) {
+				OFNiciraControllerRole nrole;
+				switch (role) {
+				case ROLE_EQUAL:
+					nrole = OFNiciraControllerRole.ROLE_OTHER;
+					log.warn("Assuming EQUAL as OTHER for Nicira role request.");
+					break;
+				case ROLE_MASTER:
+					nrole = OFNiciraControllerRole.ROLE_MASTER;
+					break;
+				case ROLE_SLAVE:
+					nrole = OFNiciraControllerRole.ROLE_SLAVE;
+					break;
+				case ROLE_NOCHANGE:
+					log.error("Nicira extension does not support NOCHANGE role. Thus, we won't change the role.");
+					return OFFactories.getFactory(OFVersion.OF_13).buildRoleReply().setRole(sw.getControllerRole()).setGenerationId(U64.ZERO).build();
+				default:
+					log.error("Impossible to have anything other than MASTER, OTHER, or SLAVE for Nicira role.");
+					return OFFactories.getFactory(OFVersion.OF_13).buildRoleReply().setRole(sw.getControllerRole()).setGenerationId(U64.ZERO).build();
+				}
+
+				ListenableFuture<OFNiciraControllerRoleReply> future = sw.writeRequest(sw.getOFFactory().buildNiciraControllerRoleRequest()
+						.setRole(nrole)
+						.build());
+				OFNiciraControllerRoleReply nreply = future.get(10, TimeUnit.SECONDS);
+				if (nreply != null) {
+					/* Turn the OFControllerRoleReply into a OFNiciraControllerRoleReply */
+					switch (nreply.getRole()) {
+					case ROLE_MASTER:
+						return OFFactories.getFactory(OFVersion.OF_13).buildRoleReply().setRole(OFControllerRole.ROLE_MASTER).setGenerationId(U64.ZERO).build();
+					case ROLE_OTHER:
+						return OFFactories.getFactory(OFVersion.OF_13).buildRoleReply().setRole(OFControllerRole.ROLE_EQUAL).setGenerationId(U64.ZERO).build();
+					case ROLE_SLAVE:
+						return OFFactories.getFactory(OFVersion.OF_13).buildRoleReply().setRole(OFControllerRole.ROLE_SLAVE).setGenerationId(U64.ZERO).build();
+					default:
+						log.error("Impossible to have anything other than MASTER, OTHER, or SLAVE for Nicira role: {}.", nreply.getRole().toString());
+						break;
+					}
+				} else {
+					log.error("Did not receive Nicira role reply for switch {}.", sw.getId().toString());
+				}
+			} else {
+				ListenableFuture<OFRoleReply> future = sw.writeRequest(sw.getOFFactory().buildRoleRequest()
+						.setGenerationId(U64.ZERO)
+						.setRole(role)
+						.build());
+				return future.get(10, TimeUnit.SECONDS);
+			}
+		} catch (Exception e) {
+			log.error("Failure setting switch {} role to {}.", sw.toString(), role.toString());
+			log.error(e.getMessage());
+		}
+		return null;
+	}
+
+	private static OFControllerRole parseRole(String role) {
+		if (role == null || role.isEmpty()) {
+			return OFControllerRole.ROLE_NOCHANGE;
+		} 
+
+		role = role.toUpperCase();		
+
+		if (role.contains(STR_ROLE_MASTER)) {
+			return OFControllerRole.ROLE_MASTER;
+		} else if (role.contains(STR_ROLE_SLAVE)) {
+			return OFControllerRole.ROLE_SLAVE;
+		} else if (role.contains(STR_ROLE_EQUAL) || role.contains(STR_ROLE_OTHER)) {
+			return OFControllerRole.ROLE_EQUAL;
+		} else {
+			return OFControllerRole.ROLE_NOCHANGE;
+		}
+	}
 }

--- a/src/main/java/net/floodlightcontroller/core/web/serializers/StatsReplySerializer.java
+++ b/src/main/java/net/floodlightcontroller/core/web/serializers/StatsReplySerializer.java
@@ -745,12 +745,11 @@ public class StatsReplySerializer extends JsonSerializer<StatsReply> {
 	}
 
 	public static void serializeFlowReply(List<OFFlowStatsReply> flowReplies, JsonGenerator jGen) throws IOException, JsonProcessingException{
+		/* start the array before each reply */
+		jGen.writeFieldName("flows"); 
+		jGen.writeStartArray();
 		for (OFFlowStatsReply flowReply : flowReplies) { // for each flow stats reply
-			//Dose the switch will reply multiple OFFlowStatsReply ?
-			//Or we juse need to use the first item of the list.
 			List<OFFlowStatsEntry> entries = flowReply.getEntries();
-			jGen.writeFieldName("flows");
-			jGen.writeStartArray();
 			for (OFFlowStatsEntry entry : entries) { // for each flow
 				jGen.writeStartObject();
 				// list flow stats/info
@@ -796,9 +795,10 @@ public class StatsReplySerializer extends JsonSerializer<StatsReply> {
 				}
 
 				jGen.writeEndObject();
-			} // end for each OFFlowStatsReply entry
-			jGen.writeEndArray();
+			} // end for each OFFlowStatsReply entry */
 		} // end for each OFStatsReply
+		//jGen.writeEndObject();
+		jGen.writeEndArray();
 	} // end method
 
 	public static void serializeDescReply(List<OFDescStatsReply> descReplies, JsonGenerator jGen) throws IOException, JsonProcessingException{

--- a/src/main/java/net/floodlightcontroller/firewall/Firewall.java
+++ b/src/main/java/net/floodlightcontroller/firewall/Firewall.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.projectfloodlight.openflow.protocol.OFFactories;
 import org.projectfloodlight.openflow.protocol.OFMessage;
 import org.projectfloodlight.openflow.protocol.OFPacketIn;
 import org.projectfloodlight.openflow.protocol.OFType;
@@ -61,7 +62,6 @@ import net.floodlightcontroller.routing.RoutingDecision;
 import net.floodlightcontroller.storage.IResultSet;
 import net.floodlightcontroller.storage.IStorageSourceService;
 import net.floodlightcontroller.storage.StorageException;
-import net.floodlightcontroller.util.MatchUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,553 +75,554 @@ import org.slf4j.LoggerFactory;
  * @edited Ryan Izard
  */
 public class Firewall implements IFirewallService, IOFMessageListener,
-        IFloodlightModule {
+IFloodlightModule {
 
-    // service modules needed
-    protected IFloodlightProviderService floodlightProvider;
-    protected IStorageSourceService storageSource;
-    protected IRestApiService restApi;
-    protected static Logger logger;
+	// service modules needed
+	protected IFloodlightProviderService floodlightProvider;
+	protected IStorageSourceService storageSource;
+	protected IRestApiService restApi;
+	protected static Logger logger;
 
-    protected List<FirewallRule> rules; // protected by synchronized
-    protected boolean enabled;
-    protected IPv4Address subnet_mask = IPv4Address.of("255.255.255.0");
+	protected List<FirewallRule> rules; // protected by synchronized
+	protected boolean enabled;
+	protected IPv4Address subnet_mask = IPv4Address.of("255.255.255.0");
 
-    // constant strings for storage/parsing
-    public static final String TABLE_NAME = "controller_firewallrules";
-    public static final String COLUMN_RULEID = "ruleid";
-    public static final String COLUMN_DPID = "dpid";
-    public static final String COLUMN_IN_PORT = "in_port";
-    public static final String COLUMN_DL_SRC = "dl_src";
-    public static final String COLUMN_DL_DST = "dl_dst";
-    public static final String COLUMN_DL_TYPE = "dl_type";
-    public static final String COLUMN_NW_SRC_PREFIX = "nw_src_prefix";
-    public static final String COLUMN_NW_SRC_MASKBITS = "nw_src_maskbits";
-    public static final String COLUMN_NW_DST_PREFIX = "nw_dst_prefix";
-    public static final String COLUMN_NW_DST_MASKBITS = "nw_dst_maskbits";
-    public static final String COLUMN_NW_PROTO = "nw_proto";
-    public static final String COLUMN_TP_SRC = "tp_src";
-    public static final String COLUMN_TP_DST = "tp_dst";
-    public static final String COLUMN_WILDCARD_DPID = "wildcard_dpid";
-    public static final String COLUMN_WILDCARD_IN_PORT = "any_in_port";
-    public static final String COLUMN_WILDCARD_DL_SRC = "any_dl_src";
-    public static final String COLUMN_WILDCARD_DL_DST = "any_dl_dst";
-    public static final String COLUMN_WILDCARD_DL_TYPE = "any_dl_type";
-    public static final String COLUMN_WILDCARD_NW_SRC = "any_nw_src";
-    public static final String COLUMN_WILDCARD_NW_DST = "any_nw_dst";
-    public static final String COLUMN_WILDCARD_NW_PROTO = "any_nw_proto";
-    public static final String COLUMN_WILDCARD_TP_SRC = "any_tp_src";
-    public static final String COLUMN_WILDCARD_TP_DST = "any_tp_dst";
-    public static final String COLUMN_PRIORITY = "priority";
-    public static final String COLUMN_ACTION = "action";
-    public static String ColumnNames[] = { COLUMN_RULEID, COLUMN_DPID,
-            COLUMN_IN_PORT, COLUMN_DL_SRC, COLUMN_DL_DST, COLUMN_DL_TYPE,
-            COLUMN_NW_SRC_PREFIX, COLUMN_NW_SRC_MASKBITS, COLUMN_NW_DST_PREFIX,
-            COLUMN_NW_DST_MASKBITS, COLUMN_NW_PROTO, COLUMN_TP_SRC,
-            COLUMN_TP_DST, COLUMN_WILDCARD_DPID, COLUMN_WILDCARD_IN_PORT,
-            COLUMN_WILDCARD_DL_SRC, COLUMN_WILDCARD_DL_DST,
-            COLUMN_WILDCARD_DL_TYPE, COLUMN_WILDCARD_NW_SRC,
-            COLUMN_WILDCARD_NW_DST, COLUMN_WILDCARD_NW_PROTO, COLUMN_PRIORITY,
-            COLUMN_ACTION };
+	// constant strings for storage/parsing
+	public static final String TABLE_NAME = "controller_firewallrules";
+	public static final String COLUMN_RULEID = "ruleid";
+	public static final String COLUMN_DPID = "dpid";
+	public static final String COLUMN_IN_PORT = "in_port";
+	public static final String COLUMN_DL_SRC = "dl_src";
+	public static final String COLUMN_DL_DST = "dl_dst";
+	public static final String COLUMN_DL_TYPE = "dl_type";
+	public static final String COLUMN_NW_SRC_PREFIX = "nw_src_prefix";
+	public static final String COLUMN_NW_SRC_MASKBITS = "nw_src_maskbits";
+	public static final String COLUMN_NW_DST_PREFIX = "nw_dst_prefix";
+	public static final String COLUMN_NW_DST_MASKBITS = "nw_dst_maskbits";
+	public static final String COLUMN_NW_PROTO = "nw_proto";
+	public static final String COLUMN_TP_SRC = "tp_src";
+	public static final String COLUMN_TP_DST = "tp_dst";
+	public static final String COLUMN_WILDCARD_DPID = "wildcard_dpid";
+	public static final String COLUMN_WILDCARD_IN_PORT = "any_in_port";
+	public static final String COLUMN_WILDCARD_DL_SRC = "any_dl_src";
+	public static final String COLUMN_WILDCARD_DL_DST = "any_dl_dst";
+	public static final String COLUMN_WILDCARD_DL_TYPE = "any_dl_type";
+	public static final String COLUMN_WILDCARD_NW_SRC = "any_nw_src";
+	public static final String COLUMN_WILDCARD_NW_DST = "any_nw_dst";
+	public static final String COLUMN_WILDCARD_NW_PROTO = "any_nw_proto";
+	public static final String COLUMN_WILDCARD_TP_SRC = "any_tp_src";
+	public static final String COLUMN_WILDCARD_TP_DST = "any_tp_dst";
+	public static final String COLUMN_PRIORITY = "priority";
+	public static final String COLUMN_ACTION = "action";
+	public static String ColumnNames[] = { COLUMN_RULEID, COLUMN_DPID,
+		COLUMN_IN_PORT, COLUMN_DL_SRC, COLUMN_DL_DST, COLUMN_DL_TYPE,
+		COLUMN_NW_SRC_PREFIX, COLUMN_NW_SRC_MASKBITS, COLUMN_NW_DST_PREFIX,
+		COLUMN_NW_DST_MASKBITS, COLUMN_NW_PROTO, COLUMN_TP_SRC,
+		COLUMN_TP_DST, COLUMN_WILDCARD_DPID, COLUMN_WILDCARD_IN_PORT,
+		COLUMN_WILDCARD_DL_SRC, COLUMN_WILDCARD_DL_DST,
+		COLUMN_WILDCARD_DL_TYPE, COLUMN_WILDCARD_NW_SRC,
+		COLUMN_WILDCARD_NW_DST, COLUMN_WILDCARD_NW_PROTO, COLUMN_PRIORITY,
+		COLUMN_ACTION };
 
-    @Override
-    public String getName() {
-        return "firewall";
-    }
+	@Override
+	public String getName() {
+		return "firewall";
+	}
 
-    @Override
-    public boolean isCallbackOrderingPrereq(OFType type, String name) {
-        // no prereq
-        return false;
-    }
+	@Override
+	public boolean isCallbackOrderingPrereq(OFType type, String name) {
+		// no prereq
+		return false;
+	}
 
-    @Override
-    public boolean isCallbackOrderingPostreq(OFType type, String name) {
-        return (type.equals(OFType.PACKET_IN) && name.equals("forwarding"));
-    }
+	@Override
+	public boolean isCallbackOrderingPostreq(OFType type, String name) {
+		return (type.equals(OFType.PACKET_IN) && name.equals("forwarding"));
+	}
 
-    @Override
-    public Collection<Class<? extends IFloodlightService>> getModuleServices() {
-        Collection<Class<? extends IFloodlightService>> l = new ArrayList<Class<? extends IFloodlightService>>();
-        l.add(IFirewallService.class);
-        return l;
-    }
+	@Override
+	public Collection<Class<? extends IFloodlightService>> getModuleServices() {
+		Collection<Class<? extends IFloodlightService>> l = new ArrayList<Class<? extends IFloodlightService>>();
+		l.add(IFirewallService.class);
+		return l;
+	}
 
-    @Override
-    public Map<Class<? extends IFloodlightService>, IFloodlightService> getServiceImpls() {
-        Map<Class<? extends IFloodlightService>, IFloodlightService> m = new HashMap<Class<? extends IFloodlightService>, IFloodlightService>();
-        // We are the class that implements the service
-        m.put(IFirewallService.class, this);
-        return m;
-    }
+	@Override
+	public Map<Class<? extends IFloodlightService>, IFloodlightService> getServiceImpls() {
+		Map<Class<? extends IFloodlightService>, IFloodlightService> m = new HashMap<Class<? extends IFloodlightService>, IFloodlightService>();
+		// We are the class that implements the service
+		m.put(IFirewallService.class, this);
+		return m;
+	}
 
-    @Override
-    public Collection<Class<? extends IFloodlightService>> getModuleDependencies() {
-        Collection<Class<? extends IFloodlightService>> l = new ArrayList<Class<? extends IFloodlightService>>();
-        l.add(IFloodlightProviderService.class);
-        l.add(IStorageSourceService.class);
-        l.add(IRestApiService.class);
-        return l;
-    }
+	@Override
+	public Collection<Class<? extends IFloodlightService>> getModuleDependencies() {
+		Collection<Class<? extends IFloodlightService>> l = new ArrayList<Class<? extends IFloodlightService>>();
+		l.add(IFloodlightProviderService.class);
+		l.add(IStorageSourceService.class);
+		l.add(IRestApiService.class);
+		return l;
+	}
 
-    /**
-     * Reads the rules from the storage and creates a sorted arraylist of
-     * FirewallRule from them.
-     * 
-     * Similar to getStorageRules(), which only reads contents for REST GET and
-     * does no parsing, checking, nor putting into FirewallRule objects
-     * 
-     * @return the sorted arraylist of FirewallRule instances (rules from
-     *         storage)
-     */
-    protected ArrayList<FirewallRule> readRulesFromStorage() {
-        ArrayList<FirewallRule> l = new ArrayList<FirewallRule>();
+	/**
+	 * Reads the rules from the storage and creates a sorted arraylist of
+	 * FirewallRule from them.
+	 * 
+	 * Similar to getStorageRules(), which only reads contents for REST GET and
+	 * does no parsing, checking, nor putting into FirewallRule objects
+	 * 
+	 * @return the sorted arraylist of FirewallRule instances (rules from
+	 *         storage)
+	 */
+	protected ArrayList<FirewallRule> readRulesFromStorage() {
+		ArrayList<FirewallRule> l = new ArrayList<FirewallRule>();
 
-        try {
-            Map<String, Object> row;
+		try {
+			Map<String, Object> row;
 
-            // (..., null, null) for no predicate, no ordering
-            IResultSet resultSet = storageSource.executeQuery(TABLE_NAME, ColumnNames, null, null);
+			// (..., null, null) for no predicate, no ordering
+			IResultSet resultSet = storageSource.executeQuery(TABLE_NAME, ColumnNames, null, null);
 
-            // put retrieved rows into FirewallRules
-            for (Iterator<IResultSet> it = resultSet.iterator(); it.hasNext();) {
-                row = it.next().getRow();
-                // now, parse row
-                FirewallRule r = new FirewallRule();
-                if (!row.containsKey(COLUMN_RULEID) || !row.containsKey(COLUMN_DPID)) {
-                    logger.error( "skipping entry with missing required 'ruleid' or 'switchid' entry: {}", row);
-                    return l;
-                }
-                try {
-                    r.ruleid = Integer
-                            .parseInt((String) row.get(COLUMN_RULEID));
-                    r.dpid = DatapathId.of((String) row.get(COLUMN_DPID));
+			// put retrieved rows into FirewallRules
+			for (Iterator<IResultSet> it = resultSet.iterator(); it.hasNext();) {
+				row = it.next().getRow();
+				// now, parse row
+				FirewallRule r = new FirewallRule();
+				if (!row.containsKey(COLUMN_RULEID) || !row.containsKey(COLUMN_DPID)) {
+					logger.error( "skipping entry with missing required 'ruleid' or 'switchid' entry: {}", row);
+					return l;
+				}
+				try {
+					r.ruleid = Integer
+							.parseInt((String) row.get(COLUMN_RULEID));
+					r.dpid = DatapathId.of((String) row.get(COLUMN_DPID));
 
-                    for (String key : row.keySet()) {
-                        if (row.get(key) == null) {
-                            continue;
-                        }
-                        if (key.equals(COLUMN_RULEID) || key.equals(COLUMN_DPID) || key.equals("id")) {
-                            continue; // already handled
-                        } else if (key.equals(COLUMN_IN_PORT)) {
-                            r.in_port = OFPort.of(Integer.parseInt((String) row.get(COLUMN_IN_PORT)));
-                        } else if (key.equals(COLUMN_DL_SRC)) {
-                            r.dl_src = MacAddress.of(Long.parseLong((String) row.get(COLUMN_DL_SRC)));
-                        }  else if (key.equals(COLUMN_DL_DST)) {
-                            r.dl_dst = MacAddress.of(Long.parseLong((String) row.get(COLUMN_DL_DST)));
-                        } else if (key.equals(COLUMN_DL_TYPE)) {
-                            r.dl_type = EthType.of(Integer.parseInt((String) row.get(COLUMN_DL_TYPE)));
-                        } else if (key.equals(COLUMN_NW_SRC_PREFIX)) {
-                            r.nw_src_prefix_and_mask = IPv4AddressWithMask.of(IPv4Address.of(Integer.parseInt((String) row.get(COLUMN_NW_SRC_PREFIX))), r.nw_src_prefix_and_mask.getMask());
-                        } else if (key.equals(COLUMN_NW_SRC_MASKBITS)) {
-                            r.nw_src_prefix_and_mask = IPv4AddressWithMask.of(r.nw_src_prefix_and_mask.getValue(), IPv4Address.of(Integer.parseInt((String) row.get(COLUMN_NW_SRC_MASKBITS))));
-                        } else if (key.equals(COLUMN_NW_DST_PREFIX)) {
-                            r.nw_dst_prefix_and_mask = IPv4AddressWithMask.of(IPv4Address.of(Integer.parseInt((String) row.get(COLUMN_NW_DST_PREFIX))), r.nw_dst_prefix_and_mask.getMask());
-                        } else if (key.equals(COLUMN_NW_DST_MASKBITS)) {
-                            r.nw_dst_prefix_and_mask = IPv4AddressWithMask.of(r.nw_dst_prefix_and_mask.getValue(), IPv4Address.of(Integer.parseInt((String) row.get(COLUMN_NW_DST_MASKBITS))));
-                        } else if (key.equals(COLUMN_NW_PROTO)) {
-                            r.nw_proto = IpProtocol.of(Short.parseShort((String) row.get(COLUMN_NW_PROTO)));
-                        } else if (key.equals(COLUMN_TP_SRC)) {
-                            r.tp_src = TransportPort.of(Integer.parseInt((String) row.get(COLUMN_TP_SRC)));
-                        } else if (key.equals(COLUMN_TP_DST)) {
-                            r.tp_dst = TransportPort.of(Integer.parseInt((String) row.get(COLUMN_TP_DST)));
-                        } else if (key.equals(COLUMN_WILDCARD_DPID)) {
-                            r.any_dpid = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_DPID));
-                        } else if (key.equals(COLUMN_WILDCARD_IN_PORT)) {
-                            r.any_in_port = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_IN_PORT));
-                        } else if (key.equals(COLUMN_WILDCARD_DL_SRC)) {
-                            r.any_dl_src = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_DL_SRC));
-                        } else if (key.equals(COLUMN_WILDCARD_DL_DST)) {
-                            r.any_dl_dst = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_DL_DST));
-                        } else if (key.equals(COLUMN_WILDCARD_DL_TYPE)) {
-                            r.any_dl_type = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_DL_TYPE));
-                        } else if (key.equals(COLUMN_WILDCARD_NW_SRC)) {
-                            r.any_nw_src = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_NW_SRC));
-                        } else if (key.equals(COLUMN_WILDCARD_NW_DST)) {
-                            r.any_nw_dst = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_NW_DST));
-                        } else if (key.equals(COLUMN_WILDCARD_NW_PROTO)) {
-                            r.any_nw_proto = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_NW_PROTO));
-                        } else if (key.equals(COLUMN_PRIORITY)) {
-                            r.priority = Integer.parseInt((String) row.get(COLUMN_PRIORITY));
-                        } else if (key.equals(COLUMN_ACTION)) {
-                            int tmp = Integer.parseInt((String) row.get(COLUMN_ACTION));
-                            if (tmp == FirewallRule.FirewallAction.DROP.ordinal()) {
-                                r.action = FirewallRule.FirewallAction.DROP;
-                            } else if (tmp == FirewallRule.FirewallAction.ALLOW.ordinal()) {
-                                r.action = FirewallRule.FirewallAction.ALLOW;
-                            } else {
-                                r.action = null;
-                                logger.error("action not recognized");
-                            }
-                        }
-                    }
-                } catch (ClassCastException e) {
-                    logger.error("skipping rule {} with bad data : " + e.getMessage(), r.ruleid);
-                }
-                if (r.action != null) {
-                    l.add(r);
-                }
-            }
-        } catch (StorageException e) {
-            logger.error("failed to access storage: {}", e.getMessage());
-            // if the table doesn't exist, then wait to populate later via
-            // setStorageSource()
-        }
+					for (String key : row.keySet()) {
+						if (row.get(key) == null) {
+							continue;
+						}
+						if (key.equals(COLUMN_RULEID) || key.equals(COLUMN_DPID) || key.equals("id")) {
+							continue; // already handled
+						} else if (key.equals(COLUMN_IN_PORT)) {
+							r.in_port = OFPort.of(Integer.parseInt((String) row.get(COLUMN_IN_PORT)));
+						} else if (key.equals(COLUMN_DL_SRC)) {
+							r.dl_src = MacAddress.of(Long.parseLong((String) row.get(COLUMN_DL_SRC)));
+						}  else if (key.equals(COLUMN_DL_DST)) {
+							r.dl_dst = MacAddress.of(Long.parseLong((String) row.get(COLUMN_DL_DST)));
+						} else if (key.equals(COLUMN_DL_TYPE)) {
+							r.dl_type = EthType.of(Integer.parseInt((String) row.get(COLUMN_DL_TYPE)));
+						} else if (key.equals(COLUMN_NW_SRC_PREFIX)) {
+							r.nw_src_prefix_and_mask = IPv4AddressWithMask.of(IPv4Address.of(Integer.parseInt((String) row.get(COLUMN_NW_SRC_PREFIX))), r.nw_src_prefix_and_mask.getMask());
+						} else if (key.equals(COLUMN_NW_SRC_MASKBITS)) {
+							r.nw_src_prefix_and_mask = IPv4AddressWithMask.of(r.nw_src_prefix_and_mask.getValue(), IPv4Address.of(Integer.parseInt((String) row.get(COLUMN_NW_SRC_MASKBITS))));
+						} else if (key.equals(COLUMN_NW_DST_PREFIX)) {
+							r.nw_dst_prefix_and_mask = IPv4AddressWithMask.of(IPv4Address.of(Integer.parseInt((String) row.get(COLUMN_NW_DST_PREFIX))), r.nw_dst_prefix_and_mask.getMask());
+						} else if (key.equals(COLUMN_NW_DST_MASKBITS)) {
+							r.nw_dst_prefix_and_mask = IPv4AddressWithMask.of(r.nw_dst_prefix_and_mask.getValue(), IPv4Address.of(Integer.parseInt((String) row.get(COLUMN_NW_DST_MASKBITS))));
+						} else if (key.equals(COLUMN_NW_PROTO)) {
+							r.nw_proto = IpProtocol.of(Short.parseShort((String) row.get(COLUMN_NW_PROTO)));
+						} else if (key.equals(COLUMN_TP_SRC)) {
+							r.tp_src = TransportPort.of(Integer.parseInt((String) row.get(COLUMN_TP_SRC)));
+						} else if (key.equals(COLUMN_TP_DST)) {
+							r.tp_dst = TransportPort.of(Integer.parseInt((String) row.get(COLUMN_TP_DST)));
+						} else if (key.equals(COLUMN_WILDCARD_DPID)) {
+							r.any_dpid = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_DPID));
+						} else if (key.equals(COLUMN_WILDCARD_IN_PORT)) {
+							r.any_in_port = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_IN_PORT));
+						} else if (key.equals(COLUMN_WILDCARD_DL_SRC)) {
+							r.any_dl_src = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_DL_SRC));
+						} else if (key.equals(COLUMN_WILDCARD_DL_DST)) {
+							r.any_dl_dst = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_DL_DST));
+						} else if (key.equals(COLUMN_WILDCARD_DL_TYPE)) {
+							r.any_dl_type = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_DL_TYPE));
+						} else if (key.equals(COLUMN_WILDCARD_NW_SRC)) {
+							r.any_nw_src = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_NW_SRC));
+						} else if (key.equals(COLUMN_WILDCARD_NW_DST)) {
+							r.any_nw_dst = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_NW_DST));
+						} else if (key.equals(COLUMN_WILDCARD_NW_PROTO)) {
+							r.any_nw_proto = Boolean.parseBoolean((String) row.get(COLUMN_WILDCARD_NW_PROTO));
+						} else if (key.equals(COLUMN_PRIORITY)) {
+							r.priority = Integer.parseInt((String) row.get(COLUMN_PRIORITY));
+						} else if (key.equals(COLUMN_ACTION)) {
+							int tmp = Integer.parseInt((String) row.get(COLUMN_ACTION));
+							if (tmp == FirewallRule.FirewallAction.DROP.ordinal()) {
+								r.action = FirewallRule.FirewallAction.DROP;
+							} else if (tmp == FirewallRule.FirewallAction.ALLOW.ordinal()) {
+								r.action = FirewallRule.FirewallAction.ALLOW;
+							} else {
+								r.action = null;
+								logger.error("action not recognized");
+							}
+						}
+					}
+				} catch (ClassCastException e) {
+					logger.error("skipping rule {} with bad data : " + e.getMessage(), r.ruleid);
+				}
+				if (r.action != null) {
+					l.add(r);
+				}
+			}
+		} catch (StorageException e) {
+			logger.error("failed to access storage: {}", e.getMessage());
+			// if the table doesn't exist, then wait to populate later via
+			// setStorageSource()
+		}
 
-        // now, sort the list based on priorities
-        Collections.sort(l);
+		// now, sort the list based on priorities
+		Collections.sort(l);
 
-        return l;
-    }
+		return l;
+	}
 
-    @Override
-    public void init(FloodlightModuleContext context) throws FloodlightModuleException {
-        floodlightProvider = context.getServiceImpl(IFloodlightProviderService.class);
-        storageSource = context.getServiceImpl(IStorageSourceService.class);
-        restApi = context.getServiceImpl(IRestApiService.class);
-        rules = new ArrayList<FirewallRule>();
-        logger = LoggerFactory.getLogger(Firewall.class);
+	@Override
+	public void init(FloodlightModuleContext context) throws FloodlightModuleException {
+		floodlightProvider = context.getServiceImpl(IFloodlightProviderService.class);
+		storageSource = context.getServiceImpl(IStorageSourceService.class);
+		restApi = context.getServiceImpl(IRestApiService.class);
+		rules = new ArrayList<FirewallRule>();
+		logger = LoggerFactory.getLogger(Firewall.class);
 
-        // start disabled
-        enabled = false;
-    }
+		// start disabled
+		enabled = false;
+	}
 
-    @Override
-    public void startUp(FloodlightModuleContext context) {
-        // register REST interface
-        restApi.addRestletRoutable(new FirewallWebRoutable());
+	@Override
+	public void startUp(FloodlightModuleContext context) {
+		// register REST interface
+		restApi.addRestletRoutable(new FirewallWebRoutable());
 
-        // always place firewall in pipeline at bootup
-        floodlightProvider.addOFMessageListener(OFType.PACKET_IN, this);
+		// always place firewall in pipeline at bootup
+		floodlightProvider.addOFMessageListener(OFType.PACKET_IN, this);
 
-        // storage, create table and read rules
-        storageSource.createTable(TABLE_NAME, null);
-        storageSource.setTablePrimaryKeyName(TABLE_NAME, COLUMN_RULEID);
-        this.rules = readRulesFromStorage();
-    }
+		// storage, create table and read rules
+		storageSource.createTable(TABLE_NAME, null);
+		storageSource.setTablePrimaryKeyName(TABLE_NAME, COLUMN_RULEID);
+		this.rules = readRulesFromStorage();
+	}
 
-    @Override
-    public Command receive(IOFSwitch sw, OFMessage msg, FloodlightContext cntx) {
-        if (!this.enabled) {
-            return Command.CONTINUE;
-        }
+	@Override
+	public Command receive(IOFSwitch sw, OFMessage msg, FloodlightContext cntx) {
+		if (!this.enabled) {
+			return Command.CONTINUE;
+		}
 
-        switch (msg.getType()) {
-        case PACKET_IN:
-            IRoutingDecision decision = null;
-            if (cntx != null) {
-                decision = IRoutingDecision.rtStore.get(cntx, IRoutingDecision.CONTEXT_DECISION);
-                return this.processPacketInMessage(sw, (OFPacketIn) msg, decision, cntx);
-            }
-            break;
-        default:
-            break;
-        }
+		switch (msg.getType()) {
+		case PACKET_IN:
+			IRoutingDecision decision = null;
+			if (cntx != null) {
+				decision = IRoutingDecision.rtStore.get(cntx, IRoutingDecision.CONTEXT_DECISION);
+				return this.processPacketInMessage(sw, (OFPacketIn) msg, decision, cntx);
+			}
+			break;
+		default:
+			break;
+		}
 
-        return Command.CONTINUE;
-    }
+		return Command.CONTINUE;
+	}
 
-    @Override
-    public void enableFirewall(boolean enabled) {
-        logger.info("Setting firewall to {}", enabled);
-        this.enabled = enabled;
-    }
+	@Override
+	public void enableFirewall(boolean enabled) {
+		logger.info("Setting firewall to {}", enabled);
+		this.enabled = enabled;
+	}
 
-    @Override
-    public List<FirewallRule> getRules() {
-        return this.rules;
-    }
+	@Override
+	public List<FirewallRule> getRules() {
+		return this.rules;
+	}
 
-    // Only used to serve REST GET
-    // Similar to readRulesFromStorage(), which actually checks and stores
-    // record into FirewallRule list
-    @Override
-    public List<Map<String, Object>> getStorageRules() {
-        ArrayList<Map<String, Object>> l = new ArrayList<Map<String, Object>>();
-        try {
-            // null1=no predicate, null2=no ordering
-            IResultSet resultSet = storageSource.executeQuery(TABLE_NAME, ColumnNames, null, null);
-            for (Iterator<IResultSet> it = resultSet.iterator(); it.hasNext();) {
-                l.add(it.next().getRow());
-            }
-        } catch (StorageException e) {
-            logger.error("failed to access storage: {}", e.getMessage());
-            // if the table doesn't exist, then wait to populate later via
-            // setStorageSource()
-        }
-        return l;
-    }
+	// Only used to serve REST GET
+	// Similar to readRulesFromStorage(), which actually checks and stores
+	// record into FirewallRule list
+	@Override
+	public List<Map<String, Object>> getStorageRules() {
+		ArrayList<Map<String, Object>> l = new ArrayList<Map<String, Object>>();
+		try {
+			// null1=no predicate, null2=no ordering
+			IResultSet resultSet = storageSource.executeQuery(TABLE_NAME, ColumnNames, null, null);
+			for (Iterator<IResultSet> it = resultSet.iterator(); it.hasNext();) {
+				l.add(it.next().getRow());
+			}
+		} catch (StorageException e) {
+			logger.error("failed to access storage: {}", e.getMessage());
+			// if the table doesn't exist, then wait to populate later via
+			// setStorageSource()
+		}
+		return l;
+	}
 
-    @Override
-    public String getSubnetMask() {
-        return this.subnet_mask.toString();
-    }
+	@Override
+	public String getSubnetMask() {
+		return this.subnet_mask.toString();
+	}
 
-    @Override
-    public void setSubnetMask(String newMask) {
-        if (newMask.trim().isEmpty())
-            return;
-        this.subnet_mask = IPv4Address.of(newMask.trim());
-    }
+	@Override
+	public void setSubnetMask(String newMask) {
+		if (newMask.trim().isEmpty())
+			return;
+		this.subnet_mask = IPv4Address.of(newMask.trim());
+	}
 
-    @Override
-    public synchronized void addRule(FirewallRule rule) {
-        
-        // generate random ruleid for each newly created rule
-        // may want to return to caller if useful
-        // may want to check conflict
-        rule.ruleid = rule.genID();
-        
-        int i = 0;
-        // locate the position of the new rule in the sorted arraylist
-        for (i = 0; i < this.rules.size(); i++) {
-            if (this.rules.get(i).priority >= rule.priority)
-                break;
-        }
-        // now, add rule to the list
-        if (i <= this.rules.size()) {
-            this.rules.add(i, rule);
-        } else {
-            this.rules.add(rule);
-        }
-        // add rule to database
-        Map<String, Object> entry = new HashMap<String, Object>();
-        entry.put(COLUMN_RULEID, Integer.toString(rule.ruleid));
-        entry.put(COLUMN_DPID, Long.toString(rule.dpid.getLong()));
-        entry.put(COLUMN_IN_PORT, Integer.toString(rule.in_port.getPortNumber()));
-        entry.put(COLUMN_DL_SRC, Long.toString(rule.dl_src.getLong()));
-        entry.put(COLUMN_DL_DST, Long.toString(rule.dl_dst.getLong()));
-        entry.put(COLUMN_DL_TYPE, Integer.toString(rule.dl_type.getValue()));
-        entry.put(COLUMN_NW_SRC_PREFIX, Integer.toString(rule.nw_src_prefix_and_mask.getValue().getInt()));
-        entry.put(COLUMN_NW_SRC_MASKBITS, Integer.toString(rule.nw_src_prefix_and_mask.getMask().getInt()));
-        entry.put(COLUMN_NW_DST_PREFIX, Integer.toString(rule.nw_dst_prefix_and_mask.getValue().getInt()));
-        entry.put(COLUMN_NW_DST_MASKBITS, Integer.toString(rule.nw_dst_prefix_and_mask.getMask().getInt()));
-        entry.put(COLUMN_NW_PROTO, Short.toString(rule.nw_proto.getIpProtocolNumber()));
-        entry.put(COLUMN_TP_SRC, Integer.toString(rule.tp_src.getPort()));
-        entry.put(COLUMN_TP_DST, Integer.toString(rule.tp_dst.getPort()));
-        entry.put(COLUMN_WILDCARD_DPID, Boolean.toString(rule.any_dpid));
-        entry.put(COLUMN_WILDCARD_IN_PORT, Boolean.toString(rule.any_in_port));
-        entry.put(COLUMN_WILDCARD_DL_SRC, Boolean.toString(rule.any_dl_src));
-        entry.put(COLUMN_WILDCARD_DL_DST, Boolean.toString(rule.any_dl_dst));
-        entry.put(COLUMN_WILDCARD_DL_TYPE, Boolean.toString(rule.any_dl_type));
-        entry.put(COLUMN_WILDCARD_NW_SRC, Boolean.toString(rule.any_nw_src));
-        entry.put(COLUMN_WILDCARD_NW_DST, Boolean.toString(rule.any_nw_dst));
-        entry.put(COLUMN_WILDCARD_NW_PROTO, Boolean.toString(rule.any_nw_proto));
-        entry.put(COLUMN_WILDCARD_TP_SRC, Boolean.toString(rule.any_tp_src));
-        entry.put(COLUMN_WILDCARD_TP_DST, Boolean.toString(rule.any_tp_dst));
-        entry.put(COLUMN_PRIORITY, Integer.toString(rule.priority));
-        entry.put(COLUMN_ACTION, Integer.toString(rule.action.ordinal()));
-        storageSource.insertRow(TABLE_NAME, entry);
-    }
+	@Override
+	public synchronized void addRule(FirewallRule rule) {
 
-    @Override
-    public synchronized void deleteRule(int ruleid) {
-        Iterator<FirewallRule> iter = this.rules.iterator();
-        while (iter.hasNext()) {
-            FirewallRule r = iter.next();
-            if (r.ruleid == ruleid) {
-                // found the rule, now remove it
-                iter.remove();
-                break;
-            }
-        }
-        // delete from database
-        storageSource.deleteRow(TABLE_NAME, Integer.toString(ruleid));
-    }
+		// generate random ruleid for each newly created rule
+		// may want to return to caller if useful
+		// may want to check conflict
+		rule.ruleid = rule.genID();
 
-    /**
-     * Iterates over the firewall rules and tries to match them with the
-     * incoming packet (flow). Uses the FirewallRule class's matchWithFlow
-     * method to perform matching. It maintains a pair of wildcards (allow and
-     * deny) which are assigned later to the firewall's decision, where 'allow'
-     * wildcards are applied if the matched rule turns out to be an ALLOW rule
-     * and 'deny' wildcards are applied otherwise. Wildcards are applied to
-     * firewall decision to optimize flows in the switch, ensuring least number
-     * of flows per firewall rule. So, if a particular field is not "ANY" (i.e.
-     * not wildcarded) in a higher priority rule, then if a lower priority rule
-     * matches the packet and wildcards it, it can't be wildcarded in the
-     * switch's flow entry, because otherwise some packets matching the higher
-     * priority rule might escape the firewall. The reason for keeping different
-     * two different wildcards is that if a field is not wildcarded in a higher
-     * priority allow rule, the same field shouldn't be wildcarded for packets
-     * matching the lower priority deny rule (non-wildcarded fields in higher
-     * priority rules override the wildcarding of those fields in lower priority
-     * rules of the opposite type). So, to ensure that wildcards are
-     * appropriately set for different types of rules (allow vs. deny), separate
-     * wildcards are maintained. Iteration is performed on the sorted list of
-     * rules (sorted in decreasing order of priority).
-     * 
-     * @param sw
-     *            the switch instance
-     * @param pi
-     *            the incoming packet data structure
-     * @param cntx
-     *            the floodlight context
-     * @return an instance of RuleWildcardsPair that specify rule that matches
-     *         and the wildcards for the firewall decision
-     */
-    protected RuleMatchPair matchWithRule(IOFSwitch sw, OFPacketIn pi, FloodlightContext cntx) {
-        FirewallRule matched_rule = null;
-        Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
-        AllowDropPair adp = new AllowDropPair(sw.getOFFactory());
+		int i = 0;
+		// locate the position of the new rule in the sorted arraylist
+		for (i = 0; i < this.rules.size(); i++) {
+			if (this.rules.get(i).priority >= rule.priority)
+				break;
+		}
+		// now, add rule to the list
+		if (i <= this.rules.size()) {
+			this.rules.add(i, rule);
+		} else {
+			this.rules.add(rule);
+		}
+		// add rule to database
+		Map<String, Object> entry = new HashMap<String, Object>();
+		entry.put(COLUMN_RULEID, Integer.toString(rule.ruleid));
+		entry.put(COLUMN_DPID, Long.toString(rule.dpid.getLong()));
+		entry.put(COLUMN_IN_PORT, Integer.toString(rule.in_port.getPortNumber()));
+		entry.put(COLUMN_DL_SRC, Long.toString(rule.dl_src.getLong()));
+		entry.put(COLUMN_DL_DST, Long.toString(rule.dl_dst.getLong()));
+		entry.put(COLUMN_DL_TYPE, Integer.toString(rule.dl_type.getValue()));
+		entry.put(COLUMN_NW_SRC_PREFIX, Integer.toString(rule.nw_src_prefix_and_mask.getValue().getInt()));
+		entry.put(COLUMN_NW_SRC_MASKBITS, Integer.toString(rule.nw_src_prefix_and_mask.getMask().getInt()));
+		entry.put(COLUMN_NW_DST_PREFIX, Integer.toString(rule.nw_dst_prefix_and_mask.getValue().getInt()));
+		entry.put(COLUMN_NW_DST_MASKBITS, Integer.toString(rule.nw_dst_prefix_and_mask.getMask().getInt()));
+		entry.put(COLUMN_NW_PROTO, Short.toString(rule.nw_proto.getIpProtocolNumber()));
+		entry.put(COLUMN_TP_SRC, Integer.toString(rule.tp_src.getPort()));
+		entry.put(COLUMN_TP_DST, Integer.toString(rule.tp_dst.getPort()));
+		entry.put(COLUMN_WILDCARD_DPID, Boolean.toString(rule.any_dpid));
+		entry.put(COLUMN_WILDCARD_IN_PORT, Boolean.toString(rule.any_in_port));
+		entry.put(COLUMN_WILDCARD_DL_SRC, Boolean.toString(rule.any_dl_src));
+		entry.put(COLUMN_WILDCARD_DL_DST, Boolean.toString(rule.any_dl_dst));
+		entry.put(COLUMN_WILDCARD_DL_TYPE, Boolean.toString(rule.any_dl_type));
+		entry.put(COLUMN_WILDCARD_NW_SRC, Boolean.toString(rule.any_nw_src));
+		entry.put(COLUMN_WILDCARD_NW_DST, Boolean.toString(rule.any_nw_dst));
+		entry.put(COLUMN_WILDCARD_NW_PROTO, Boolean.toString(rule.any_nw_proto));
+		entry.put(COLUMN_WILDCARD_TP_SRC, Boolean.toString(rule.any_tp_src));
+		entry.put(COLUMN_WILDCARD_TP_DST, Boolean.toString(rule.any_tp_dst));
+		entry.put(COLUMN_PRIORITY, Integer.toString(rule.priority));
+		entry.put(COLUMN_ACTION, Integer.toString(rule.action.ordinal()));
+		storageSource.insertRow(TABLE_NAME, entry);
+	}
 
-        synchronized (rules) {
-            Iterator<FirewallRule> iter = this.rules.iterator();
-            FirewallRule rule = null;
-            // iterate through list to find a matching firewall rule
-            while (iter.hasNext()) {
-                // get next rule from list
-                rule = iter.next();
+	@Override
+	public synchronized void deleteRule(int ruleid) {
+		Iterator<FirewallRule> iter = this.rules.iterator();
+		while (iter.hasNext()) {
+			FirewallRule r = iter.next();
+			if (r.ruleid == ruleid) {
+				// found the rule, now remove it
+				iter.remove();
+				break;
+			}
+		}
+		// delete from database
+		storageSource.deleteRow(TABLE_NAME, Integer.toString(ruleid));
+	}
 
-                // check if rule matches
-                // AllowDropPair adp's allow and drop matches will modified with what matches
-                if (rule.matchesThisPacket(sw.getId(), (pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT)), eth, adp) == true) {
-                    matched_rule = rule;
-                    break;
-                }
-            }
-        }
+	/**
+	 * Iterates over the firewall rules and tries to match them with the
+	 * incoming packet (flow). Uses the FirewallRule class's matchWithFlow
+	 * method to perform matching. It maintains a pair of wildcards (allow and
+	 * deny) which are assigned later to the firewall's decision, where 'allow'
+	 * wildcards are applied if the matched rule turns out to be an ALLOW rule
+	 * and 'deny' wildcards are applied otherwise. Wildcards are applied to
+	 * firewall decision to optimize flows in the switch, ensuring least number
+	 * of flows per firewall rule. So, if a particular field is not "ANY" (i.e.
+	 * not wildcarded) in a higher priority rule, then if a lower priority rule
+	 * matches the packet and wildcards it, it can't be wildcarded in the
+	 * switch's flow entry, because otherwise some packets matching the higher
+	 * priority rule might escape the firewall. The reason for keeping different
+	 * two different wildcards is that if a field is not wildcarded in a higher
+	 * priority allow rule, the same field shouldn't be wildcarded for packets
+	 * matching the lower priority deny rule (non-wildcarded fields in higher
+	 * priority rules override the wildcarding of those fields in lower priority
+	 * rules of the opposite type). So, to ensure that wildcards are
+	 * appropriately set for different types of rules (allow vs. deny), separate
+	 * wildcards are maintained. Iteration is performed on the sorted list of
+	 * rules (sorted in decreasing order of priority).
+	 * 
+	 * @param sw
+	 *            the switch instance
+	 * @param pi
+	 *            the incoming packet data structure
+	 * @param cntx
+	 *            the floodlight context
+	 * @return an instance of RuleWildcardsPair that specify rule that matches
+	 *         and the wildcards for the firewall decision
+	 */
+	protected RuleMatchPair matchWithRule(IOFSwitch sw, OFPacketIn pi, FloodlightContext cntx) {
+		FirewallRule matched_rule = null;
+		Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
+		AllowDropPair adp = new AllowDropPair(sw.getOFFactory());
 
-        // make a pair of rule and wildcards, then return it
-        RuleMatchPair rmp = new RuleMatchPair();
-        rmp.rule = matched_rule;
-        if (matched_rule == null) {
-        	/*
-        	 * No rule was found, so drop the packet with as specific 
-        	 * of a drop rule as possible as not to interfere with other
-        	 * firewall rules.
-        	 */
-        	Match.Builder mb = MatchUtils.createRetentiveBuilder(pi.getMatch()); // capture the ingress port
-        	mb.setExact(MatchField.ETH_SRC, eth.getSourceMACAddress())
-        		.setExact(MatchField.ETH_DST, eth.getDestinationMACAddress())
-        		.setExact(MatchField.ETH_TYPE, eth.getEtherType());
-        	
-        	if (mb.get(MatchField.ETH_TYPE).equals(EthType.IPv4)) {
-        		IPv4 ipv4 = (IPv4) eth.getPayload();
-        		mb.setExact(MatchField.IPV4_SRC, ipv4.getSourceAddress())
-        			.setExact(MatchField.IPV4_DST, ipv4.getDestinationAddress())
-        			.setExact(MatchField.IP_PROTO, ipv4.getProtocol());
-        		
-        		if (mb.get(MatchField.IP_PROTO).equals(IpProtocol.TCP)) {
-        			TCP tcp = (TCP) ipv4.getPayload();
-        			mb.setExact(MatchField.TCP_SRC, tcp.getSourcePort())
-        			.setExact(MatchField.TCP_DST, tcp.getDestinationPort());
-        		} else if (mb.get(MatchField.IP_PROTO).equals(IpProtocol.UDP)) {
-        			UDP udp = (UDP) ipv4.getPayload();
-        			mb.setExact(MatchField.UDP_SRC, udp.getSourcePort())
-        			.setExact(MatchField.UDP_DST, udp.getDestinationPort());
-        		} else {
-        			// could be ICMP, which will be taken care of via IPv4 src/dst + ip proto
-        		}
-        	}
-        	rmp.match = mb.build();
-            //rmp.match = adp.drop.build(); This inserted a "drop all" rule if no match was found (not what we want to do...)
-        } else if (matched_rule.action == FirewallRule.FirewallAction.DROP) {
-            rmp.match = adp.drop.build();
-        } else {
-            rmp.match = adp.allow.build();
-        }
-        return rmp;
-    }
+		synchronized (rules) {
+			Iterator<FirewallRule> iter = this.rules.iterator();
+			FirewallRule rule = null;
+			// iterate through list to find a matching firewall rule
+			while (iter.hasNext()) {
+				// get next rule from list
+				rule = iter.next();
 
-    /**
-     * Checks whether an IP address is a broadcast address or not (determines
-     * using subnet mask)
-     * 
-     * @param IPAddress
-     *            the IP address to check
-     * @return true if it is a broadcast address, false otherwise
-     */
-    protected boolean isIPBroadcast(IPv4Address ip) {
-        // inverted subnet mask
-        IPv4Address inv_subnet_mask = subnet_mask.not();
-        return ip.and(inv_subnet_mask).equals(inv_subnet_mask);
-    }
+				// check if rule matches
+				// AllowDropPair adp's allow and drop matches will modified with what matches
+				if (rule.matchesThisPacket(sw.getId(), (pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT)), eth, adp) == true) {
+					matched_rule = rule;
+					break;
+				}
+			}
+		}
 
-    public Command processPacketInMessage(IOFSwitch sw, OFPacketIn pi, IRoutingDecision decision, FloodlightContext cntx) {
-        Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
-        OFPort inPort = (pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT));
-        
-        // Allowing L2 broadcast + ARP broadcast request (also deny malformed
-        // broadcasts -> L2 broadcast + L3 unicast)
-        if (eth.isBroadcast() == true) {
-            boolean allowBroadcast = true;
-            // the case to determine if we have L2 broadcast + L3 unicast (L3 broadcast default set to /24 or 255.255.255.0)
-            // don't allow this broadcast packet if such is the case (malformed packet)
-            if ((eth.getPayload() instanceof IPv4) && !isIPBroadcast(((IPv4) eth.getPayload()).getDestinationAddress())) {
-                allowBroadcast = false;
-            }
-            if (allowBroadcast == true) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Allowing broadcast traffic for PacketIn={}", pi);
-                }
-                                        
-                decision = new RoutingDecision(sw.getId(), inPort, 
-                		IDeviceService.fcStore.get(cntx, IDeviceService.CONTEXT_SRC_DEVICE),
-                        IRoutingDecision.RoutingAction.MULTICAST);
-                decision.addToContext(cntx);
-            } else {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Blocking malformed broadcast traffic for PacketIn={}", pi);
-                }
+		// make a pair of rule and wildcards, then return it
+		RuleMatchPair rmp = new RuleMatchPair();
+		rmp.rule = matched_rule;
+		if (matched_rule == null) {
+			/*
+			 * No rule was found, so drop the packet with as specific 
+			 * of a drop rule as possible as not to interfere with other
+			 * firewall rules.
+			 */
+			Match.Builder mb = OFFactories.getFactory(pi.getVersion()).buildMatch();
+			mb.setExact(MatchField.IN_PORT, (pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT)))
+			.setExact(MatchField.ETH_SRC, eth.getSourceMACAddress())
+			.setExact(MatchField.ETH_DST, eth.getDestinationMACAddress())
+			.setExact(MatchField.ETH_TYPE, eth.getEtherType());
 
-                decision = new RoutingDecision(sw.getId(), inPort,
-                		IDeviceService.fcStore.get(cntx, IDeviceService.CONTEXT_SRC_DEVICE),
-                        IRoutingDecision.RoutingAction.DROP);
-                decision.addToContext(cntx);
-            }
-            return Command.CONTINUE;
-        }
-        /*
-         * ARP response (unicast) can be let through without filtering through
-         * rules by uncommenting the code below
-         */
-        /*
-         * else if (eth.getEtherType() == Ethernet.TYPE_ARP) {
-         * logger.info("allowing ARP traffic"); decision = new
-         * FirewallDecision(IRoutingDecision.RoutingAction.FORWARD_OR_FLOOD);
-         * decision.addToContext(cntx); return Command.CONTINUE; }
-         */
+			if (mb.get(MatchField.ETH_TYPE).equals(EthType.IPv4)) {
+				IPv4 ipv4 = (IPv4) eth.getPayload();
+				mb.setExact(MatchField.IPV4_SRC, ipv4.getSourceAddress())
+				.setExact(MatchField.IPV4_DST, ipv4.getDestinationAddress())
+				.setExact(MatchField.IP_PROTO, ipv4.getProtocol());
 
-        // check if we have a matching rule for this packet/flow and no decision has been made yet
-        if (decision == null) {
-        	// check if the packet we received matches an existing rule
-            RuleMatchPair rmp = this.matchWithRule(sw, pi, cntx);
-            FirewallRule rule = rmp.rule;
+				if (mb.get(MatchField.IP_PROTO).equals(IpProtocol.TCP)) {
+					TCP tcp = (TCP) ipv4.getPayload();
+					mb.setExact(MatchField.TCP_SRC, tcp.getSourcePort())
+					.setExact(MatchField.TCP_DST, tcp.getDestinationPort());
+				} else if (mb.get(MatchField.IP_PROTO).equals(IpProtocol.UDP)) {
+					UDP udp = (UDP) ipv4.getPayload();
+					mb.setExact(MatchField.UDP_SRC, udp.getSourcePort())
+					.setExact(MatchField.UDP_DST, udp.getDestinationPort());
+				} else {
+					// could be ICMP, which will be taken care of via IPv4 src/dst + ip proto
+				}
+			}
+			rmp.match = mb.build();
+			//rmp.match = adp.drop.build(); This inserted a "drop all" rule if no match was found (not what we want to do...)
+		} else if (matched_rule.action == FirewallRule.FirewallAction.DROP) {
+			rmp.match = adp.drop.build();
+		} else {
+			rmp.match = adp.allow.build();
+		}
+		return rmp;
+	}
 
-            // Drop the packet if we don't have a rule allowing or dropping it or if we explicitly drop it
-            if (rule == null || rule.action == FirewallRule.FirewallAction.DROP) {
-                decision = new RoutingDecision(sw.getId(), inPort, 
-                		IDeviceService.fcStore.get(cntx, IDeviceService.CONTEXT_SRC_DEVICE), 
-                		IRoutingDecision.RoutingAction.DROP);
-                decision.setMatch(rmp.match);
-                decision.addToContext(cntx);
-                if (logger.isTraceEnabled()) {
-                    if (rule == null) {
-                        logger.trace("No firewall rule found for PacketIn={}, blocking flow", pi);
-                    } else if (rule.action == FirewallRule.FirewallAction.DROP) {
-                        logger.trace("Deny rule={} match for PacketIn={}", rule, pi);
-                    }
-                }
-            // Found a rule and the rule is not a drop, so allow the packet
-            } else {
-                decision = new RoutingDecision(sw.getId(), inPort, 
-                		IDeviceService.fcStore.get(cntx, IDeviceService.CONTEXT_SRC_DEVICE),
-                        IRoutingDecision.RoutingAction.FORWARD_OR_FLOOD);
-                decision.setMatch(rmp.match);
-                decision.addToContext(cntx);
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Allow rule={} match for PacketIn={}", rule, pi);
-                }
-            }
-        }
+	/**
+	 * Checks whether an IP address is a broadcast address or not (determines
+	 * using subnet mask)
+	 * 
+	 * @param IPAddress
+	 *            the IP address to check
+	 * @return true if it is a broadcast address, false otherwise
+	 */
+	protected boolean isIPBroadcast(IPv4Address ip) {
+		// inverted subnet mask
+		IPv4Address inv_subnet_mask = subnet_mask.not();
+		return ip.and(inv_subnet_mask).equals(inv_subnet_mask);
+	}
 
-        return Command.CONTINUE;
-    }
+	public Command processPacketInMessage(IOFSwitch sw, OFPacketIn pi, IRoutingDecision decision, FloodlightContext cntx) {
+		Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
+		OFPort inPort = (pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT));
 
-    @Override
-    public boolean isEnabled() {
-        return enabled;
-    }
+		// Allowing L2 broadcast + ARP broadcast request (also deny malformed
+		// broadcasts -> L2 broadcast + L3 unicast)
+		if (eth.isBroadcast() == true) {
+			boolean allowBroadcast = true;
+			// the case to determine if we have L2 broadcast + L3 unicast (L3 broadcast default set to /24 or 255.255.255.0)
+			// don't allow this broadcast packet if such is the case (malformed packet)
+			if ((eth.getPayload() instanceof IPv4) && !isIPBroadcast(((IPv4) eth.getPayload()).getDestinationAddress())) {
+				allowBroadcast = false;
+			}
+			if (allowBroadcast == true) {
+				if (logger.isTraceEnabled()) {
+					logger.trace("Allowing broadcast traffic for PacketIn={}", pi);
+				}
+
+				decision = new RoutingDecision(sw.getId(), inPort, 
+						IDeviceService.fcStore.get(cntx, IDeviceService.CONTEXT_SRC_DEVICE),
+						IRoutingDecision.RoutingAction.MULTICAST);
+				decision.addToContext(cntx);
+			} else {
+				if (logger.isTraceEnabled()) {
+					logger.trace("Blocking malformed broadcast traffic for PacketIn={}", pi);
+				}
+
+				decision = new RoutingDecision(sw.getId(), inPort,
+						IDeviceService.fcStore.get(cntx, IDeviceService.CONTEXT_SRC_DEVICE),
+						IRoutingDecision.RoutingAction.DROP);
+				decision.addToContext(cntx);
+			}
+			return Command.CONTINUE;
+		}
+		/*
+		 * ARP response (unicast) can be let through without filtering through
+		 * rules by uncommenting the code below
+		 */
+		/*
+		 * else if (eth.getEtherType() == Ethernet.TYPE_ARP) {
+		 * logger.info("allowing ARP traffic"); decision = new
+		 * FirewallDecision(IRoutingDecision.RoutingAction.FORWARD_OR_FLOOD);
+		 * decision.addToContext(cntx); return Command.CONTINUE; }
+		 */
+
+		// check if we have a matching rule for this packet/flow and no decision has been made yet
+		if (decision == null) {
+			// check if the packet we received matches an existing rule
+			RuleMatchPair rmp = this.matchWithRule(sw, pi, cntx);
+			FirewallRule rule = rmp.rule;
+
+			// Drop the packet if we don't have a rule allowing or dropping it or if we explicitly drop it
+			if (rule == null || rule.action == FirewallRule.FirewallAction.DROP) {
+				decision = new RoutingDecision(sw.getId(), inPort, 
+						IDeviceService.fcStore.get(cntx, IDeviceService.CONTEXT_SRC_DEVICE), 
+						IRoutingDecision.RoutingAction.DROP);
+				decision.setMatch(rmp.match);
+				decision.addToContext(cntx);
+				if (logger.isTraceEnabled()) {
+					if (rule == null) {
+						logger.trace("No firewall rule found for PacketIn={}, blocking flow", pi);
+					} else if (rule.action == FirewallRule.FirewallAction.DROP) {
+						logger.trace("Deny rule={} match for PacketIn={}", rule, pi);
+					}
+				}
+				// Found a rule and the rule is not a drop, so allow the packet
+			} else {
+				decision = new RoutingDecision(sw.getId(), inPort, 
+						IDeviceService.fcStore.get(cntx, IDeviceService.CONTEXT_SRC_DEVICE),
+						IRoutingDecision.RoutingAction.FORWARD_OR_FLOOD);
+				decision.setMatch(rmp.match);
+				decision.addToContext(cntx);
+				if (logger.isTraceEnabled()) {
+					logger.trace("Allow rule={} match for PacketIn={}", rule, pi);
+				}
+			}
+		}
+
+		return Command.CONTINUE;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return enabled;
+	}
 
 }

--- a/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
@@ -1190,6 +1190,7 @@ IFloodlightModule, IInfoProvider {
 		for (DatapathId sw : switchService.getAllSwitchDpids()) {
 			IOFSwitch iofSwitch = switchService.getSwitch(sw);
 			if (iofSwitch == null) continue;
+			if (!iofSwitch.isActive()) continue; /* can't do anything if the switch is SLAVE */
 			if (iofSwitch.getEnabledPorts() != null) {
 				for (OFPortDesc ofp : iofSwitch.getEnabledPorts()) {
 					if (isLinkDiscoverySuppressed(sw, ofp.getPortNo())) {

--- a/src/main/resources/floodlightdefault.properties
+++ b/src/main/resources/floodlightdefault.properties
@@ -14,14 +14,15 @@ net.floodlightcontroller.linkdiscovery.internal.LinkDiscoveryManager,\
 net.floodlightcontroller.ui.web.StaticWebRoutable,\
 net.floodlightcontroller.loadbalancer.LoadBalancer,\
 net.floodlightcontroller.firewall.Firewall,\
-net.floodlightcontroller.devicemanager.internal.DeviceManagerImpl,\
-net.floodlightcontroller.accesscontrollist.ACL
+net.floodlightcontroller.devicemanager.internal.DeviceManagerImpl
 org.sdnplatform.sync.internal.SyncManager.authScheme=CHALLENGE_RESPONSE
 org.sdnplatform.sync.internal.SyncManager.keyStorePath=/etc/floodlight/auth_credentials.jceks
 org.sdnplatform.sync.internal.SyncManager.dbPath=/var/lib/floodlight/
 org.sdnplatform.sync.internal.SyncManager.port=6642
 net.floodlightcontroller.core.internal.FloodlightProvider.openflowPort=6653
 net.floodlightcontroller.core.internal.FloodlightProvider.role=ACTIVE
+net.floodlightcontroller.core.internal.OFSwitchManager.clearTablesOnInitialHandshakeAsMaster=YES
+net.floodlightcontroller.core.internal.OFSwitchManager.clearTablesOnEachTransitionToMaster=YES
 net.floodlightcontroller.core.internal.OFSwitchManager.keyStorePath=/path/to/your/keystore-file.jks
 net.floodlightcontroller.core.internal.OFSwitchManager.keyStorePassword=your-keystore-password
 net.floodlightcontroller.core.internal.OFSwitchManager.useSsl=NO

--- a/src/test/java/net/floodlightcontroller/core/OFSwitchBaseTest.java
+++ b/src/test/java/net/floodlightcontroller/core/OFSwitchBaseTest.java
@@ -148,6 +148,7 @@ public class OFSwitchBaseTest {
 
         sw = new OFSwitchTest(conn, switchManager);
         sw.registerConnection(auxConn);
+        sw.setControllerRole(OFControllerRole.ROLE_MASTER); /* must supply role now, otherwise write() will be blocked if not master/equal/other */
 
         switches = new ConcurrentHashMap<DatapathId, IOFSwitchBackend>();
         switches.put(sw.getId(), sw);


### PR DESCRIPTION
Had to tap into the connection and handshake handlers to make this work with the given structure, but modules can send role requests now, and the switch(es) will automatically update state(s) appropriately.

Reworked REST API at /wm/core/switch/<dpid-or-"all">/role/json
Can list using GET as above or POST '{"role":"MASTER | SLAVE | EQUAL | NOCHANGE | OTHER"}'
