### PR TITLE
Feature/handle outgoing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ findbugs-results
 /thrift
 *.idea/*
 *.iml
+/target/

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ findbugs-results
 /thrift
 *.idea/*
 *.iml
-/target/

--- a/src/main/java/net/floodlightcontroller/core/OFSwitch.java
+++ b/src/main/java/net/floodlightcontroller/core/OFSwitch.java
@@ -715,6 +715,7 @@ public class OFSwitch implements IOFSwitchBackend {
 		log.trace("Channel: {}, Connected: {}", connections.get(OFAuxId.MAIN).getRemoteInetAddress(), connections.get(OFAuxId.MAIN).isConnected());
 		if (isActive()) {
 			connections.get(OFAuxId.MAIN).write(m);
+			switchManager.handleOutgoingMessage(this, m);			
 		} else {
 			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
 		}
@@ -746,6 +747,7 @@ public class OFSwitch implements IOFSwitchBackend {
 	public void write(OFMessage m, LogicalOFMessageCategory category) {
 		if (isActive()) {
 			this.getConnection(category).write(m);
+			switchManager.handleOutgoingMessage(this, m);			
 		} else {
 			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
 		}
@@ -755,6 +757,10 @@ public class OFSwitch implements IOFSwitchBackend {
 	public void write(Iterable<OFMessage> msglist, LogicalOFMessageCategory category) {
 		if (isActive()) {
 			this.getConnection(category).write(msglist);
+			
+			for(OFMessage m : msglist) {
+				switchManager.handleOutgoingMessage(this, m);				
+			}
 		} else {
 			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
 		}
@@ -785,6 +791,10 @@ public class OFSwitch implements IOFSwitchBackend {
 	public void write(Iterable<OFMessage> msglist) {
 		if (isActive()) {
 			connections.get(OFAuxId.MAIN).write(msglist);
+						
+			for(OFMessage m : msglist) {
+				switchManager.handleOutgoingMessage(this, m);
+			}
 		} else {
 			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
 		}

--- a/src/main/java/net/floodlightcontroller/core/OFSwitch.java
+++ b/src/main/java/net/floodlightcontroller/core/OFSwitch.java
@@ -715,7 +715,7 @@ public class OFSwitch implements IOFSwitchBackend {
 		log.trace("Channel: {}, Connected: {}", connections.get(OFAuxId.MAIN).getRemoteInetAddress(), connections.get(OFAuxId.MAIN).isConnected());
 		if (isActive()) {
 			connections.get(OFAuxId.MAIN).write(m);
-			switchManager.handleOutgoingMessage(this, m);			
+			switchManager.handleOutgoingMessage(this, m);
 		} else {
 			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
 		}
@@ -747,7 +747,7 @@ public class OFSwitch implements IOFSwitchBackend {
 	public void write(OFMessage m, LogicalOFMessageCategory category) {
 		if (isActive()) {
 			this.getConnection(category).write(m);
-			switchManager.handleOutgoingMessage(this, m);			
+			switchManager.handleOutgoingMessage(this, m);
 		} else {
 			log.warn("Attempted to write to switch {} that is SLAVE.", this.getId().toString());
 		}

--- a/src/main/java/net/floodlightcontroller/core/internal/IOFSwitchManager.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/IOFSwitchManager.java
@@ -61,9 +61,8 @@ public interface IOFSwitchManager {
      * Process written messages through the message listeners for the controller
      * @param sw The switch being written to
      * @param m the message
-     * @throws NullPointerException if switch or msg is null
      */
-    public void handleOutgoingMessage(IOFSwitch sw, OFMessage m);    
+    public void handleOutgoingMessage(IOFSwitch sw, OFMessage m);
 
     /**
      * Gets an unmodifiable collection of OFSwitchHandshakeHandlers

--- a/src/main/java/net/floodlightcontroller/core/internal/IOFSwitchManager.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/IOFSwitchManager.java
@@ -5,6 +5,7 @@ import java.util.List;
 import net.floodlightcontroller.core.FloodlightContext;
 import net.floodlightcontroller.core.IOFConnectionBackend;
 import net.floodlightcontroller.core.IOFSwitch.SwitchStatus;
+import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.IOFSwitchBackend;
 import net.floodlightcontroller.core.IOFSwitchDriver;
 import net.floodlightcontroller.core.LogicalOFMessageCategory;
@@ -55,6 +56,14 @@ public interface IOFSwitchManager {
      * @param bContext the Floodlight context of the message, normally null in this case.
      */
     void handleMessage(IOFSwitchBackend sw, OFMessage m, FloodlightContext bContext);
+    
+    /**
+     * Process written messages through the message listeners for the controller
+     * @param sw The switch being written to
+     * @param m the message
+     * @throws NullPointerException if switch or msg is null
+     */
+    public void handleOutgoingMessage(IOFSwitch sw, OFMessage m);    
 
     /**
      * Gets an unmodifiable collection of OFSwitchHandshakeHandlers

--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitchManager.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitchManager.java
@@ -503,6 +503,11 @@ public class OFSwitchManager implements IOFSwitchManager, INewOFConnectionListen
 	public void handleMessage(IOFSwitchBackend sw, OFMessage m, FloodlightContext bContext) {
 		floodlightProvider.handleMessage(sw, m, bContext);
 	}
+	
+	@Override
+	public void handleOutgoingMessage(IOFSwitch sw, OFMessage m) {
+		floodlightProvider.handleOutgoingMessage(sw, m);
+	}
 
 	@Override
 	public void addOFSwitchDriver(String manufacturerDescriptionPrefix,

--- a/src/test/java/net/floodlightcontroller/core/test/MockSwitchManager.java
+++ b/src/test/java/net/floodlightcontroller/core/test/MockSwitchManager.java
@@ -90,6 +90,12 @@ public class MockSwitchManager implements IFloodlightModule, IOFSwitchManager, I
         // do nothing
 
     }
+    
+    @Override
+    public void handleOutgoingMessage(IOFSwitch sw, OFMessage m) {
+    	// do nothing
+    	
+    }
 
     public void setSwitchHandshakeHandlers(Map<DatapathId, OFSwitchHandshakeHandler> handlers) {
         this.switchHandlers = handlers;


### PR DESCRIPTION
Re-introduction of a pre-1.0 floodlight feature. It is designed in a way that is least-intrusive, e.g. the message is forwarded AFTER being written to the switch. This means:
* There should be no real performance loss
* The message cannot be changed before its written to the switch. This was possible pre-1.0, however i'm not sure if this would be even possible anymore because of the way OpenFlowJ/Loxi works.