### PR TITLE
fixed failed unit test because of new handleOutgoingMessage() in IOFSwitchManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,16 +48,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12</version>
-				<configuration>
-					<excludes>
-						<exclude>**</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>

--- a/src/test/java/net/floodlightcontroller/core/OFSwitchBaseTest.java
+++ b/src/test/java/net/floodlightcontroller/core/OFSwitchBaseTest.java
@@ -1394,6 +1394,8 @@ public class OFSwitchBaseTest {
 
         reset(switchManager);
         expect(switchManager.isCategoryRegistered(category)).andReturn(true);
+        switchManager.handleOutgoingMessage(sw, testMessage);
+        expectLastCall();
         replay(switchManager);
 
         sw.write(testMessage, category);


### PR DESCRIPTION
Fixed one failed unit test (see #548)