### PR TITLE
Fix data races in LoadBalancer and DHCPSwitchFlowSetter

### DIFF
--- a/src/main/java/net/floodlightcontroller/dhcpserver/DHCPSwitchFlowSetter.java
+++ b/src/main/java/net/floodlightcontroller/dhcpserver/DHCPSwitchFlowSetter.java
@@ -77,6 +77,11 @@ public class DHCPSwitchFlowSetter implements IFloodlightModule, IOFSwitchListene
 		 */
 		IOFSwitch sw = switchService.getSwitch(dpid);
 		
+		//fix concurrency flaw
+		if (sw == null){
+			return;
+		}
+		
 		OFFlowAdd.Builder flow = sw.getOFFactory().buildFlowAdd();
 		Match.Builder match = sw.getOFFactory().buildMatch();
 		ArrayList<OFAction> actionList = new ArrayList<OFAction>();


### PR DESCRIPTION
Fix harmful data races in LoadBalancer and DHCPSwitchFlowSetter module. A concurrent switch removal can cause null pointer exception on getSwitch() service function and incur serious logic flaws in those modules, e.g., break service chain and leak physic IP address of server replica. 