### PR TITLE
Minor OXM serializer patch and Static Flow Pusher bug fix

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/web/serializers/OXMSerializer.java
+++ b/src/main/java/net/floodlightcontroller/core/web/serializers/OXMSerializer.java
@@ -390,6 +390,10 @@ public class OXMSerializer {
 		
 		map.put(U32.ofRaw(NXM_1 | (36 << SHIFT_FIELD) | 4), STR_NXM + "internal_recirc_id");
 		map.put(U32.ofRaw(NXM_1 | (36 << SHIFT_FIELD) | 4 * 2 | MASKED), STR_NXM + "internal_recirc_id" + STR_MASKED);
+		
+		map.put(U32.ofRaw(NXM_1 | (37 << SHIFT_FIELD) | 4), STR_NXM + MatchUtils.STR_PBB_ISID);
+		map.put(U32.ofRaw(NXM_1 | (37 << SHIFT_FIELD) | 4 * 2 | MASKED), STR_NXM + MatchUtils.STR_PBB_ISID + STR_MASKED);
+		
 	}
 	
 	/**

--- a/src/main/java/net/floodlightcontroller/staticflowentry/StaticFlowEntryPusher.java
+++ b/src/main/java/net/floodlightcontroller/staticflowentry/StaticFlowEntryPusher.java
@@ -741,11 +741,11 @@ implements IOFSwitchListener, IFloodlightModule, IStaticFlowEntryPusherService, 
 					Map<String, OFFlowMod> flowsByName = getFlows(sw.getId());
 					for (Map.Entry<String, OFFlowMod> entry : flowsByName.entrySet()) {
 						if (msg.getCookie().equals(entry.getValue().getCookie()) &&
-								msg.getHardTimeout() == entry.getValue().getHardTimeout() &&
+								(msg.getVersion().compareTo(OFVersion.OF_12) < 0 ? true : msg.getHardTimeout() == entry.getValue().getHardTimeout()) &&
 								msg.getIdleTimeout() == entry.getValue().getIdleTimeout() &&
 								msg.getMatch().equals(entry.getValue().getMatch()) &&
 								msg.getPriority() == entry.getValue().getPriority() &&
-								msg.getTableId().equals(entry.getValue().getTableId())
+								(msg.getVersion().compareTo(OFVersion.OF_10) == 0 ? true : msg.getTableId().equals(entry.getValue().getTableId()))
 								) {
 							flowToRemove = entry.getKey();
 							break;


### PR DESCRIPTION
Added an NXM to the new OXM serialization/deserialization class.

Fixed an OpenFlow version bug in the SFP, where a table ID would be asked for in the flow removed message in OF1.0 (a no-no) and the hard timeout would be asked of the flow removed message in OF1.0 and OF1.1 (also a no-no -- not introduced until OF1.2).