### PR TITLE
Allow switches that don't support table-features message to still receive table-miss flows

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFChannelHandler.java
@@ -729,7 +729,7 @@ class OFChannelHandler extends IdleStateAwareChannelHandler {
 			log.warn("Could not process message: queue full");
 			counters.rejectedExecutionException.increment();
 		} else if (e.getCause() instanceof IllegalArgumentException) {
-			log.error("Could not decode OpenFlow protocol version from switch {}. Perhaps the switch is trying to use SSL and the controller is not (or vice versa)? {}", getConnectionInfoString(), e.getCause());
+			log.error("Illegal argument exception with switch {}. {}", getConnectionInfoString(), e.getCause());
 			counters.switchSslConfigurationError.increment();
 			ctx.getChannel().close();
 		} else {

--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitchHandshakeHandler.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitchHandshakeHandler.java
@@ -527,7 +527,7 @@ public class OFSwitchHandshakeHandler implements IOFConnectionListener {
 			for (int tableId = 0; tableId < this.sw.getMaxTableForTableMissFlow().getValue(); tableId++) {
 				/* Only add the flow if the table exists and if it supports sending to the controller */
 				TableFeatures tf = this.sw.getTableFeatures(TableId.of(tableId));
-				if (tf != null /* TODO && tf.supportsSendingToController() -- we need something like this, but how? */) {
+				if (/* TODO tf != null*/ true /* TODO && tf.supportsSendingToController() -- we need something like this, but how? */) {
 					OFFlowAdd defaultFlow = this.factory.buildFlowAdd()
 							.setTableId(TableId.of(tableId))
 							.setPriority(0)


### PR DESCRIPTION
All switches should support table-features if they are OF1.3 switches. But in the case they do not, then we should still insert the table-miss flows anyway.

TODO: Tweak IOFSwitch to properly allow access to specific switch table IDs