### PR TITLE
fix data races in LoadBalancer module

### DIFF
--- a/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
@@ -226,9 +226,15 @@ public class LoadBalancer implements IFloodlightModule,
                     }
                     
                     LBVip vip = vips.get(vipIpToId.get(destIpAddress));
+                    if (vip == null)			// fix deference violations           
+                    	return Command.CONTINUE;
                     LBPool pool = pools.get(vip.pickPool(client));
+                    if (pool == null)			// fix deference violations
+                    	return Command.CONTINUE;
                     LBMember member = members.get(pool.pickMember(client));
-
+                    if(member == null)			//fix deference violations
+                    	return Command.CONTINUE;
+                    
                     // for chosen member, check device manager and find and push routes, in both directions                    
                     pushBidirectionalVipRoutes(sw, pi, cntx, client, member);
                    
@@ -662,6 +668,8 @@ public class LoadBalancer implements IFloodlightModule,
         LBPool pool;
         if (pools != null) {
             pool = pools.get(poolId);
+            if (pool == null)	// fix deference violations
+            	return -1;
             if (pool.vipId != null)
                 vips.get(pool.vipId).pools.remove(poolId);
             pools.remove(poolId);


### PR DESCRIPTION
The deference violations (may incur by data races) need to be fixed in LoadBalancer module. Those bugs can cause a serious vulnerability, .i.e., blocking forwarding module.