### PR TITLE
OF-DPA updates and ignore PI on wait features

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
@@ -46,7 +46,9 @@ import org.projectfloodlight.openflow.protocol.OFHello;
 import org.projectfloodlight.openflow.protocol.OFHelloElem;
 import org.projectfloodlight.openflow.protocol.OFHelloElemVersionbitmap;
 import org.projectfloodlight.openflow.protocol.OFMessage;
+import org.projectfloodlight.openflow.protocol.OFPacketIn;
 import org.projectfloodlight.openflow.protocol.OFPortStatus;
+import org.projectfloodlight.openflow.protocol.OFType;
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.protocol.ver13.OFHelloElemTypeSerializerVer13;
 import org.projectfloodlight.openflow.protocol.ver14.OFHelloElemTypeSerializerVer14;
@@ -122,7 +124,7 @@ class OFChannelHandler extends IdleStateAwareChannelHandler {
 			// we only expect features reply in the WAIT_FEATURES_REPLY state
 			illegalMessageReceived(m);
 		}
-		
+
 		void processOFPortStatus(OFPortStatus m) {
 			unhandledMessageReceived(m);
 		}
@@ -419,7 +421,7 @@ class OFChannelHandler extends IdleStateAwareChannelHandler {
 				super.processOFHello(m); /* Versions don't match as they should; abort */
 			}
 		}
-		
+
 		@Override
 		void processOFPortStatus(OFPortStatus m) {
 			log.warn("Ignoring PORT_STATUS message from {} during OpenFlow channel establishment. Ports will be explicitly queried in a later state.", channel.getRemoteAddress());
@@ -428,6 +430,15 @@ class OFChannelHandler extends IdleStateAwareChannelHandler {
 		@Override
 		void enterState() throws IOException {
 			sendFeaturesRequest();
+		}
+
+		@Override
+		void processOFMessage(OFMessage m) throws IOException {
+			if (m.getType().equals(OFType.PACKET_IN)) {
+				log.warn("Ignoring PACKET_IN message from {} during OpenFlow channel establishment.", channel.getRemoteAddress());
+			} else {
+				super.processOFMessage(m);
+			}
 		}
 	};
 
@@ -856,8 +867,8 @@ class OFChannelHandler extends IdleStateAwareChannelHandler {
 		// Send initial hello message
 		List<OFHelloElem> he = new ArrayList<OFHelloElem>();
 		he.add(factory.buildHelloElemVersionbitmap()
-						.setBitmaps(ofBitmaps)
-						.build());
+				.setBitmaps(ofBitmaps)
+				.build());
 		OFHello.Builder builder = factory.buildHello()
 				.setXid(handshakeTransactionIds--)
 				.setElements(he);

--- a/src/main/java/net/floodlightcontroller/util/OFPortMode.java
+++ b/src/main/java/net/floodlightcontroller/util/OFPortMode.java
@@ -1,0 +1,14 @@
+package net.floodlightcontroller.util;
+
+/**
+ * Define the different operating modes of a switch
+ * port as trunk, access, and both (trunk and access).
+ * 
+ * @author Ryan Izard, ryan.izard@bigswitch.com, rizard@g.clemson.edu
+ */
+
+public enum OFPortMode {
+	TRUNK,
+	ACCESS,
+	TRUNK_AND_ACCESS
+}

--- a/src/main/java/net/floodlightcontroller/util/OFPortModeTuple.java
+++ b/src/main/java/net/floodlightcontroller/util/OFPortModeTuple.java
@@ -1,0 +1,72 @@
+package net.floodlightcontroller.util;
+
+import javax.annotation.Nonnull;
+
+import org.projectfloodlight.openflow.types.OFPort;
+
+/**
+ * Make it easier to track a port and it's operating {@link OFPortMode mode}.
+ * Objects of this class are immutable.
+ * 
+ * @author Ryan Izard, ryan.izard@bigswitch.com, rizard@g.clemson.edu
+ */
+public class OFPortModeTuple {
+	private final OFPort p;
+	private final OFPortMode m;
+	
+	private OFPortModeTuple(@Nonnull OFPort p, @Nonnull OFPortMode m) {
+		this.p = p;
+		this.m = m;
+	}
+
+	public static OFPortModeTuple of(OFPort p, OFPortMode m) {
+		if (p == null) {
+			throw new NullPointerException("Port cannot be null.");
+		}
+		if (m == null) {
+			throw new NullPointerException("Mode cannot be null.");
+		}
+		return new OFPortModeTuple(p, m);
+	}
+	
+	public OFPort getPort() {
+		return this.p;
+	}
+	
+	public OFPortMode getMode() {
+		return this.m;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((m == null) ? 0 : m.hashCode());
+		result = prime * result + ((p == null) ? 0 : p.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		OFPortModeTuple other = (OFPortModeTuple) obj;
+		if (m != other.m)
+			return false;
+		if (p == null) {
+			if (other.p != null)
+				return false;
+		} else if (!p.equals(other.p))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "OFPortModeTuple [p=" + p + ", m=" + m + "]";
+	}
+}


### PR DESCRIPTION
Some non-tested updates to the OF-DPA utilities. Still a work in progress, but almost done.

Ignore packet-in message in the WaitFeaturesReply state in OFChannelHandler. Some switches like to send packet-ins even though we don't know the DPID yet and cannot process them.