### PR TITLE
fix race conditions in LinkDiscoveryManager module

### DIFF
--- a/src/main/java/net/floodlightcontroller/linkdiscovery/ILinkDiscoveryService.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/ILinkDiscoveryService.java
@@ -62,7 +62,7 @@ public interface ILinkDiscoveryService extends IFloodlightService {
      * to switchport (sw, port). PacketOut does not contain actions.
      * PacketOut length includes the minimum length and data length.
      */
-    public OFPacketOut generateLLDPMessage(DatapathId sw, OFPort port,
+    public OFPacketOut generateLLDPMessage(IOFSwitch iofSwitch, OFPort port,
                                            boolean isStandard,
                                            boolean isReverse);
 

--- a/src/main/java/net/floodlightcontroller/linkdiscovery/ILinkDiscoveryService.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/ILinkDiscoveryService.java
@@ -25,6 +25,7 @@ import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.MacAddress;
 import org.projectfloodlight.openflow.types.OFPort;
 
+import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.module.IFloodlightService;
 import net.floodlightcontroller.routing.Link;
 import net.floodlightcontroller.topology.NodePortTuple;

--- a/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
@@ -288,10 +288,9 @@ IFloodlightModule, IInfoProvider {
 	//*********************
 
 	@Override
-	public OFPacketOut generateLLDPMessage(DatapathId sw, OFPort port,
+	public OFPacketOut generateLLDPMessage(IOFSwitch iofSwitch, OFPort port,
 			boolean isStandard, boolean isReverse) {
 
-		IOFSwitch iofSwitch = switchService.getSwitch(sw);
 		OFPortDesc ofpPort = iofSwitch.getPort(port);
 
 		if (log.isTraceEnabled()) {
@@ -1160,6 +1159,8 @@ IFloodlightModule, IInfoProvider {
 			return;
 
 		IOFSwitch iofSwitch = switchService.getSwitch(sw);
+		if (iofSwitch == null)             //fix dereference violations in case race conditions
+			return;
 		OFPortDesc ofpPort = iofSwitch.getPort(port);
 
 		if (log.isTraceEnabled()) {
@@ -1687,6 +1688,8 @@ IFloodlightModule, IInfoProvider {
 	@Override
 	public void switchActivated(DatapathId switchId) {
 		IOFSwitch sw = switchService.getSwitch(switchId);
+		if (sw == null)       //fix dereference violation in case race conditions
+			return;
 		if (sw.getEnabledPortNumbers() != null) {
 			for (OFPort p : sw.getEnabledPortNumbers()) {
 				processNewPort(sw.getId(), p);

--- a/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
@@ -290,12 +290,12 @@ IFloodlightModule, IInfoProvider {
 	@Override
 	public OFPacketOut generateLLDPMessage(IOFSwitch iofSwitch, OFPort port,
 			boolean isStandard, boolean isReverse) {
-
+		
 		OFPortDesc ofpPort = iofSwitch.getPort(port);
 
 		if (log.isTraceEnabled()) {
 			log.trace("Sending LLDP packet out of swich: {}, port: {}",
-					sw.toString(), port);
+					iofSwitch.getId().toString(), port);
 		}
 
 		// using "nearest customer bridge" MAC address for broadest possible
@@ -319,7 +319,7 @@ IFloodlightModule, IInfoProvider {
 		ByteBuffer dpidBB = ByteBuffer.wrap(dpidArray);
 		ByteBuffer portBB = ByteBuffer.wrap(portId, 1, 2);
 
-		DatapathId dpid = sw;
+		DatapathId dpid = iofSwitch.getId();
 		dpidBB.putLong(dpid.getLong());
 		// set the chassis id's value to last 6 bytes of dpid
 		System.arraycopy(dpidArray, 2, chassisId, 1, 6);
@@ -343,7 +343,7 @@ IFloodlightModule, IInfoProvider {
 		portBB.putShort(port.getShortPortNumber());
 		if (log.isTraceEnabled()) {
 			log.trace("Sending LLDP out of interface: {}/{}",
-					sw.toString(), port);
+					iofSwitch.getId().toString(), port);
 		}
 
 		LLDP lldp = new LLDP();
@@ -384,7 +384,7 @@ IFloodlightModule, IInfoProvider {
 
 		// serialize and wrap in a packet out
 		byte[] data = ethernet.serialize();
-		OFPacketOut.Builder pob = switchService.getSwitch(sw).getOFFactory().buildPacketOut();
+		OFPacketOut.Builder pob = iofSwitch.getOFFactory().buildPacketOut();
 		pob.setBufferId(OFBufferId.NO_BUFFER);
 		pob.setInPort(OFPort.ANY);
 
@@ -1167,7 +1167,7 @@ IFloodlightModule, IInfoProvider {
 			log.trace("Sending LLDP packet out of swich: {}, port: {}",
 					sw.toString(), port.getPortNumber());
 		}
-		OFPacketOut po = generateLLDPMessage(sw, port, isStandard, isReverse);
+		OFPacketOut po = generateLLDPMessage(iofSwitch, port, isStandard, isReverse);
 		OFPacketOut.Builder pob = po.createBuilder();
 
 		// Add actions


### PR DESCRIPTION
Fix deference bugs in LinkDiscoveryManager module. Those bugs stems from a potential race condition in OFSwitch.switchDisconnected() and OFSwitch.getSwitch() in OFSwtichManager module. I have also modified the interface generateLLDPMessage() in ILinkDiscoveryService to avoid atomicity violations. 

The unit test is passed for those modifications.