### PR TITLE
Finish new topology service integration by patching Forwarding + one new feature

### DIFF
--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -78,19 +78,21 @@ public abstract class ForwardingBase implements IOFMessageListener {
 	protected static int OFMESSAGE_DAMPER_CAPACITY = 10000; // TODO: find sweet spot
 	protected static int OFMESSAGE_DAMPER_TIMEOUT = 250; // ms
 
-	public static int FLOWMOD_DEFAULT_IDLE_TIMEOUT = 5; // in seconds
-	public static int FLOWMOD_DEFAULT_HARD_TIMEOUT = 0; // infinite
-	public static int FLOWMOD_DEFAULT_PRIORITY = 1; // 0 is the default table-miss flow in OF1.3+, so we need to use 1
+	protected static int FLOWMOD_DEFAULT_IDLE_TIMEOUT = 5; // in seconds
+	protected static int FLOWMOD_DEFAULT_HARD_TIMEOUT = 0; // infinite
+	protected static int FLOWMOD_DEFAULT_PRIORITY = 1; // 0 is the default table-miss flow in OF1.3+, so we need to use 1
 	
-	public static boolean FLOWMOD_DEFAULT_SET_SEND_FLOW_REM_FLAG = false;
+	protected static boolean FLOWMOD_DEFAULT_SET_SEND_FLOW_REM_FLAG = false;
 	
-	public static boolean FLOWMOD_DEFAULT_MATCH_VLAN = true;
-	public static boolean FLOWMOD_DEFAULT_MATCH_MAC = true;
-	public static boolean FLOWMOD_DEFAULT_MATCH_IP_ADDR = true;
-	public static boolean FLOWMOD_DEFAULT_MATCH_TRANSPORT = true;
+	protected static boolean FLOWMOD_DEFAULT_MATCH_VLAN = true;
+	protected static boolean FLOWMOD_DEFAULT_MATCH_MAC = true;
+	protected static boolean FLOWMOD_DEFAULT_MATCH_IP_ADDR = true;
+	protected static boolean FLOWMOD_DEFAULT_MATCH_TRANSPORT = true;
 
-	public static final short FLOWMOD_DEFAULT_IDLE_TIMEOUT_CONSTANT = 5;
-	public static final short FLOWMOD_DEFAULT_HARD_TIMEOUT_CONSTANT = 0;
+	protected static final short FLOWMOD_DEFAULT_IDLE_TIMEOUT_CONSTANT = 5;
+	protected static final short FLOWMOD_DEFAULT_HARD_TIMEOUT_CONSTANT = 0;
+	
+	protected static boolean FLOOD_ALL_ARP_PACKETS = false;
 
 	protected IFloodlightProviderService floodlightProviderService;
 	protected IOFSwitchService switchService;

--- a/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
@@ -212,9 +212,9 @@ public class TopologyInstance {
 	/*
 	 * Checks if OF port is edge port
 	 */
-    public boolean isEdge(DatapathId sw, OFPort portId){ 
+    public boolean isEdge(DatapathId sw, OFPort portId) { 
 		NodePortTuple np = new NodePortTuple(sw, portId);
-		if (allLinks.get(np) == null){
+		if (allLinks.get(np) == null || allLinks.get(np).isEmpty()) {
 			return true;
 		}
 		else {

--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -356,7 +356,7 @@ public class TopologyManager implements IFloodlightModule, ITopologyService, IRo
 	@Override
 	public boolean isEdge(DatapathId sw, OFPort p){
 		TopologyInstance ti = getCurrentInstance(true);
-		return ti.isEdge(sw,p);
+		return ti.isEdge(sw, p);
 	}
 
 	@Override

--- a/src/main/resources/floodlightdefault.properties
+++ b/src/main/resources/floodlightdefault.properties
@@ -21,6 +21,7 @@ org.sdnplatform.sync.internal.SyncManager.keyStorePath=/etc/floodlight/auth_cred
 org.sdnplatform.sync.internal.SyncManager.dbPath=/var/lib/floodlight/
 org.sdnplatform.sync.internal.SyncManager.port=6642
 net.floodlightcontroller.forwarding.Forwarding.match=vlan, mac, ip, transport
+net.floodlightcontroller.forwarding.Forwarding.flood-arp=NO
 net.floodlightcontroller.core.internal.FloodlightProvider.openflowPort=6653
 net.floodlightcontroller.core.internal.FloodlightProvider.role=ACTIVE
 net.floodlightcontroller.linkdiscovery.internal.LinkDiscoveryManager.latency-history-size=10


### PR DESCRIPTION
Added ability to disable ARP flows in Forwarding. Many hardware switches cannot handle ARP flows. ARP flows on by default; turn off/on via 'flood-arp' in floodlightdefault.properties. Also, finished integrating new topology service/routing into Forwarding. This required a few more null checks to handle cases where packet-ins are received while the controller is starting/still discovering the topology/links.

Also, changed many ForwardingBase fields to protected. Not quite sure why they were all public.