### PR TITLE
Quick bug fix in OFHello composition for OF versions 1.0, 1.1, and 1.2. 

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/OFConnection.java
+++ b/src/main/java/net/floodlightcontroller/core/OFConnection.java
@@ -411,6 +411,4 @@ public class OFConnection implements IOFConnection, IOFConnectionBackend{
 		}
 
     }
-
-
 }

--- a/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
@@ -865,14 +865,21 @@ class OFChannelHandler extends IdleStateAwareChannelHandler {
 	 */
 	private void sendHelloMessage() throws IOException {
 		// Send initial hello message
-		List<OFHelloElem> he = new ArrayList<OFHelloElem>();
-		he.add(factory.buildHelloElemVersionbitmap()
-				.setBitmaps(ofBitmaps)
-				.build());
-		OFHello.Builder builder = factory.buildHello()
-				.setXid(handshakeTransactionIds--)
-				.setElements(he);
-		OFHello m = builder.build();
+
+		OFHello.Builder builder = factory.buildHello();
+
+		/* Our highest-configured OFVersion does support version bitmaps, so include it */
+		if (factory.getVersion().compareTo(OFVersion.OF_13) >= 0) {
+			List<OFHelloElem> he = new ArrayList<OFHelloElem>();
+			he.add(factory.buildHelloElemVersionbitmap()
+					.setBitmaps(ofBitmaps)
+					.build());
+			builder.setElements(he);
+		}
+
+		OFHello m = builder.setXid(handshakeTransactionIds--)
+				.build();
+		
 		channel.write(Collections.singletonList(m));
 		log.debug("Send hello: {}", m);
 	}


### PR DESCRIPTION
Fix bug in controller OF protocol version when we set our default below 1.3. We now honor OF1.2 and under's lack of version bitmaps in the hello.

Also, remove some unnecessary spaces. I hate those.