### PR TITLE
Improve handshake reliability with user modules that implement IOFSwitchListener and modify flow table on switchAdded event

### DIFF
--- a/src/test/java/net/floodlightcontroller/core/internal/OFSwitchHandlerTestBase.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/OFSwitchHandlerTestBase.java
@@ -48,6 +48,7 @@ import net.floodlightcontroller.debugcounter.IDebugCounterService;
 
 import org.projectfloodlight.openflow.protocol.OFBadActionCode;
 import org.projectfloodlight.openflow.protocol.OFBadRequestCode;
+import org.projectfloodlight.openflow.protocol.OFBarrierReply;
 import org.projectfloodlight.openflow.protocol.OFControllerRole;
 import org.projectfloodlight.openflow.protocol.OFDescStatsReply;
 import org.projectfloodlight.openflow.protocol.OFErrorMsg;
@@ -547,8 +548,13 @@ public abstract class OFSwitchHandlerTestBase {
 			switchManager.switchStatusChanged(sw, SwitchStatus.HANDSHAKE, newStatus);
 		}
 		replay(sw, switchManager);
-
+		
 		switchHandler.sendRoleRequest(role);
+		
+		/* Now, trigger transition to master */
+		OFBarrierReply br = getFactory().buildBarrierReply()
+				.build();
+		switchHandler.processOFMessage(br);
 
 		verify(sw, switchManager);
 	}
@@ -605,6 +611,7 @@ public abstract class OFSwitchHandlerTestBase {
 		expect(sw.getStatus()).andReturn(SwitchStatus.HANDSHAKE).once();
 		sw.setStatus(SwitchStatus.MASTER);
 		expectLastCall().once();
+
 		if (factory.getVersion().compareTo(OFVersion.OF_13) >= 0) {
 			expect(sw.getMaxTableForTableMissFlow()).andReturn(TableId.ZERO).times(1);
 			expect(sw.getTableFeatures(TableId.ZERO)).andReturn(TableFeatures.of(createTableFeaturesStatsReply().getEntries().get(0))).anyTimes();
@@ -617,8 +624,13 @@ public abstract class OFSwitchHandlerTestBase {
 		replay(switchManager);
 		OFMessage reply = getRoleReply(xid, OFControllerRole.ROLE_MASTER);
 
-		// sendMessageToHandler will verify and rest controller mock
+		/* Go into the MasterState */
 		switchHandler.processOFMessage(reply);
+		
+		/* Now, trigger transition to master */
+		OFBarrierReply br = getFactory().buildBarrierReply()
+				.build();
+		switchHandler.processOFMessage(br);
 
 		assertThat(switchHandler.getStateForTesting(), CoreMatchers.instanceOf(OFSwitchHandshakeHandler.MasterState.class));
 	}
@@ -719,8 +731,14 @@ public abstract class OFSwitchHandlerTestBase {
 		switchManager.switchStatusChanged(sw, SwitchStatus.HANDSHAKE, SwitchStatus.MASTER);
 		expectLastCall().once();
 		replay(switchManager);
-		// sendMessageToHandler will verify and rest controller mock
+		
+		/* Go into the MasterState */
 		switchHandler.processOFMessage(err);
+		
+		/* Now, trigger transition to master */
+		OFBarrierReply br = getFactory().buildBarrierReply()
+				.build();
+		switchHandler.processOFMessage(br);
 
 		assertThat(switchHandler.getStateForTesting(), CoreMatchers.instanceOf(OFSwitchHandshakeHandler.MasterState.class));
 	}
@@ -743,7 +761,7 @@ public abstract class OFSwitchHandlerTestBase {
 		assertThat(switchHandler.getStateForTesting(), CoreMatchers.instanceOf(OFSwitchHandshakeHandler.WaitInitialRoleState.class));
 
 		// Set the role
-		setupSwitchSendRoleRequestAndVerify(null, OFControllerRole.ROLE_MASTER);
+		setupSwitchSendRoleRequestAndVerify(null, OFControllerRole.ROLE_MASTER); /* don't care about the XID, since we assume the reply is lost */
 		assertThat(switchHandler.getStateForTesting(), CoreMatchers.instanceOf(OFSwitchHandshakeHandler.WaitInitialRoleState.class));
 
 		// prepare mocks and inject the role reply message
@@ -767,15 +785,19 @@ public abstract class OFSwitchHandlerTestBase {
 		}
 		replay(sw);
 
-		OFMessage m = factory.buildBarrierReply().build();
+		OFMessage m = factory.barrierReply();
 
-		Thread.sleep(timeout+5);
+		Thread.sleep(timeout + 5);
 
 		reset(switchManager);
 		switchManager.switchStatusChanged(sw, SwitchStatus.HANDSHAKE, SwitchStatus.MASTER);
 		expectLastCall().once();
 		replay(switchManager);
 		switchHandler.processOFMessage(m);
+		
+		/* Send another barrier to trigger becoming master */
+		switchHandler.processOFMessage(m);
+
 
 		assertThat(switchHandler.getStateForTesting(), CoreMatchers.instanceOf(OFSwitchHandshakeHandler.MasterState.class));
 


### PR DESCRIPTION
Patched the handshake so that on transition to master, we guarantee the order of flow table operations (e.g. clear, adding table-miss flows, and IOFSwitchListener module switchAdded/switchActivated listener operations). Barriers are used inbetween all such operations.