### PR TITLE
Single-switch islands list correct outgoing broadcast ports; tidy up topology service

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
@@ -282,7 +282,7 @@ public class Device implements IDevice {
 			if (!deviceManager.isValidAttachmentPoint(ap.getSw(), ap.getPort()))
 				continue;
 
-			DatapathId id = deviceManager.topology.getL2DomainId(ap.getSw());
+			DatapathId id = deviceManager.topology.getOpenflowDomainId(ap.getSw());
 			apMap.put(id, ap);
 		}
 
@@ -345,7 +345,7 @@ public class Device implements IDevice {
 		Set<DatapathId> visitedIslands = new HashSet<DatapathId>();
 			
 		for (AttachmentPoint ap : oldAPList) {
-			DatapathId id = topology.getL2DomainId(ap.getSw());
+			DatapathId id = topology.getOpenflowDomainId(ap.getSw());
 			AttachmentPoint trueAP = apMap.get(id);
 
 			if (trueAP == null) {
@@ -367,7 +367,7 @@ public class Device implements IDevice {
 		 * has not expired, add them as duplicates to the list.
 		 */
 		for (AttachmentPoint ap : oldAPList) {				
-			DatapathId id = topology.getL2DomainId(ap.getSw());
+			DatapathId id = topology.getOpenflowDomainId(ap.getSw());
 			if (visitedIslands.contains(id)) {
 				if (ap.getLastSeen().getTime() > timeThreshold) {
 					dupAPs.add(ap);
@@ -472,7 +472,7 @@ public class Device implements IDevice {
 			return true;
 		}
 
-		DatapathId id = topology.getL2DomainId(sw);
+		DatapathId id = topology.getOpenflowDomainId(sw);
 		AttachmentPoint oldAP = apMap.get(id);
 
 		if (oldAP == null) { // No attachment on this L2 domain.

--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
@@ -353,12 +353,12 @@ public class DeviceManagerImpl implements IDeviceService, IOFMessageListener, IT
 
 			DatapathId oldSw = oldAP.getSw();
 			OFPort oldPort = oldAP.getPort();
-			DatapathId oldDomain = topology.getL2DomainId(oldSw);
+			DatapathId oldDomain = topology.getOpenflowDomainId(oldSw);
 			boolean oldBD = topology.isBroadcastDomainPort(oldSw, oldPort);
 
 			DatapathId newSw = newAP.getSw();
 			OFPort newPort = newAP.getPort();
-			DatapathId newDomain = topology.getL2DomainId(newSw);
+			DatapathId newDomain = topology.getOpenflowDomainId(newSw);
 			boolean newBD = topology.isBroadcastDomainPort(newSw, newPort);
 
 			if (oldDomain.getLong() < newDomain.getLong()) return -1;

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
@@ -127,8 +127,8 @@ public class LoadBalancer implements IFloodlightModule,
             new Comparator<SwitchPort>() {
                 @Override
                 public int compare(SwitchPort d1, SwitchPort d2) {
-                    DatapathId d1ClusterId = topologyService.getL2DomainId(d1.getSwitchDPID());
-                    DatapathId d2ClusterId = topologyService.getL2DomainId(d2.getSwitchDPID());
+                    DatapathId d1ClusterId = topologyService.getOpenflowDomainId(d1.getSwitchDPID());
+                    DatapathId d2ClusterId = topologyService.getOpenflowDomainId(d2.getSwitchDPID());
                     return d1ClusterId.compareTo(d2ClusterId);
                 }
             };
@@ -383,7 +383,7 @@ public class LoadBalancer implements IFloodlightModule,
         // srcDevice and/or dstDevice is null, no route can be pushed
         if (srcDevice == null || dstDevice == null) return;
         
-        DatapathId srcIsland = topologyService.getL2DomainId(sw.getId());
+        DatapathId srcIsland = topologyService.getOpenflowDomainId(sw.getId());
 
         if (srcIsland == null) {
             log.debug("No openflow island found for source {}/{}", 
@@ -397,7 +397,7 @@ public class LoadBalancer implements IFloodlightModule,
         boolean on_same_if = false;
         for (SwitchPort dstDap : dstDevice.getAttachmentPoints()) {
             DatapathId dstSwDpid = dstDap.getSwitchDPID();
-            DatapathId dstIsland = topologyService.getL2DomainId(dstSwDpid);
+            DatapathId dstIsland = topologyService.getOpenflowDomainId(dstSwDpid);
             if ((dstIsland != null) && dstIsland.equals(srcIsland)) {
                 on_same_island = true;
                 if ((sw.getId().equals(dstSwDpid)) && ((pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT)).equals(dstDap.getPort()))) {
@@ -441,9 +441,9 @@ public class LoadBalancer implements IFloodlightModule,
             SwitchPort srcDap = srcDaps[iSrcDaps];
             SwitchPort dstDap = dstDaps[iDstDaps];
             DatapathId srcCluster = 
-                    topologyService.getL2DomainId(srcDap.getSwitchDPID());
+                    topologyService.getOpenflowDomainId(srcDap.getSwitchDPID());
             DatapathId dstCluster = 
-                    topologyService.getL2DomainId(dstDap.getSwitchDPID());
+                    topologyService.getOpenflowDomainId(dstDap.getSwitchDPID());
 
             int srcVsDest = srcCluster.compareTo(dstCluster);
             if (srcVsDest == 0) {

--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -120,8 +120,8 @@ public abstract class ForwardingBase implements IOFMessageListener {
 			new Comparator<SwitchPort>() {
 		@Override
 		public int compare(SwitchPort d1, SwitchPort d2) {
-			DatapathId d1ClusterId = topologyService.getL2DomainId(d1.getSwitchDPID());
-			DatapathId d2ClusterId = topologyService.getL2DomainId(d2.getSwitchDPID());
+			DatapathId d1ClusterId = topologyService.getOpenflowDomainId(d1.getSwitchDPID());
+			DatapathId d2ClusterId = topologyService.getOpenflowDomainId(d2.getSwitchDPID());
 			return d1ClusterId.compareTo(d2ClusterId);
 		}
 	};

--- a/src/main/java/net/floodlightcontroller/topology/ITopologyService.java
+++ b/src/main/java/net/floodlightcontroller/topology/ITopologyService.java
@@ -28,86 +28,118 @@ import net.floodlightcontroller.routing.Link;
 
 public interface ITopologyService extends IFloodlightService  {
 
+	/*******************************************************
+	 * GENERAL TOPOLOGY FUNCTIONS
+	 *******************************************************/
+	
+	/**
+	 * Add a listener to be notified upon topology events.
+	 * @param listener
+	 */
 	public void addListener(ITopologyListener listener);
 
+	/**
+	 * Retrieve the last time the topology was computed.
+	 * @return
+	 */
 	public Date getLastUpdateTime();
 
+	/*******************************************************
+	 * PORT FUNCTIONS
+	 *******************************************************/
+	
 	/**
-	 * Query to determine if devices must be learned on a given switch port.
+	 * Determines if a device can be learned/located on this switch+port.
+	 * @param switchid
+	 * @param port
+	 * @return
 	 */
 	public boolean isAttachmentPointPort(DatapathId switchid, OFPort port);
-	public boolean isAttachmentPointPort(DatapathId switchid, OFPort port,
-			boolean tunnelEnabled);
-
-	public DatapathId getOpenflowDomainId(DatapathId switchId);
-	public DatapathId getOpenflowDomainId(DatapathId switchId, boolean tunnelEnabled);
-	
 	
 	/**
-	 * Returns a complete list of the network links, including intra-cluster and inter-cluster links. Links are grouped for each DatapathId separately.
+	 * Determines if a device can be learned/located on this switch+port.
+	 * @param switchid
+	 * @param port
+	 * @return
 	 */
-	public Map<DatapathId, Set<Link>> getAllLinks();
-	
+	public boolean isAttachmentPointPort(DatapathId switchid, OFPort port, boolean tunnelEnabled);
+
 	/**
-	 * Checks if port "p" is edge port or belongs to one of the detected network links.
+	 * Determines whether or not a switch+port is a part of
+	 * a link or is a leaf of the network.
+	 * @param sw
+	 * @param p
+	 * @return
 	 */
    	public boolean isEdge(DatapathId sw, OFPort p);
-	
+   	
 	/**
-	 * Returns list of switch ports allowed for broadcast
+	 * Get list of ports that can SEND a broadcast packet.
+	 * @param sw
+	 * @return
 	 */
 	public Set<OFPort> getSwitchBroadcastPorts(DatapathId sw);
+	
 	/**
-	 * Returns the identifier of the L2 domain of a given switch.
-	 * @param switchId The DPID of the switch in long form
-	 * @return The DPID of the switch that is the key for the cluster
+	 * Checks if the switch+port is in the broadcast tree.
+	 * @param sw
+	 * @param port
+	 * @return
 	 */
-	public DatapathId getL2DomainId(DatapathId switchId);
-	public DatapathId getL2DomainId(DatapathId switchId, boolean tunnelEnabled);
-
-	/**
-	 * Queries whether two switches are in the same cluster.
-	 * @param switch1
-	 * @param switch2
-	 * @return true if the switches are in the same cluster
-	 */
-	public boolean inSameOpenflowDomain(DatapathId switch1, DatapathId switch2);
-	public boolean inSameOpenflowDomain(DatapathId switch1, DatapathId switch2,
-			boolean tunnelEnabled);
-
-	public Set<DatapathId> getSwitchesInOpenflowDomain(DatapathId switchDPID);
-	public Set<DatapathId> getSwitchesInOpenflowDomain(DatapathId switchDPID,
-			boolean tunnelEnabled);
-
-	/**
-	 * Queries whether two switches are in the same island.
-	 * Currently, island and cluster are the same. In future,
-	 * islands could be different than clusters.
-	 * @param switch1
-	 * @param switch2
-	 * @return True of they are in the same island, false otherwise
-	 */
-	public boolean inSameL2Domain(DatapathId switch1, DatapathId switch2);
-	public boolean inSameL2Domain(DatapathId switch1, DatapathId switch2,
-			boolean tunnelEnabled);
-
 	public boolean isBroadcastDomainPort(DatapathId sw, OFPort port);
-	public boolean isBroadcastDomainPort(DatapathId sw, OFPort port,
-			boolean tunnelEnabled);
+	
+	/**
+	 * Checks if the switch+port is in the broadcast tree.
+	 * @param sw
+	 * @param port
+	 * @param tunnelEnabled
+	 * @return
+	 */
+	public boolean isBroadcastDomainPort(DatapathId sw, OFPort port, boolean tunnelEnabled);
 
-
+	/**
+	 * Determines if the switch+port is blocked. If blocked, it
+	 * should not be allowed to send/receive any traffic.
+	 * @param sw
+	 * @param port
+	 * @return
+	 */
 	public boolean isAllowed(DatapathId sw, OFPort portId);
+	
+	/**
+	 * Determines if the switch+port is blocked. If blocked, it
+	 * should not be allowed to send/receive any traffic.
+	 * @param sw
+	 * @param port
+	 * @param tunnelEnabled
+	 * @return
+	 */
 	public boolean isAllowed(DatapathId sw, OFPort portId, boolean tunnelEnabled);
 
 	/**
 	 * Indicates if an attachment point on the new switch port is consistent
 	 * with the attachment point on the old switch port or not.
+	 * @param oldSw
+	 * @param oldPort
+	 * @param newSw
+	 * @param newPort
+	 * @return
+	 */
+	public boolean isConsistent(DatapathId oldSw, OFPort oldPort, 
+			DatapathId newSw, OFPort newPort);
+	
+	/**
+	 * Indicates if an attachment point on the new switch port is consistent
+	 * with the attachment point on the old switch port or not.
+	 * @param oldSw
+	 * @param oldPort
+	 * @param newSw
+	 * @param newPort
+	 * @param tunnelEnabled
+	 * @return
 	 */
 	public boolean isConsistent(DatapathId oldSw, OFPort oldPort,
-			DatapathId newSw, OFPort newPort);
-	public boolean isConsistent(DatapathId oldSw, OFPort oldPort,
-			DatapathId newSw, OFPort newPort,
-			boolean tunnelEnabled);
+			DatapathId newSw, OFPort newPort, boolean tunnelEnabled);
 
 	/**
 	 * Indicates if the two switch ports are connected to the same
@@ -120,98 +152,91 @@ public interface ITopologyService extends IFloodlightService  {
 	 */
 	public boolean isInSameBroadcastDomain(DatapathId s1, OFPort p1,
 			DatapathId s2, OFPort p2);
+	
+	/**
+	 * Indicates if the two switch ports are connected to the same
+	 * broadcast domain or not.
+	 * @param s1
+	 * @param p1
+	 * @param s2
+	 * @param p2
+	 * @param tunnelEnabled
+	 * @return
+	 */
 	public boolean isInSameBroadcastDomain(DatapathId s1, OFPort p1,
 			DatapathId s2, OFPort p2,
 			boolean tunnelEnabled);
 
-	/**
-	 * Gets a list of ports on a given switch that are known to topology.
-	 * @param sw The switch DPID in long
-	 * @return The set of ports on this switch
-	 */
-	public Set<OFPort> getPortsWithLinks(DatapathId sw);
-	public Set<OFPort> getPortsWithLinks(DatapathId sw, boolean tunnelEnabled);
-
-	/** Get broadcast ports on a target switch for a given attachmentpoint
+	/** 
+	 * Get broadcast ports on a target switch for a given attachment point
 	 * point port.
+	 * @param targetSw
+	 * @param src
+	 * @param srcPort
+	 * @return
 	 */
 	public Set<OFPort> getBroadcastPorts(DatapathId targetSw, DatapathId src, OFPort srcPort);
 
-	public Set<OFPort> getBroadcastPorts(DatapathId targetSw, DatapathId src, OFPort srcPort,
-			boolean tunnelEnabled);
+	/** 
+	 * Get broadcast ports on a target switch for a given attachment point
+	 * point port.
+	 * @param targetSw
+	 * @param src
+	 * @param srcPort
+	 * @param tunnelEnabled
+	 * @return
+	 */
+	public Set<OFPort> getBroadcastPorts(DatapathId targetSw, DatapathId src, OFPort srcPort, boolean tunnelEnabled);
 
 	/**
-	 *
+	 * Checks if the given switch+port is allowed to receive broadcast packets.
+	 * @param sw
+	 * @param portId
+	 * @return
 	 */
 	public boolean isIncomingBroadcastAllowed(DatapathId sw, OFPort portId);
-	public boolean isIncomingBroadcastAllowed(DatapathId sw, OFPort portId,
-			boolean tunnelEnabled);
-
-
-	/** Get the proper outgoing switchport for a given pair of src-dst
-	 * switchports.
-	 */
-	public NodePortTuple getOutgoingSwitchPort(DatapathId src, OFPort srcPort,
-			DatapathId dst, OFPort dstPort);
-
-
-	public NodePortTuple getOutgoingSwitchPort(DatapathId src, OFPort srcPort,
-			DatapathId dst, OFPort dstPort,
-			boolean tunnelEnabled);
-
-
-	public NodePortTuple getIncomingSwitchPort(DatapathId src, OFPort srcPort,
-			DatapathId dst, OFPort dstPort);
-	public NodePortTuple getIncomingSwitchPort(DatapathId src, OFPort srcPort,
-			DatapathId dst, OFPort dstPort,
-			boolean tunnelEnabled);
-
+	
 	/**
-	 * If the dst is not allowed by the higher-level topology,
-	 * this method provides the topologically equivalent broadcast port.
+	 * Checks if the given switch+port is allowed to receive broadcast packets.
+	 * @param sw
+	 * @param portId
+	 * @param tunnelEnabled
+	 * @return
+	 */
+	public boolean isIncomingBroadcastAllowed(DatapathId sw, OFPort portId, boolean tunnelEnabled);
+	
+	/**
+	 * If the src broadcast domain port is not allowed for incoming
+	 * broadcast, this method provides the topologically equivalent
+	 * incoming broadcast-allowed src port.
 	 * @param src
 	 * @param dst
-	 * @return the allowed broadcast port
+	 * @return
 	 */
-	public NodePortTuple
-	getAllowedOutgoingBroadcastPort(DatapathId src,
-			OFPort srcPort,
-			DatapathId dst,
-			OFPort dstPort);
-
-	public NodePortTuple
-	getAllowedOutgoingBroadcastPort(DatapathId src,
-			OFPort srcPort,
-			DatapathId dst,
-			OFPort dstPort,
-			boolean tunnelEnabled);
+	public NodePortTuple getAllowedIncomingBroadcastPort(DatapathId src, OFPort srcPort);
 
 	/**
 	 * If the src broadcast domain port is not allowed for incoming
 	 * broadcast, this method provides the topologically equivalent
-	 * incoming broadcast-allowed
-	 * src port.
+	 * incoming broadcast-allowed src port.
 	 * @param src
 	 * @param dst
-	 * @return the allowed broadcast port
+	 * @param tunnelEnabled
+	 * @return
 	 */
-	public NodePortTuple
-	getAllowedIncomingBroadcastPort(DatapathId src,
-			OFPort srcPort);
-
-	public NodePortTuple
-	getAllowedIncomingBroadcastPort(DatapathId src,
-			OFPort srcPort,
-			boolean tunnelEnabled);
-
+	public NodePortTuple getAllowedIncomingBroadcastPort(DatapathId src, OFPort srcPort, boolean tunnelEnabled);
 
 	/**
 	 * Gets the set of ports that belong to a broadcast domain.
-	 * @return The set of ports that belong to a broadcast domain.
+	 * @return
 	 */
 	public Set<NodePortTuple> getBroadcastDomainPorts();
+	
+	/**
+	 * Gets the set of ports that belong to tunnels.
+	 * @return
+	 */
 	public Set<NodePortTuple> getTunnelPorts();
-
 
 	/**
 	 * Returns a set of blocked ports.  The set of blocked
@@ -227,4 +252,153 @@ public interface ITopologyService extends IFloodlightService  {
 	 * has only quarantined ports. Will never return null.
 	 */
 	public Set<OFPort> getPorts(DatapathId sw);
+	
+	/*******************************************************
+	 * ISLAND/DOMAIN/CLUSTER FUNCTIONS
+	 *******************************************************/
+	
+	/**
+	 * Return the ID of the domain/island/cluster this switch is
+	 * a part of. The ID is the lowest switch DPID within the domain.
+	 * @param switchId
+	 * @return
+	 */
+	public DatapathId getOpenflowDomainId(DatapathId switchId);
+	
+	/**
+	 * Return the ID of the domain/island/cluster this switch is
+	 * a part of. The ID is the lowest switch DPID within the domain.
+	 * @param switchId
+	 * @return
+	 */
+	public DatapathId getOpenflowDomainId(DatapathId switchId, boolean tunnelEnabled);
+	
+	/**
+	 * Determines if two switches are in the same domain/island/cluster.
+	 * @param switch1
+	 * @param switch2
+	 * @return true if the switches are in the same cluster
+	 */
+	public boolean inSameOpenflowDomain(DatapathId switch1, DatapathId switch2);
+	
+	/**
+	 * Determines if two switches are in the same domain/island/cluster.
+	 * @param switch1
+	 * @param switch2
+	 * @param tunnelEnabled
+	 * @return true if the switches are in the same cluster
+	 */
+	public boolean inSameOpenflowDomain(DatapathId switch1, DatapathId switch2, boolean tunnelEnabled);
+
+	/**
+	 * Gets all switches in the same domain/island/cluster as the switch provided.
+	 * @param switchDPID
+	 * @return
+	 */
+	public Set<DatapathId> getSwitchesInOpenflowDomain(DatapathId switchDPID);
+	
+	/**
+	 * Gets all switches in the same domain/island/cluster as the switch provided.
+	 * @param switchDPID
+	 * @param tunnelEnabled
+	 * @return
+	 */
+	public Set<DatapathId> getSwitchesInOpenflowDomain(DatapathId switchDPID, boolean tunnelEnabled);
+	
+	/*******************************************************
+	 * LINK FUNCTIONS
+	 *******************************************************/
+	
+	/**
+	 * Get all network links, including intra-cluster and inter-cluster links. 
+	 * Links are grouped for each DatapathId separately.
+	 * @return
+	 */
+	public Map<DatapathId, Set<Link>> getAllLinks();
+	
+	/**
+	 * Gets a list of ports on a given switch that are part of known links.
+	 * @param sw
+	 * @return
+	 */
+	public Set<OFPort> getPortsWithLinks(DatapathId sw);
+	
+	/**
+	 * Gets a list of ports on a given switch that are part of known links.
+	 * @param sw
+	 * @param tunnelEnabled
+	 * @return
+	 */
+	public Set<OFPort> getPortsWithLinks(DatapathId sw, boolean tunnelEnabled);
+
+	/*******************************************************
+	 * ROUTING FUNCTIONS
+	 *******************************************************/
+	
+	/**
+	 * If trying to route a packet ingress a source switch+port to a destination
+	 * switch+port, retrieve the egress source switch+port leading to the destination.
+	 * @param src
+	 * @param srcPort
+	 * @param dst
+	 * @param dstPort
+	 * @return
+	 */
+	public NodePortTuple getOutgoingSwitchPort(DatapathId src, OFPort srcPort, DatapathId dst, OFPort dstPort);
+
+	/**
+	 * If trying to route a packet ingress a source switch+port to a destination
+	 * switch+port, retrieve the egress source switch+port leading to the destination.
+	 * @param src
+	 * @param srcPort
+	 * @param dst
+	 * @param dstPort
+	 * @param tunnelEnabled
+	 * @return
+	 */
+	public NodePortTuple getOutgoingSwitchPort(DatapathId src, OFPort srcPort,
+			DatapathId dst, OFPort dstPort, boolean tunnelEnabled);
+
+	/**
+	 * If trying to route a packet ingress a source switch+port to a destination
+	 * switch+port, retrieve the ingress destination switch+port leading to the destination.
+	 * @param src
+	 * @param srcPort
+	 * @param dst
+	 * @param dstPort
+	 * @return
+	 */
+	public NodePortTuple getIncomingSwitchPort(DatapathId src, OFPort srcPort, DatapathId dst, OFPort dstPort);
+	
+	/**
+	 * If trying to route a packet ingress a source switch+port to a destination
+	 * switch+port, retrieve the ingress destination switch+port leading to the destination.
+	 * @param src
+	 * @param srcPort
+	 * @param dst
+	 * @param dstPort
+	 * @param tunnelEnabled
+	 * @return
+	 */
+	public NodePortTuple getIncomingSwitchPort(DatapathId src, OFPort srcPort,
+			DatapathId dst, OFPort dstPort, boolean tunnelEnabled);
+
+	/**
+	 * If the dst is not allowed by the higher-level topology,
+	 * this method provides the topologically equivalent broadcast port.
+	 * @param src
+	 * @param dst
+	 * @return the allowed broadcast port
+	 */
+	public NodePortTuple getAllowedOutgoingBroadcastPort(DatapathId src, OFPort srcPort, DatapathId dst, OFPort dstPort);
+	
+	/**
+	 * If the dst is not allowed by the higher-level topology,
+	 * this method provides the topologically equivalent broadcast port.
+	 * @param src
+	 * @param dst
+	 * @param tunnelEnabled
+	 * @return the allowed broadcast port
+	 */
+	public NodePortTuple getAllowedOutgoingBroadcastPort(DatapathId src, OFPort srcPort, DatapathId dst, OFPort dstPort, boolean tunnelEnabled);
 }

--- a/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
@@ -118,32 +118,32 @@ public class TopologyInstance {
                             Set<NodePortTuple> blockedPorts,
                             Map<NodePortTuple, Set<Link>> switchPortLinks,
                             Set<NodePortTuple> broadcastDomainPorts,
-                            Set<NodePortTuple> tunnelPorts, Map<NodePortTuple, Set<Link>> allLinks, Map<DatapathId, Set<OFPort>> allPorts){
-
-        // copy these structures
+                            Set<NodePortTuple> tunnelPorts, 
+                            Map<NodePortTuple, Set<Link>> allLinks, 
+                            Map<DatapathId, Set<OFPort>> allPorts) {
 	
         this.switches = new HashSet<DatapathId>(switchPorts.keySet());
         this.switchPorts = new HashMap<DatapathId, Set<OFPort>>();
-        for(DatapathId sw: switchPorts.keySet()) {
+        for (DatapathId sw : switchPorts.keySet()) {
             this.switchPorts.put(sw, new HashSet<OFPort>(switchPorts.get(sw)));
         }
 		
 		this.allPorts = new HashMap<DatapathId, Set<OFPort>>();
-		for(DatapathId sw: allPorts.keySet()) {
+		for (DatapathId sw : allPorts.keySet()) {
             this.allPorts.put(sw, new HashSet<OFPort>(allPorts.get(sw)));
         }
 
         this.blockedPorts = new HashSet<NodePortTuple>(blockedPorts);
         this.switchPortLinks = new HashMap<NodePortTuple, Set<Link>>();
-        for(NodePortTuple npt: switchPortLinks.keySet()) {
-            this.switchPortLinks.put(npt,
-                                     new HashSet<Link>(switchPortLinks.get(npt)));
+        for (NodePortTuple npt : switchPortLinks.keySet()) {
+            this.switchPortLinks.put(npt, new HashSet<Link>(switchPortLinks.get(npt)));
         }
+        
 		this.allLinks = new HashMap<NodePortTuple, Set<Link>>();
-        for(NodePortTuple npt: allLinks.keySet()) {
-            this.allLinks.put(npt,
-                                     new HashSet<Link>(allLinks.get(npt)));
+        for (NodePortTuple npt : allLinks.keySet()) {
+            this.allLinks.put(npt, new HashSet<Link>(allLinks.get(npt)));
         }
+        
         this.broadcastDomainPorts = new HashSet<NodePortTuple>(broadcastDomainPorts);
         this.tunnelPorts = new HashSet<NodePortTuple>(tunnelPorts);
 
@@ -226,8 +226,8 @@ public class TopologyInstance {
 	 * Returns broadcast ports for the given DatapathId
 	 */
     public Set<OFPort> swBroadcastPorts(DatapathId sw){
-	
-		return this.broadcastPortMap.get(sw);
+    	return this.broadcastPortMap.get(sw);
+
     }
 
     public void printTopology() {
@@ -281,22 +281,22 @@ public class TopologyInstance {
 
         if (switches == null) return;
 
-        for (DatapathId key: switches) {
+        for (DatapathId key : switches) {
             ClusterDFS cdfs = new ClusterDFS();
             dfsList.put(key, cdfs);
         }
+        
         Set<DatapathId> currSet = new HashSet<DatapathId>();
 
-        for (DatapathId sw: switches) {
+        for (DatapathId sw : switches) {
             ClusterDFS cdfs = dfsList.get(sw);
             if (cdfs == null) {
                 log.error("No DFS object for switch {} found.", sw);
-            }else if (!cdfs.isVisited()) {
+            } else if (!cdfs.isVisited()) {
                 dfsTraverse(0, 1, sw, dfsList, currSet);
             }
         }
     }
-
 
     /**
      * @author Srinivasan Ramasubramanian
@@ -327,11 +327,10 @@ public class TopologyInstance {
      * @return long: DSF index to be used when a new node is visited
      */
     private long dfsTraverse (long parentIndex, long currIndex, DatapathId currSw,
-                              Map<DatapathId, ClusterDFS> dfsList, Set <DatapathId> currSet) {
+                              Map<DatapathId, ClusterDFS> dfsList, Set<DatapathId> currSet) {
 
         //Get the DFS object corresponding to the current switch
         ClusterDFS currDFS = dfsList.get(currSw);
-        // Get all the links corresponding to this switch
 
         Set<DatapathId> nodesInMyCluster = new HashSet<DatapathId>();
         Set<DatapathId> myCurrSet = new HashSet<DatapathId>();
@@ -344,10 +343,10 @@ public class TopologyInstance {
 
         // Traverse the graph through every outgoing link.
         if (switchPorts.get(currSw) != null){
-            for(OFPort p: switchPorts.get(currSw)) {
+            for (OFPort p : switchPorts.get(currSw)) {
                 Set<Link> lset = switchPortLinks.get(new NodePortTuple(currSw, p));
                 if (lset == null) continue;
-                for(Link l:lset) {
+                for (Link l : lset) {
                     DatapathId dstSw = l.getDst();
 
                     // ignore incoming links.
@@ -368,19 +367,22 @@ public class TopologyInstance {
 
                     if (dstDFS.getDfsIndex() < currDFS.getDfsIndex()) {
                         // could be a potential lowpoint
-                        if (dstDFS.getDfsIndex() < currDFS.getLowpoint())
+                        if (dstDFS.getDfsIndex() < currDFS.getLowpoint()) {
                             currDFS.setLowpoint(dstDFS.getDfsIndex());
-
+                        }
                     } else if (!dstDFS.isVisited()) {
                         // make a DFS visit
-                        currIndex = dfsTraverse(currDFS.getDfsIndex(), currIndex, dstSw,
-                                                dfsList, myCurrSet);
+                        currIndex = dfsTraverse(
+                        		currDFS.getDfsIndex(), 
+                        		currIndex, dstSw, 
+                        		dfsList, myCurrSet);
 
                         if (currIndex < 0) return -1;
 
                         // update lowpoint after the visit
-                        if (dstDFS.getLowpoint() < currDFS.getLowpoint())
+                        if (dstDFS.getLowpoint() < currDFS.getLowpoint()) {
                             currDFS.setLowpoint(dstDFS.getLowpoint());
+                        }
 
                         nodesInMyCluster.addAll(myCurrSet);
                         myCurrSet.clear();
@@ -403,7 +405,7 @@ public class TopologyInstance {
             // create a new switch cluster and the switches in the current
             // set to the switch cluster.
             Cluster sc = new Cluster();
-            for(DatapathId sw: currSet){
+            for (DatapathId sw : currSet) {
                 sc.add(sw);
                 switchClusterMap.put(sw, sc);
             }
@@ -517,48 +519,57 @@ public class TopologyInstance {
     protected BroadcastTree clusterDijkstra(Cluster c, DatapathId root,
                                      Map<Link, Integer> linkCost,
                                      boolean isDstRooted) {
+    	
         HashMap<DatapathId, Link> nexthoplinks = new HashMap<DatapathId, Link>();
-        //HashMap<Long, Long> nexthopnodes = new HashMap<Long, Long>();
         HashMap<DatapathId, Integer> cost = new HashMap<DatapathId, Integer>();
         int w;
 
-        for (DatapathId node: c.links.keySet()) {
+        for (DatapathId node : c.links.keySet()) {
             nexthoplinks.put(node, null);
-            //nexthopnodes.put(node, null);
             cost.put(node, MAX_PATH_WEIGHT);
         }
 
         HashMap<DatapathId, Boolean> seen = new HashMap<DatapathId, Boolean>();
         PriorityQueue<NodeDist> nodeq = new PriorityQueue<NodeDist>();
+        
         nodeq.add(new NodeDist(root, 0));
         cost.put(root, 0);
+        
         while (nodeq.peek() != null) {
             NodeDist n = nodeq.poll();
             DatapathId cnode = n.getNode();
+            
             int cdist = n.getDist();
             if (cdist >= MAX_PATH_WEIGHT) break;
             if (seen.containsKey(cnode)) continue;
+            
             seen.put(cnode, true);
 
-            for (Link link: c.links.get(cnode)) {
+            for (Link link : c.links.get(cnode)) {
                 DatapathId neighbor;
 
-                if (isDstRooted == true) neighbor = link.getSrc();
-                else neighbor = link.getDst();
+                if (isDstRooted == true) {
+                	neighbor = link.getSrc();
+                } else {
+                	neighbor = link.getDst();
+                }
 
                 // links directed toward cnode will result in this condition
                 if (neighbor.equals(cnode)) continue;
 
                 if (seen.containsKey(neighbor)) continue;
 
-                if (linkCost == null || linkCost.get(link)==null) w = 1;
-                else w = linkCost.get(link);
+                if (linkCost == null || linkCost.get(link) == null) {
+                	w = 1;
+                } else {
+                	w = linkCost.get(link);
+                }
 
                 int ndist = cdist + w; // the weight of the link, always 1 in current version of floodlight.
                 if (ndist < cost.get(neighbor)) {
                     cost.put(neighbor, ndist);
                     nexthoplinks.put(neighbor, link);
-                    //nexthopnodes.put(neighbor, cnode);
+                    
                     NodeDist ndTemp = new NodeDist(neighbor, ndist);
                     // Remove an object that's already in there.
                     // Note that the comparison is based on only the node id,
@@ -574,11 +585,9 @@ public class TopologyInstance {
         return ret;
     }
     
-	
 	/*
 	 * Dijkstra that calculates destination rooted trees over the entire topology.
 	*/
-    
     protected BroadcastTree dijkstra(Map<DatapathId, Set<Link>> links, DatapathId root,
             Map<Link, Integer> linkCost,
             boolean isDstRooted) {
@@ -586,7 +595,7 @@ public class TopologyInstance {
     	HashMap<DatapathId, Integer> cost = new HashMap<DatapathId, Integer>();
     	int w;
     	
-    	for (DatapathId node: links.keySet()) {
+    	for (DatapathId node : links.keySet()) {
     		nexthoplinks.put(node, null);
     		cost.put(node, MAX_PATH_WEIGHT);
     	}
@@ -595,31 +604,41 @@ public class TopologyInstance {
     	PriorityQueue<NodeDist> nodeq = new PriorityQueue<NodeDist>();
     	nodeq.add(new NodeDist(root, 0));
     	cost.put(root, 0);
+    	
     	while (nodeq.peek() != null) {
     		NodeDist n = nodeq.poll();
     		DatapathId cnode = n.getNode();
     		int cdist = n.getDist();
+    		
     		if (cdist >= MAX_PATH_WEIGHT) break;
     		if (seen.containsKey(cnode)) continue;
     		seen.put(cnode, true);
 
-    		for (Link link: links.get(cnode)) {
+    		for (Link link : links.get(cnode)) {
     			DatapathId neighbor;
 
-    			if (isDstRooted == true) neighbor = link.getSrc();
-    			else neighbor = link.getDst();
+    			if (isDstRooted == true) {
+    				neighbor = link.getSrc();
+    			} else {
+    				neighbor = link.getDst();
+    			}
         
     			// links directed toward cnode will result in this condition
     			if (neighbor.equals(cnode)) continue;
 
     			if (seen.containsKey(neighbor)) continue;
 
-    			if (linkCost == null || linkCost.get(link)==null) w = 1;
-    			else w = linkCost.get(link);
+    			if (linkCost == null || linkCost.get(link) == null) {
+    				w = 1;
+    			} else {
+    				w = linkCost.get(link);
+    			}
+    			
     			int ndist = cdist + w; // the weight of the link, always 1 in current version of floodlight.
     			if (ndist < cost.get(neighbor)) {
     				cost.put(neighbor, ndist);
     				nexthoplinks.put(neighbor, link);
+    				
     				NodeDist ndTemp = new NodeDist(neighbor, ndist);
     				// Remove an object that's already in there.
     				// Note that the comparison is based on only the node id,
@@ -645,22 +664,22 @@ public class TopologyInstance {
     	Map<Link, Integer> linkCost = new HashMap<Link, Integer>();
         int tunnel_weight = switchPorts.size() + 1;
 		
-        for(NodePortTuple npt : tunnelPorts) {
+        for (NodePortTuple npt : tunnelPorts) {
             if (allLinks.get(npt) == null) continue;
-            for(Link link : allLinks.get(npt)) {
+            for (Link link : allLinks.get(npt)) {
                 if (link == null) continue;
                 linkCost.put(link, tunnel_weight);
             }
         }
         
         Map<DatapathId, Set<Link>> linkDpidMap = new HashMap<DatapathId, Set<Link>>();
-        for(DatapathId s : switches) {
+        for (DatapathId s : switches) {
             if (switchPorts.get(s) == null) continue;
-            for (OFPort p: switchPorts.get(s)) {
+            for (OFPort p : switchPorts.get(s)) {
                 NodePortTuple np = new NodePortTuple(s, p);
                 if (allLinks.get(np) == null) continue;
-                for(Link l: allLinks.get(np)) {
-                	if(linkDpidMap.containsKey(s)) {
+                for (Link l : allLinks.get(np)) {
+                	if (linkDpidMap.containsKey(s)) {
                 		linkDpidMap.get(s).add(l);
                 	}
                 	else {
@@ -674,9 +693,10 @@ public class TopologyInstance {
         	BroadcastTree tree = dijkstra(linkDpidMap, node, linkCost, true);
             destinationRootedFullTrees.put(node, tree);
         }
+        
 		//finiteBroadcastTree is randomly chosen in this implementation
         if (this.destinationRootedFullTrees.size() > 0) {
-			this.finiteBroadcastTree =  destinationRootedFullTrees.values().iterator().next();
+			this.finiteBroadcastTree = destinationRootedFullTrees.values().iterator().next();
         }         	
     }
 
@@ -684,18 +704,18 @@ public class TopologyInstance {
         pathcache.invalidateAll();
         destinationRootedTrees.clear();
 
-        Map <Link, Integer> linkCost = new HashMap<Link, Integer>();
+        Map<Link, Integer> linkCost = new HashMap<Link, Integer>();
         int tunnel_weight = switchPorts.size() + 1;
 
-        for(NodePortTuple npt: tunnelPorts) {
+        for (NodePortTuple npt : tunnelPorts) {
             if (switchPortLinks.get(npt) == null) continue;
-            for(Link link: switchPortLinks.get(npt)) {
+            for (Link link : switchPortLinks.get(npt)) {
                 if (link == null) continue;
                 linkCost.put(link, tunnel_weight);
             }
         }
 
-        for(Cluster c: clusters) {
+        for (Cluster c : clusters) {
             for (DatapathId node : c.links.keySet()) {
                 BroadcastTree tree = clusterDijkstra(c, node, linkCost, true);
                 destinationRootedTrees.put(node, tree);
@@ -717,10 +737,10 @@ public class TopologyInstance {
 	
     protected void calculateAllBroadcastNodePorts() {
 		if (this.destinationRootedFullTrees.size() > 0) {
-			this.finiteBroadcastTree=destinationRootedFullTrees.values().iterator().next();
+			this.finiteBroadcastTree = destinationRootedFullTrees.values().iterator().next();
 			Map<DatapathId, Link> links = finiteBroadcastTree.getLinks();
 			if (links == null) return;
-			for(DatapathId nodeId: links.keySet()) {
+			for (DatapathId nodeId : links.keySet()) {
 				Link l = links.get(nodeId);
 				if (l == null) continue;
 				NodePortTuple npt1 = new NodePortTuple(l.getSrc(), l.getSrcPort());
@@ -733,7 +753,6 @@ public class TopologyInstance {
 
     protected void calculateBroadcastPortMap(){
 		this.broadcastPortMap.clear();
-		if (destinationRootedFullTrees.size() == 0) return;
 
 		for (DatapathId sw : this.switches) {
 			for (OFPort p : this.allPorts.get(sw)){
@@ -741,9 +760,8 @@ public class TopologyInstance {
 				if (isEdge(sw, p) || broadcastNodePorts.contains(npt)) { 
 					if (broadcastPortMap.containsKey(sw)) {
                 		broadcastPortMap.get(sw).add(p);
-                	}
-                	else {
-                		broadcastPortMap.put(sw,new HashSet<OFPort>(Arrays.asList(p)));
+                	} else {
+                		broadcastPortMap.put(sw, new HashSet<OFPort>(Arrays.asList(p)));
                 	}
 				}      		
 			}
@@ -755,7 +773,7 @@ public class TopologyInstance {
         
         calculateBroadcastTreeInClusters();
 
-        for(Cluster c: clusters) {
+        for (Cluster c : clusters) {
             // c.id is the smallest node that's in the cluster
             BroadcastTree tree = clusterBroadcastTrees.get(c.id);
             //log.info("Broadcast Tree {}", tree);
@@ -763,7 +781,7 @@ public class TopologyInstance {
             Set<NodePortTuple> nptSet = new HashSet<NodePortTuple>();
             Map<DatapathId, Link> links = tree.getLinks();
             if (links == null) continue;
-            for (DatapathId nodeId: links.keySet()) {
+            for (DatapathId nodeId : links.keySet()) {
                 Link l = links.get(nodeId);
                 if (l == null) continue;
                 NodePortTuple npt1 = new NodePortTuple(l.getSrc(), l.getSrcPort());
@@ -825,7 +843,7 @@ public class TopologyInstance {
     protected int getCost(DatapathId srcId, DatapathId dstId) {
         BroadcastTree bt = destinationRootedTrees.get(dstId);
         if (bt == null) return -1;
-        return (bt.getCost(srcId));
+        return bt.getCost(srcId);
     }
     
     protected Set<Cluster> getClusters() {
@@ -847,13 +865,16 @@ public class TopologyInstance {
             DatapathId dstId, OFPort dstPort, U64 cookie) {
         // Return null if the route source and destination are the
         // same switch ports.
-        if (srcId.equals(dstId) && srcPort.equals(dstPort))
+        if (srcId.equals(dstId) && srcPort.equals(dstPort)) {
             return null;
+        }
 
         List<NodePortTuple> nptList;
         NodePortTuple npt;
         Route r = getRoute(srcId, dstId, U64.of(0));
-        if (r == null && !srcId.equals(dstId)) return null;
+        if (r == null && !srcId.equals(dstId)) {
+        	return null;
+        }
 
         if (r != null) {
             nptList= new ArrayList<NodePortTuple>(r.getPath());
@@ -1003,7 +1024,7 @@ public class TopologyInstance {
     public Set<OFPort> getBroadcastPorts(DatapathId targetSw, DatapathId src, OFPort srcPort) {
         Set<OFPort> result = new HashSet<OFPort>();
         DatapathId clusterId = getOpenflowDomainId(targetSw);
-        for(NodePortTuple npt: clusterPorts.get(clusterId)) {
+        for (NodePortTuple npt : clusterPorts.get(clusterId)) {
             if (npt.getNodeId().equals(targetSw)) {
                 result.add(npt.getPortId());
             }

--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -418,17 +418,6 @@ public class TopologyManager implements IFloodlightModule, ITopologyService, IRo
 	}
 
 	@Override
-	public DatapathId getL2DomainId(DatapathId switchId) {
-		return getL2DomainId(switchId, true);
-	}
-
-	@Override
-	public DatapathId getL2DomainId(DatapathId switchId, boolean tunnelEnabled) {
-		TopologyInstance ti = getCurrentInstance(tunnelEnabled);
-		return ti.getL2DomainId(switchId);
-	}
-
-	@Override
 	public boolean inSameOpenflowDomain(DatapathId switch1, DatapathId switch2) {
 		return inSameOpenflowDomain(switch1, switch2, true);
 	}
@@ -597,23 +586,6 @@ public class TopologyManager implements IFloodlightModule, ITopologyService, IRo
 			boolean tunnelEnabled) {
 		TopologyInstance ti = getCurrentInstance(tunnelEnabled);
 		return ti.isConsistent(oldSw, oldPort, newSw, newPort);
-	}
-
-	////////////////////////////////////////////////////////////////////////
-	////////////////////////////////////////////////////////////////////////
-	/**
-	 * Checks if the two switches are in the same Layer 2 domain.
-	 */
-	@Override
-	public boolean inSameL2Domain(DatapathId switch1, DatapathId switch2) {
-		return inSameL2Domain(switch1, switch2, true);
-	}
-
-	@Override
-	public boolean inSameL2Domain(DatapathId switch1, DatapathId switch2,
-			boolean tunnelEnabled) {
-		TopologyInstance ti = getCurrentInstance(tunnelEnabled);
-		return ti.inSameL2Domain(switch1, switch2);
 	}
 
 	////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/floodlightcontroller/topology/web/SwitchClustersResource.java
+++ b/src/main/java/net/floodlightcontroller/topology/web/SwitchClustersResource.java
@@ -55,7 +55,7 @@ public class SwitchClustersResource extends ServerResource {
             DatapathId clusterDpid =
                     (openflowDomain
                      ? topologyService.getOpenflowDomainId(dpid)
-                     :topologyService.getL2DomainId(dpid));
+                     :topologyService.getOpenflowDomainId(dpid));
             List<String> switchesInCluster = switchClusterMap.get(clusterDpid.toString());
             if (switchesInCluster != null) {
                 switchesInCluster.add(dpid.toString());

--- a/src/test/java/net/floodlightcontroller/accesscontrollist/ACLTest.java
+++ b/src/test/java/net/floodlightcontroller/accesscontrollist/ACLTest.java
@@ -167,7 +167,7 @@ public class ACLTest extends FloodlightTestCase {
 		
 		reset(topology);
 //		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
-//		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+//		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L), OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(2L), OFPort.of(1))).andReturn(true).anyTimes();
 		replay(topology);
@@ -413,7 +413,7 @@ public class ACLTest extends FloodlightTestCase {
 	public void testDeviceIPV4AddrChanged() {
 		
 		reset(topology);
-		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L), OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(2L), OFPort.of(1))).andReturn(true).anyTimes();
 		replay(topology);
@@ -474,7 +474,7 @@ public class ACLTest extends FloodlightTestCase {
 	public void testDeleteRule(){
 		reset(topology);
 //		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
-//		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+//		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L), OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(2L), OFPort.of(1))).andReturn(true).anyTimes();
 		replay(topology);
@@ -560,7 +560,7 @@ public class ACLTest extends FloodlightTestCase {
 	public void testDeleteAllRules(){
 		reset(topology);
 //		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
-//		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+//		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L), OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(2L), OFPort.of(1))).andReturn(true).anyTimes();
 		replay(topology);

--- a/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImplTest.java
+++ b/src/test/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImplTest.java
@@ -157,7 +157,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		ITopologyService mockTopology = createMock(ITopologyService.class);
 		mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()), OFPort.of(anyShort()));
 		expectLastCall().andReturn(true).anyTimes();
-		mockTopology.getL2DomainId(DatapathId.of(anyLong()));
+		mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()));
 		expectLastCall().andReturn(DatapathId.of(1L)).anyTimes();
 		mockTopology.isBroadcastDomainPort(DatapathId.of(anyLong()), OFPort.of(anyShort()));
 		expectLastCall().andReturn(false).anyTimes();
@@ -409,7 +409,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		deviceManager.startUp(null);
 
 		ITopologyService mockTopology = createMock(ITopologyService.class);
-		expect(mockTopology.getL2DomainId(DatapathId.of(anyLong()))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()))).
 		andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isBroadcastDomainPort(DatapathId.of(anyLong()), OFPort.of(anyShort()))).
 		andReturn(false).anyTimes();
@@ -580,7 +580,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		deviceManager.startUp(null);
 
 		ITopologyService mockTopology = createMock(ITopologyService.class);
-		expect(mockTopology.getL2DomainId(DatapathId.of(anyLong()))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()))).
 		andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isBroadcastDomainPort(DatapathId.of(anyLong()), OFPort.of(anyShort()))).
 		andReturn(false).anyTimes();
@@ -790,13 +790,13 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		reset(mockListener);
 
 		ITopologyService mockTopology = createMock(ITopologyService.class);
-		expect(mockTopology.getL2DomainId(DatapathId.of(1L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(1L))).
 		andReturn(DatapathId.of(1L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(5L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(5L))).
 		andReturn(DatapathId.of(1L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(10L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(10L))).
 		andReturn(DatapathId.of(10L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(50L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(50L))).
 		andReturn(DatapathId.of(10L)).anyTimes();
 		expect(mockTopology.isBroadcastDomainPort(DatapathId.of(anyLong()), OFPort.of(anyShort()))).
 		andReturn(false).anyTimes();
@@ -907,13 +907,13 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		reset(mockListener);
 
 		ITopologyService mockTopology = createMock(ITopologyService.class);
-		expect(mockTopology.getL2DomainId(DatapathId.of(1L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(1L))).
 		andReturn(DatapathId.of(1L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(2L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(2L))).
 		andReturn(DatapathId.of(1L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(3L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(3L))).
 		andReturn(DatapathId.of(1L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(4L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(4L))).
 		andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isBroadcastDomainPort(DatapathId.of(anyLong()), OFPort.of(anyShort())))
 		.andReturn(false).anyTimes();
@@ -1031,13 +1031,13 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		reset(mockListener);
 
 		ITopologyService mockTopology = createMock(ITopologyService.class);
-		expect(mockTopology.getL2DomainId(DatapathId.of(1L))). /* two different OpenFlow islands, 1 and 10 */
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(1L))). /* two different OpenFlow islands, 1 and 10 */
 		andReturn(DatapathId.of(1L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(5L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(5L))).
 		andReturn(DatapathId.of(1L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(10L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(10L))).
 		andReturn(DatapathId.of(10L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(50L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(50L))).
 		andReturn(DatapathId.of(10L)).anyTimes();
 		expect(mockTopology.isBroadcastDomainPort(DatapathId.of(anyLong()), OFPort.of(anyShort())))
 		.andReturn(false).anyTimes();
@@ -1137,7 +1137,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 	@Test
 	public void testBDAttachmentPointLearning() throws Exception {
 		ITopologyService mockTopology = createMock(ITopologyService.class);
-		expect(mockTopology.getL2DomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()), OFPort.of(anyShort()))).
 		andReturn(true).anyTimes();
 		expect(mockTopology.isBroadcastDomainPort(DatapathId.of(1L), OFPort.of(1))).
@@ -1198,7 +1198,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 	@Test
 	public void testLOCALAttachmentPointLearning() throws Exception {
 		ITopologyService mockTopology = createMock(ITopologyService.class);
-		expect(mockTopology.getL2DomainId(DatapathId.of(anyLong()))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()))).
 		andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()), OFPort.of(anyShort()))).
 		andReturn(true).anyTimes();
@@ -1271,7 +1271,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 				OFPort.of(EasyMock.anyShort())))
 				.andReturn(false)
 				.anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isInSameBroadcastDomain(DatapathId.of(anyLong()),
 				OFPort.of(anyShort()),
 				DatapathId.of(anyLong()),
@@ -1732,8 +1732,8 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 
 		expect(mockTopology.isBroadcastDomainPort(DatapathId.of(1L), OFPort.of(1))).andReturn(false).anyTimes();
 		expect(mockTopology.isBroadcastDomainPort(DatapathId.of(5L), OFPort.of(1))).andReturn(false).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes(); /* different islands */
-		expect(mockTopology.getL2DomainId(DatapathId.of(5L))).andReturn(DatapathId.of(5L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes(); /* different islands */
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(5L))).andReturn(DatapathId.of(5L)).anyTimes();
 		expect(mockTopology.isConsistent(DatapathId.of(1L), OFPort.of(1), DatapathId.of(5L), OFPort.of(1))).
 		andReturn(false).anyTimes();
 
@@ -1821,8 +1821,8 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 				OFPort.of(EasyMock.anyShort()))).
 				andReturn(true).
 				anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(5L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(5L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isConsistent(DatapathId.of(EasyMock.anyLong()),
 				OFPort.of(EasyMock.anyShort()),
 				DatapathId.of(EasyMock.anyLong()),
@@ -1968,7 +1968,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 				andReturn(false).anyTimes();
 		expect(mockTopology.isInSameBroadcastDomain(DatapathId.of(anyLong()), OFPort.of(anyShort()),
 				DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(false).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(anyLong()))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()))).
 		andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isConsistent(DatapathId.of(1L), OFPort.of(1), DatapathId.of(1L), OFPort.of(1))).
 		andReturn(true).anyTimes();
@@ -2058,9 +2058,9 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 				andReturn(false).anyTimes();
 		expect(mockTopology.isInSameBroadcastDomain(DatapathId.of(anyLong()), OFPort.of(anyShort()),
 				DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(false).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(1L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(1L))).
 		andReturn(DatapathId.of(1L)).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(5L))).
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(5L))).
 		andReturn(DatapathId.of(5L)).anyTimes();
 		expect(mockTopology.isConsistent(DatapathId.of(1L), OFPort.of(1), DatapathId.of(1L), OFPort.of(2))).
 		andReturn(false).anyTimes();
@@ -2237,7 +2237,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()),
 				OFPort.of(anyShort()))).
 				andReturn(true).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		replay(mockTopology);
 		doTestDeviceQuery();
 	}
@@ -2249,7 +2249,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()),
 				OFPort.of(anyShort()))).
 				andReturn(true).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		replay(mockTopology);
 
 		doTestDeviceQuery();
@@ -2334,7 +2334,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()),
 				OFPort.of(anyShort()))).
 				andReturn(true).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		replay(mockTopology);
 
 		doTestDeviceClassQuery();
@@ -2346,7 +2346,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		deviceManager.topology = mockTopology;
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()),
 				OFPort.of(anyShort()))).andReturn(true).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		replay(mockTopology);
 
 		doTestDeviceClassQuery();
@@ -2363,7 +2363,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()),
 				OFPort.of(anyShort()))).
 				andReturn(true).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(EasyMock.anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		replay(mockTopology);
 
 		Entity entity1 = new Entity(MacAddress.of(1L), VlanVid.ofVlan(1), IPv4Address.of(1), IPv6Address.NONE, DatapathId.of(1L), OFPort.of(1), new Date());
@@ -2497,7 +2497,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()),
 				OFPort.of(anyShort()))).
 				andReturn(true).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isConsistent(DatapathId.of(EasyMock.anyLong()),
 				OFPort.of(EasyMock.anyShort()),
 				DatapathId.of(EasyMock.anyLong()),
@@ -2608,7 +2608,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()),
 				OFPort.of(anyShort()))).
 				andReturn(true).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isConsistent(DatapathId.of(EasyMock.anyLong()),
 				OFPort.of(EasyMock.anyShort()),
 				DatapathId.of(EasyMock.anyLong()),
@@ -2746,7 +2746,7 @@ public class DeviceManagerImplTest extends FloodlightTestCase {
 		expect(mockTopology.isAttachmentPointPort(DatapathId.of(anyLong()),
 				OFPort.of(anyShort()))).
 				andReturn(true).anyTimes();
-		expect(mockTopology.getL2DomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(mockTopology.getOpenflowDomainId(DatapathId.of(anyLong()))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(mockTopology.isConsistent(DatapathId.of(EasyMock.anyLong()),
 				OFPort.of(EasyMock.anyShort()),
 				DatapathId.of(EasyMock.anyLong()),

--- a/src/test/java/net/floodlightcontroller/forwarding/ForwardingTest.java
+++ b/src/test/java/net/floodlightcontroller/forwarding/ForwardingTest.java
@@ -456,8 +456,8 @@ public class ForwardingTest extends FloodlightTestCase {
 		expectLastCall().anyTimes();
 
 		reset(topology);
-		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
-		expect(topology.getL2DomainId(DatapathId.of(2L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(2L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L),  OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(2L),  OFPort.of(3))).andReturn(true).anyTimes();
 		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
@@ -528,8 +528,8 @@ public class ForwardingTest extends FloodlightTestCase {
 		expectLastCall().anyTimes();
 
 		reset(topology);
-		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
-		expect(topology.getL2DomainId(DatapathId.of(2L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(2L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L),  OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(2L),  OFPort.of(3))).andReturn(true).anyTimes();
 		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
@@ -597,7 +597,7 @@ public class ForwardingTest extends FloodlightTestCase {
 
 		reset(topology);
 		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
-		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L), OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L), OFPort.of(3))).andReturn(true).anyTimes();
 		expect(topology.isEdge(DatapathId.of(1L), OFPort.of(1))).andReturn(true).anyTimes();
@@ -653,7 +653,7 @@ public class ForwardingTest extends FloodlightTestCase {
 
 		reset(topology);
 		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
-		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L),  OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L),  OFPort.of(3))).andReturn(true).anyTimes();
 		expect(topology.isEdge(DatapathId.of(1L), OFPort.of(1))).andReturn(true).anyTimes();
@@ -681,7 +681,7 @@ public class ForwardingTest extends FloodlightTestCase {
 		reset(topology);
 		expect(topology.isAttachmentPointPort(DatapathId.of(anyLong()), OFPort.of(anyShort())))
 		.andReturn(true).anyTimes();
-		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
 		replay(topology);
 
 
@@ -717,7 +717,7 @@ public class ForwardingTest extends FloodlightTestCase {
 
 		reset(topology);
 		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
-		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L),  OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L),  OFPort.of(3))).andReturn(true).anyTimes();
 

--- a/src/test/java/net/floodlightcontroller/loadbalancer/LoadBalancerTest.java
+++ b/src/test/java/net/floodlightcontroller/loadbalancer/LoadBalancerTest.java
@@ -471,7 +471,7 @@ public class LoadBalancerTest extends FloodlightTestCase {
 		// Build topology
 		reset(topology);
 		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
-		expect(topology.getL2DomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
+		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L), OFPort.of(1))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L), OFPort.of(2))).andReturn(true).anyTimes();
 		expect(topology.isAttachmentPointPort(DatapathId.of(1L), OFPort.of(3))).andReturn(true).anyTimes();


### PR DESCRIPTION
Tidy up topology and get rid of some many redundant functions in IToologyService. For all intents and purposes, especially as the code is designed now, an OpenFlow domain is the same as an L2 domain.

Also, fix a bug that prevents outgoing broadcast ports from being queried on single-switch islands.