### PR TITLE
fix concurrency bugs

### DIFF
--- a/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
+++ b/src/main/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManager.java
@@ -430,18 +430,27 @@ IFloodlightModule, IInfoProvider, IHAListener {
 
         while(count < BDDP_TASK_SIZE && quarantineQueue.peek() !=null) {
             NodePortTuple npt;
-            npt = quarantineQueue.remove();
-            sendDiscoveryMessage(npt.getNodeId(), npt.getPortId(), false, false);
-            nptList.add(npt);
-            count++;
+            try {
+            	npt = quarantineQueue.remove();
+            	sendDiscoveryMessage(npt.getNodeId(), npt.getPortId(), false, false);
+            	nptList.add(npt);
+            	count++;
+            } catch (Exception e){
+            	log.error("Multiple removals in quarantineQueue.");
+            }
+        
         }
 
         count = 0;
         while (count < BDDP_TASK_SIZE && maintenanceQueue.peek() != null) {
             NodePortTuple npt;
-            npt = maintenanceQueue.remove();
-            sendDiscoveryMessage(npt.getNodeId(), npt.getPortId(), false, false);
-            count++;
+            try {
+            	npt = maintenanceQueue.remove();
+            	sendDiscoveryMessage(npt.getNodeId(), npt.getPortId(), false, false);
+            	count++;
+            } catch (Exception e){
+            	log.error("Multiple removals in maintenanceQueue.");
+            }
         }
 
         for(NodePortTuple npt:nptList) {


### PR DESCRIPTION
Fix concurrency bugs in LinkDiscoveryManager Module. In which, multiple removals on a global queue can incur exception raised and termination of the thread. 