### PR TITLE
Forwarding bug fix for edge-case simple topology

### DIFF
--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -1148,7 +1148,12 @@ public class TopologyManager implements IFloodlightModule, ITopologyService, IRo
 	}
 
 	protected void addOrUpdateSwitch(DatapathId sw) {
-		// nothing to do here for the time being.
+		/*TODO react appropriately
+		addSwitch(sw);
+		for (OFPortDesc p : switchService.getSwitch(sw).getPorts()) {
+			addPortToSwitch(sw, p.getPortNo());
+		}
+		*/
 		return;
 	}
 


### PR DESCRIPTION
Finally, finally got to the bottom of the 'simple topology' Forwarding bug.

If there is a broadcast packet that we're going to flood AND the switch is not connected to any other switch (i.e. has no links in the topology), then we just need to ignore ITopologyService's recommendation of 'null' broadcast ports and send the packet out special port FLOOD. This is an edge case workaround. Any topology with links will use the list of broadcast ports returned by the ITopologyService.

Also, if a switch has no links associated with it, we should ignore what the IRoutingService tells us ('null' route). Instead, assume the devices are on the same switch, and manually compose a route from one switch port to another.