### PR TITLE
Revert hard and idle timeout to public

### DIFF
--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -78,9 +78,9 @@ public abstract class ForwardingBase implements IOFMessageListener {
 	protected static int OFMESSAGE_DAMPER_CAPACITY = 10000; // TODO: find sweet spot
 	protected static int OFMESSAGE_DAMPER_TIMEOUT = 250; // ms
 
-	protected static int FLOWMOD_DEFAULT_IDLE_TIMEOUT = 5; // in seconds
-	protected static int FLOWMOD_DEFAULT_HARD_TIMEOUT = 0; // infinite
-	protected static int FLOWMOD_DEFAULT_PRIORITY = 1; // 0 is the default table-miss flow in OF1.3+, so we need to use 1
+	public static int FLOWMOD_DEFAULT_IDLE_TIMEOUT = 5; // in seconds
+	public static int FLOWMOD_DEFAULT_HARD_TIMEOUT = 0; // infinite
+	public static int FLOWMOD_DEFAULT_PRIORITY = 1; // 0 is the default table-miss flow in OF1.3+, so we need to use 1
 	
 	protected static boolean FLOWMOD_DEFAULT_SET_SEND_FLOW_REM_FLAG = false;
 	


### PR DESCRIPTION
Wow. Not sure how that passed. Should have run ant (outside eclipse) -- would have given the compile error. Turns out VirtualNetworkFilter required the hard and idle timeouts to be public. TODO implement getters so that nobody can change these.