### PR TITLE
Fix for Firewall issue #590

### DIFF
--- a/src/main/java/net/floodlightcontroller/firewall/FirewallRulesResource.java
+++ b/src/main/java/net/floodlightcontroller/firewall/FirewallRulesResource.java
@@ -223,8 +223,10 @@ public class FirewallRulesResource extends ServerResource {
 				else if (n.equalsIgnoreCase("src-ip")) {
 					if (!jp.getText().equalsIgnoreCase("ANY")) {
 						rule.any_nw_src = false;
-						rule.any_dl_type = false;
-						rule.dl_type = EthType.IPv4;
+						if (rule.dl_type.equals(EthType.NONE)){
+							rule.any_dl_type = false;
+							rule.dl_type = EthType.IPv4;
+						}
 						try {
 							rule.nw_src_prefix_and_mask = IPv4AddressWithMask.of(jp.getText());
 						} catch (IllegalArgumentException e) {
@@ -237,8 +239,10 @@ public class FirewallRulesResource extends ServerResource {
 				else if (n.equalsIgnoreCase("dst-ip")) {
 					if (!jp.getText().equalsIgnoreCase("ANY")) {
 						rule.any_nw_dst = false;
-						rule.any_dl_type = false;
-						rule.dl_type = EthType.IPv4;
+						if (rule.dl_type.equals(EthType.NONE)){
+							rule.any_dl_type = false;
+							rule.dl_type = EthType.IPv4;
+						}
 						try {
 							rule.nw_dst_prefix_and_mask = IPv4AddressWithMask.of(jp.getText());
 						} catch (IllegalArgumentException e) {


### PR DESCRIPTION
The `dl_type=ARP` (or any other `dl_type`) is overwritten if `dst-ip` or `src-ip` are specified later on in the json object. I added condition that only overwrites the field if it hasn't been already specified. 