### PR TITLE
Add ability to filter outbound messages while in SLAVE role

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/IOFMessageWriter.java
+++ b/src/main/java/net/floodlightcontroller/core/IOFMessageWriter.java
@@ -17,6 +17,7 @@
 
 package net.floodlightcontroller.core;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.projectfloodlight.openflow.protocol.OFMessage;
@@ -33,25 +34,24 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 public interface IOFMessageWriter{
 
-    /**
-     * Writes to the OFMessage to the output stream.
-     *
-     * <p><b>Note:</b> this method has fire-and-forget semantics. When the connection is
-     * not currently connected, it will silently discard the messages.
+	/**
+     * Writes the OFMessage to the output stream.
      *
      * @param m
+     * @return true upon success; false if message could not be written
      */
-    void write(OFMessage m);
+    boolean write(OFMessage m);
 
     /**
      * Writes the list of messages to the output stream.
      *
-     * <p><b>Note:</b> this method has fire-and-forget semantics. When the connection is
-     * not currently connected, it will silently discard the messages.
+     * Any messages that could not be written due to channel disconnect
+     * will be returned.
      *
      * @param msglist
+     * @return list of messages that could not be written
      */
-    void write(Iterable<OFMessage> msglist);
+    Collection<OFMessage> write(Iterable<OFMessage> msgList);
     
     /** write an OpenFlow Request message, register for a single corresponding reply message
      *  or error message.

--- a/src/main/java/net/floodlightcontroller/core/IOFSwitch.java
+++ b/src/main/java/net/floodlightcontroller/core/IOFSwitch.java
@@ -300,15 +300,17 @@ public interface IOFSwitch extends IOFMessageWriter {
      * Writes a message to the connection specified by the logical OFMessage category
      * @param m an OF Message
      * @param category the category of the OF Message to be sent
+     * @return true upon success; false upon failure
      */
-    void write(OFMessage m, LogicalOFMessageCategory category);
+    boolean write(OFMessage m, LogicalOFMessageCategory category);
 
     /**
      * Writes a message list to the connection specified by the logical OFMessage category
      * @param msglist an OF Message list
      * @param category the category of the OF Message list to be sent
+     * @return list of failed messages, if any; success denoted by empty list
      */
-    void write(Iterable<OFMessage> msglist, LogicalOFMessageCategory category);
+    Iterable<OFMessage> write(Iterable<OFMessage> msglist, LogicalOFMessageCategory category);
 
     /**
      * Get a connection specified by the logical OFMessage category

--- a/src/main/java/net/floodlightcontroller/core/internal/NullConnection.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/NullConnection.java
@@ -1,12 +1,14 @@
 package net.floodlightcontroller.core.internal;
 
 import java.net.SocketAddress;
+import java.util.Collection;
 import java.util.List;
 import java.util.Date;
 
 import net.floodlightcontroller.core.IOFConnectionBackend;
 import net.floodlightcontroller.core.IOFMessageWriter;
 import net.floodlightcontroller.core.SwitchDisconnectedException;
+import net.floodlightcontroller.util.IterableUtils;
 
 import org.projectfloodlight.openflow.protocol.OFFactories;
 import org.projectfloodlight.openflow.protocol.OFFactory;
@@ -42,13 +44,15 @@ public class NullConnection implements IOFConnectionBackend, IOFMessageWriter {
     }
 
     @Override
-    public void write(OFMessage m) {
+    public boolean write(OFMessage m) {
         warn();
+        return false;
     }
 
     @Override
-    public void write(Iterable<OFMessage> msglist) {
+    public Collection<OFMessage> write(Iterable<OFMessage> msgList) {
         warn();
+        return IterableUtils.toCollection(msgList);
     }
 
     @Override

--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitch.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitch.java
@@ -682,29 +682,39 @@ public class OFSwitch implements IOFSwitchBackend {
 	}
 
 	protected static class SwitchRoleMessageValidator {
-		private static final Map<OFVersion, Set<OFType>> validSlaveMsgsByOFVersion;
+		private static final Map<OFVersion, Set<OFType>> invalidSlaveMsgsByOFVersion;
 		static {
 			Map<OFVersion, Set<OFType>> m = new HashMap<OFVersion, Set<OFType>>();
 			Set<OFType> s = new HashSet<OFType>();
-			s.add(OFType.ROLE_REQUEST);
-			s.add(OFType.SET_ASYNC);
-			s.add(OFType.SET_CONFIG);
-			s.add(OFType.GET_ASYNC_REQUEST);
-			s.add(OFType.ECHO_REQUEST);
-			s.add(OFType.GET_CONFIG_REQUEST);
-			s.add(OFType.STATS_REQUEST);
-			s.add(OFType.FEATURES_REQUEST);
+			s.add(OFType.PACKET_OUT);
+			s.add(OFType.FLOW_MOD);
+			s.add(OFType.PORT_MOD);
+			s.add(OFType.TABLE_MOD);
+			s.add(OFType.BARRIER_REQUEST);
 			m.put(OFVersion.OF_10, Collections.unmodifiableSet(s));
+			
 			s = new HashSet<OFType>();
+			s.addAll(m.get(OFVersion.OF_10));
+			s.add(OFType.GROUP_MOD);
+			s.add(OFType.TABLE_MOD);
 			m.put(OFVersion.OF_11, Collections.unmodifiableSet(s));
+			
 			s = new HashSet<OFType>();
+			s.addAll(m.get(OFVersion.OF_11));
 			m.put(OFVersion.OF_12, Collections.unmodifiableSet(s));
+			
 			s = new HashSet<OFType>();
+			s.addAll(m.get(OFVersion.OF_12));
+			s.add(OFType.METER_MOD);
 			m.put(OFVersion.OF_13, Collections.unmodifiableSet(s));
+			
 			s = new HashSet<OFType>();
+			s.addAll(m.get(OFVersion.OF_13));
+			s.add(OFType.BUNDLE_ADD_MESSAGE);
+			s.add(OFType.BUNDLE_CONTROL);
 			m.put(OFVersion.OF_14, Collections.unmodifiableSet(s));
 
-			validSlaveMsgsByOFVersion = Collections.unmodifiableMap(m);
+			invalidSlaveMsgsByOFVersion = Collections.unmodifiableMap(m);
 		}
 
 		/**
@@ -724,12 +734,12 @@ public class OFSwitch implements IOFSwitchBackend {
 				valid.addAll(IterableUtils.toCollection(msgList));
 				return Collections.emptyList();
 			} else { /* slave */
-				Set<OFType> validSlaveMsgs = validSlaveMsgsByOFVersion.get(swVersion);
+				Set<OFType> invalidSlaveMsgs = invalidSlaveMsgsByOFVersion.get(swVersion);
 				List<OFMessage> invalid = new ArrayList<OFMessage>();
 				Iterator<OFMessage> itr = msgList.iterator();
 				while (itr.hasNext()) {
 					OFMessage m = itr.next();
-					if (!validSlaveMsgs.contains(m.getType())) {
+					if (invalidSlaveMsgs.contains(m.getType())) {
 						invalid.add(m);
 					} else {
 						valid.add(m);

--- a/src/main/java/net/floodlightcontroller/util/IterableUtils.java
+++ b/src/main/java/net/floodlightcontroller/util/IterableUtils.java
@@ -1,0 +1,28 @@
+package net.floodlightcontroller.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Because it's handy.
+ * @author Ryan Izard, ryan.izard@bigswitch.com, rizard@g.clemson.edu
+ */
+public class IterableUtils {
+	
+	/**
+	 * Convert an Iterable to a Collection (ArrayList under the hood). All items in the
+	 * Iterable will be retained.
+	 * @param i
+	 * @return
+	 */
+	public static <T> Collection<T> toCollection(Iterable<T> i) {
+		if (i == null) {
+			throw new IllegalArgumentException("Iterable 'i' cannot be null");
+		}
+		Collection<T> c = new ArrayList<T>();
+		for (T t : i) {
+			c.add(t);
+		}
+		return c;
+	}
+}

--- a/src/test/java/net/floodlightcontroller/core/internal/MockOFConnection.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/MockOFConnection.java
@@ -4,6 +4,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,13 +74,15 @@ public class MockOFConnection implements IOFConnectionBackend {
     }
 
     @Override
-    public void write(OFMessage m) {
+    public boolean write(OFMessage m) {
         messages.add(m);
+        return true;
     }
 
     @Override
-    public void write(Iterable<OFMessage> msglist) {
+    public Collection<OFMessage> write(Iterable<OFMessage> msglist) {
         Iterables.addAll(messages, msglist);
+        return Collections.emptyList();
     }
 
     static class RequestAndFuture<R extends OFMessage> {

--- a/src/test/java/net/floodlightcontroller/core/internal/OFSwitchBaseTest.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/OFSwitchBaseTest.java
@@ -122,7 +122,7 @@ public class OFSwitchBaseTest {
             new PortChangeEvent(portBar1, PortChangeType.DELETE);
     private final PortChangeEvent portBar2Del =
             new PortChangeEvent(portBar2, PortChangeType.DELETE);
-    private Capture<OFMessage> capturedMessage;
+    private Capture<Iterable<OFMessage>> capturedMessage;
     private OFFactory factory;
 
     @Before
@@ -144,9 +144,8 @@ public class OFSwitchBaseTest {
                 .build();
 
         IOFConnectionBackend conn = EasyMock.createNiceMock(IOFConnectionBackend.class);
-        capturedMessage = new Capture<OFMessage>();
-        conn.write(EasyMock.capture(capturedMessage));
-        expectLastCall().anyTimes();
+        capturedMessage = new Capture<Iterable<OFMessage>>();
+        expect(conn.write(EasyMock.capture(capturedMessage))).andReturn(Collections.<OFMessage>emptyList()).once();
         expect(conn.getOFFactory()).andReturn(factory).anyTimes();
         expect(conn.getAuxId()).andReturn(OFAuxId.MAIN).anyTimes();
         EasyMock.replay(conn);
@@ -154,6 +153,7 @@ public class OFSwitchBaseTest {
         IOFConnectionBackend auxConn = EasyMock.createNiceMock(IOFConnectionBackend.class);
         expect(auxConn.getOFFactory()).andReturn(factory).anyTimes();
         expect(auxConn.getAuxId()).andReturn(OFAuxId.of(1)).anyTimes();
+        expect(auxConn.write(EasyMock.capture(capturedMessage))).andReturn(Collections.<OFMessage>emptyList()).once();
         EasyMock.replay(auxConn);
 
         sw = new OFSwitchTest(conn, switchManager);
@@ -1405,9 +1405,9 @@ public class OFSwitchBaseTest {
         reset(switchManager);
         expect(switchManager.isCategoryRegistered(category)).andReturn(true);
         switchManager.handleOutgoingMessage(sw, testMessage);
-        expectLastCall();
+        expectLastCall().once();
         replay(switchManager);
-
+        
         sw.write(testMessage, category);
 
         verify(switchManager);

--- a/src/test/java/net/floodlightcontroller/core/internal/OFSwitchHandlerTestBase.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/OFSwitchHandlerTestBase.java
@@ -27,9 +27,11 @@ import java.util.concurrent.TimeUnit;
 import org.easymock.EasyMock;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
+
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import io.netty.util.TimerTask;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -521,10 +523,8 @@ public abstract class OFSwitchHandlerTestBase {
 		// TODO: hmmm. While it's not incorrect that we set the attribute
 		// again it looks odd. Maybe change
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
-		sw.write(anyObject(OFMessage.class));
-		expectLastCall().anyTimes();
-		sw.write(anyObject(Iterable.class));
-		expectLastCall().anyTimes();
+		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
 		expect(sw.getNumTables()).andStubReturn((short)0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, supportsNxRole);
 		expectLastCall().anyTimes();
@@ -599,10 +599,8 @@ public abstract class OFSwitchHandlerTestBase {
 		// prepare mocks and inject the role reply message
 		reset(sw);
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
-		sw.write(anyObject(OFMessage.class));
-		expectLastCall().anyTimes();
-		sw.write(anyObject(Iterable.class));
-		expectLastCall().anyTimes();
+		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
 		expect(sw.getTables()).andStubReturn(Collections.EMPTY_LIST);
 		expect(sw.getNumTables()).andStubReturn((short) 0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, true);
@@ -695,10 +693,8 @@ public abstract class OFSwitchHandlerTestBase {
 		// prepare mocks and inject the role reply message
 		reset(sw);
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
-		sw.write(anyObject(OFMessage.class));
-		expectLastCall().anyTimes();
-		sw.write(anyObject(Iterable.class));
-		expectLastCall().anyTimes();
+		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
 		expect(sw.getNumTables()).andStubReturn((short)0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, false);
 		expectLastCall().once();
@@ -758,10 +754,8 @@ public abstract class OFSwitchHandlerTestBase {
 		// prepare mocks and inject the role reply message
 		reset(sw);
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
-		sw.write(anyObject(OFMessage.class));
-		expectLastCall().anyTimes();
-		sw.write(anyObject(Iterable.class));
-		expectLastCall().anyTimes();
+		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
 		expect(sw.getNumTables()).andStubReturn((short)0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, false);
 		expectLastCall().once();
@@ -922,10 +916,8 @@ public abstract class OFSwitchHandlerTestBase {
 		// prepare mocks and inject the role reply message
 		reset(sw);
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
-		sw.write(anyObject(OFMessage.class));
-		expectLastCall().anyTimes();
-		sw.write(anyObject(Iterable.class));
-		expectLastCall().anyTimes();
+		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
 		expect(sw.getNumTables()).andStubReturn((short)0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, true);
 		expectLastCall().once();

--- a/src/test/java/net/floodlightcontroller/core/internal/OFSwitchTest.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/OFSwitchTest.java
@@ -49,116 +49,116 @@ import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFAuxId;
 
 public class OFSwitchTest {
-    protected OFSwitch sw;
-    protected OFFactory factory = OFFactories.getFactory(OFVersion.OF_13);
+	protected OFSwitch sw;
+	protected OFFactory factory = OFFactories.getFactory(OFVersion.OF_13);
 
-    @Before
-    public void setUp() throws Exception {
-        MockOFConnection mockConnection = new MockOFConnection(DatapathId.of(1), OFAuxId.MAIN);
-        sw = new OFSwitch(mockConnection, OFFactories.getFactory(OFVersion.OF_10),
-                EasyMock.createMock(IOFSwitchManager.class), DatapathId.of(1));
-    }
+	@Before
+	public void setUp() throws Exception {
+		MockOFConnection mockConnection = new MockOFConnection(DatapathId.of(1), OFAuxId.MAIN);
+		sw = new OFSwitch(mockConnection, OFFactories.getFactory(OFVersion.OF_10),
+				EasyMock.createMock(IOFSwitchManager.class), DatapathId.of(1));
+	}
 
-    @Test
-    public void testSetHARoleReply() {
-        sw.setControllerRole(OFControllerRole.ROLE_MASTER);
-        assertEquals(OFControllerRole.ROLE_MASTER, sw.getControllerRole());
+	@Test
+	public void testSetHARoleReply() {
+		sw.setControllerRole(OFControllerRole.ROLE_MASTER);
+		assertEquals(OFControllerRole.ROLE_MASTER, sw.getControllerRole());
 
-        sw.setControllerRole(OFControllerRole.ROLE_EQUAL);
-        assertEquals(OFControllerRole.ROLE_EQUAL, sw.getControllerRole());
+		sw.setControllerRole(OFControllerRole.ROLE_EQUAL);
+		assertEquals(OFControllerRole.ROLE_EQUAL, sw.getControllerRole());
 
-        sw.setControllerRole(OFControllerRole.ROLE_SLAVE);
-        assertEquals(OFControllerRole.ROLE_SLAVE, sw.getControllerRole());
-    }
+		sw.setControllerRole(OFControllerRole.ROLE_SLAVE);
+		assertEquals(OFControllerRole.ROLE_SLAVE, sw.getControllerRole());
+	}
 
-    @Test
-    public void testSubHandshake() {
-        OFFactory factory = OFFactories.getFactory(OFVersion.OF_10);
-        OFMessage m = factory.buildNiciraControllerRoleReply()
-                .setXid(1)
-                .setRole(OFNiciraControllerRole.ROLE_MASTER)
-                .build();
-        // test exceptions before handshake is started
-        try {
-            sw.processDriverHandshakeMessage(m);
-            fail("expected exception not thrown");
-        } catch (SwitchDriverSubHandshakeNotStarted e) { /* expected */ }
-        try {
-            sw.isDriverHandshakeComplete();
-            fail("expected exception not thrown");
-        } catch (SwitchDriverSubHandshakeNotStarted e) { /* expected */ }
+	@Test
+	public void testSubHandshake() {
+		OFFactory factory = OFFactories.getFactory(OFVersion.OF_10);
+		OFMessage m = factory.buildNiciraControllerRoleReply()
+				.setXid(1)
+				.setRole(OFNiciraControllerRole.ROLE_MASTER)
+				.build();
+		// test exceptions before handshake is started
+		try {
+			sw.processDriverHandshakeMessage(m);
+			fail("expected exception not thrown");
+		} catch (SwitchDriverSubHandshakeNotStarted e) { /* expected */ }
+		try {
+			sw.isDriverHandshakeComplete();
+			fail("expected exception not thrown");
+		} catch (SwitchDriverSubHandshakeNotStarted e) { /* expected */ }
 
-        // start the handshake -- it should immediately complete
-        sw.startDriverHandshake();
-        assertTrue("Handshake should be complete",
-                   sw.isDriverHandshakeComplete());
+		// start the handshake -- it should immediately complete
+		sw.startDriverHandshake();
+		assertTrue("Handshake should be complete",
+				sw.isDriverHandshakeComplete());
 
-        // test exceptions after handshake is completed
-        try {
-            sw.processDriverHandshakeMessage(m);
-            fail("expected exception not thrown");
-        } catch (SwitchDriverSubHandshakeCompleted e) { /* expected */ }
-        try {
-            sw.startDriverHandshake();
-            fail("Expected exception not thrown");
-        } catch (SwitchDriverSubHandshakeAlreadyStarted e) { /* expected */ }
-    }
+		// test exceptions after handshake is completed
+		try {
+			sw.processDriverHandshakeMessage(m);
+			fail("expected exception not thrown");
+		} catch (SwitchDriverSubHandshakeCompleted e) { /* expected */ }
+		try {
+			sw.startDriverHandshake();
+			fail("Expected exception not thrown");
+		} catch (SwitchDriverSubHandshakeAlreadyStarted e) { /* expected */ }
+	}
 
-    /**
-     * Helper to load controller connection messages into a switch for testing.
-     * @param sw the switch to insert the message on
-     * @param role the role for the controller connection message
-     * @param state the state for the controller connection message
-     * @param uri the URI for the controller connection message
-     */
-    public void updateControllerConnections(IOFSwitchBackend sw, OFControllerRole role1, OFBsnControllerConnectionState state1, String uri1
-                                            ,  OFControllerRole role2, OFBsnControllerConnectionState state2, String uri2) {
-        OFBsnControllerConnection connection1 = factory.buildBsnControllerConnection()
-                .setAuxiliaryId(OFAuxId.MAIN)
-                .setRole(role1)
-                .setState(state1)
-                .setUri(uri1)
-                .build();
+	/**
+	 * Helper to load controller connection messages into a switch for testing.
+	 * @param sw the switch to insert the message on
+	 * @param role the role for the controller connection message
+	 * @param state the state for the controller connection message
+	 * @param uri the URI for the controller connection message
+	 */
+	public void updateControllerConnections(IOFSwitchBackend sw, OFControllerRole role1, OFBsnControllerConnectionState state1, String uri1
+			,  OFControllerRole role2, OFBsnControllerConnectionState state2, String uri2) {
+		OFBsnControllerConnection connection1 = factory.buildBsnControllerConnection()
+				.setAuxiliaryId(OFAuxId.MAIN)
+				.setRole(role1)
+				.setState(state1)
+				.setUri(uri1)
+				.build();
 
-        OFBsnControllerConnection connection2 = factory.buildBsnControllerConnection()
-                .setAuxiliaryId(OFAuxId.MAIN)
-                .setRole(role2)
-                .setState(state2)
-                .setUri(uri2)
-                .build();
+		OFBsnControllerConnection connection2 = factory.buildBsnControllerConnection()
+				.setAuxiliaryId(OFAuxId.MAIN)
+				.setRole(role2)
+				.setState(state2)
+				.setUri(uri2)
+				.build();
 
-        List<OFBsnControllerConnection> connections = new ArrayList<OFBsnControllerConnection>();
-        connections.add(connection1);
-        connections.add(connection2);
+		List<OFBsnControllerConnection> connections = new ArrayList<OFBsnControllerConnection>();
+		connections.add(connection1);
+		connections.add(connection2);
 
-        OFBsnControllerConnectionsReply reply = factory.buildBsnControllerConnectionsReply()
-                .setConnections(connections)
-                .build();
+		OFBsnControllerConnectionsReply reply = factory.buildBsnControllerConnectionsReply()
+				.setConnections(connections)
+				.build();
 
-        sw.updateControllerConnections(reply);
-    }
+		sw.updateControllerConnections(reply);
+	}
 
-    /**
-     * This test ensures that the switch accurately determined if another master
-     * exists in the cluster by examining the controller connections it has.
-     */
-    @Test
-    public void testHasAnotherMaster() {
-        URI cokeUri = URIUtil.createURI("1.2.3.4", 6653);
-        InetSocketAddress address = (InetSocketAddress) sw.getConnection(OFAuxId.MAIN).getLocalInetAddress();
-        URI pepsiUri = URIUtil.createURI(address.getHostName(), address.getPort());
+	/**
+	 * This test ensures that the switch accurately determined if another master
+	 * exists in the cluster by examining the controller connections it has.
+	 */
+	@Test
+	public void testHasAnotherMaster() {
+		URI cokeUri = URIUtil.createURI("1.2.3.4", 6653);
+		InetSocketAddress address = (InetSocketAddress) sw.getConnection(OFAuxId.MAIN).getLocalInetAddress();
+		URI pepsiUri = URIUtil.createURI(address.getHostName(), address.getPort());
 
-        updateControllerConnections(sw, OFControllerRole.ROLE_SLAVE, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, cokeUri.toString(),
-                                    OFControllerRole.ROLE_MASTER, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, pepsiUri.toString());
+		updateControllerConnections(sw, OFControllerRole.ROLE_SLAVE, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, cokeUri.toString(),
+				OFControllerRole.ROLE_MASTER, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, pepsiUri.toString());
 
-        // From the perspective of pepsi, the cluster currently does NOT have another master controller
-        assertFalse(sw.hasAnotherMaster());
+		// From the perspective of pepsi, the cluster currently does NOT have another master controller
+		assertFalse(sw.hasAnotherMaster());
 
-        // Switch the controller connections so that pepsi is no longer master
-        updateControllerConnections(sw, OFControllerRole.ROLE_MASTER, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, cokeUri.toString(),
-                                    OFControllerRole.ROLE_SLAVE, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, pepsiUri.toString());
+		// Switch the controller connections so that pepsi is no longer master
+		updateControllerConnections(sw, OFControllerRole.ROLE_MASTER, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, cokeUri.toString(),
+				OFControllerRole.ROLE_SLAVE, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, pepsiUri.toString());
 
-        // From the perspective of pepsi, the cluster currently has another master controller
-        assertTrue(sw.hasAnotherMaster());
-    }
+		// From the perspective of pepsi, the cluster currently has another master controller
+		assertTrue(sw.hasAnotherMaster());
+	}
 }

--- a/src/test/java/net/floodlightcontroller/forwarding/ForwardingTest.java
+++ b/src/test/java/net/floodlightcontroller/forwarding/ForwardingTest.java
@@ -184,6 +184,9 @@ public class ForwardingTest extends FloodlightTestCase {
 		
 		expect(sw1.getSwitchDescription()).andReturn(new SwitchDescription(swDescription)).anyTimes();
 		expect(sw2.getSwitchDescription()).andReturn(new SwitchDescription(swDescription)).anyTimes();
+		
+		expect(sw1.isActive()).andReturn(true).anyTimes();
+		expect(sw2.isActive()).andReturn(true).anyTimes();
 
 		// Load the switch map
 		Map<DatapathId, IOFSwitch> switches = new HashMap<DatapathId, IOFSwitch>();
@@ -457,10 +460,8 @@ public class ForwardingTest extends FloodlightTestCase {
 				.build();
 		OFFlowMod fm2 = fm1.createBuilder().build();
 
-		sw1.write(capture(wc1));
-		expectLastCall().anyTimes();
-		sw2.write(capture(wc2));
-		expectLastCall().anyTimes();
+		expect(sw1.write(capture(wc1))).andReturn(true).anyTimes();
+		expect(sw2.write(capture(wc2))).andReturn(true).anyTimes();
 
 		reset(topology);
 		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
@@ -529,10 +530,8 @@ public class ForwardingTest extends FloodlightTestCase {
 				.build();
 		OFFlowMod fm2 = fm1.createBuilder().build();
 
-		sw1.write(capture(wc1));
-		expectLastCall().anyTimes();
-		sw2.write(capture(wc2));
-		expectLastCall().anyTimes();
+		expect(sw1.write(capture(wc1))).andReturn(true).anyTimes();
+		expect(sw2.write(capture(wc2))).andReturn(true).anyTimes();
 
 		reset(topology);
 		expect(topology.getOpenflowDomainId(DatapathId.of(1L))).andReturn(DatapathId.of(1L)).anyTimes();
@@ -597,10 +596,8 @@ public class ForwardingTest extends FloodlightTestCase {
 				.build();
 
 		// Record expected packet-outs/flow-mods
-		sw1.write(capture(wc1));
-		expectLastCall().once();
-		sw1.write(capture(wc2));
-		expectLastCall().once();
+		expect(sw1.write(capture(wc1))).andReturn(true).once();
+		expect(sw1.write(capture(wc2))).andReturn(true).once();
 
 		reset(topology);
 		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
@@ -653,10 +650,8 @@ public class ForwardingTest extends FloodlightTestCase {
 				.build();
 
 		// Record expected packet-outs/flow-mods
-		sw1.write(capture(wc1));
-		expectLastCall().once();
-		sw1.write(capture(wc2));
-		expectLastCall().once();
+		expect(sw1.write(capture(wc1))).andReturn(true).once();
+		expect(sw1.write(capture(wc2))).andReturn(true).once();
 
 		reset(topology);
 		expect(topology.isIncomingBroadcastAllowed(DatapathId.of(anyLong()), OFPort.of(anyShort()))).andReturn(true).anyTimes();
@@ -758,8 +753,7 @@ public class ForwardingTest extends FloodlightTestCase {
 				.andReturn(true)
 				.anyTimes();
 		expect(sw1.hasAttribute(IOFSwitch.PROP_SUPPORTS_OFPP_FLOOD)).andReturn(true).anyTimes();
-		sw1.write(capture(wc1));
-		expectLastCall().once();
+		expect(sw1.write(capture(wc1))).andReturn(true).once();
 		replay(sw1, sw2, routingEngine, topology);
 		forwarding.receive(sw1, this.packetIn, cntx);
 		verify(sw1, sw2, routingEngine);
@@ -792,8 +786,7 @@ public class ForwardingTest extends FloodlightTestCase {
 		expect(sw1.hasAttribute(IOFSwitch.PROP_SUPPORTS_OFPP_FLOOD))
 		.andReturn(true).anyTimes();
 		// Reset XID to expected (dependent on prior unit tests)
-		sw1.write(capture(wc1));
-		expectLastCall().once();
+		expect(sw1.write(capture(wc1))).andReturn(true).once();
 		replay(sw1, sw2, routingEngine, topology);
 		forwarding.receive(sw1, this.packetInIPv6, cntx);
 		verify(sw1, sw2, routingEngine);

--- a/src/test/java/net/floodlightcontroller/hub/HubTest.java
+++ b/src/test/java/net/floodlightcontroller/hub/HubTest.java
@@ -19,6 +19,7 @@ package net.floodlightcontroller.hub;
 
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.verify;
 import static org.easymock.EasyMock.capture;
 import static org.junit.Assert.*;
@@ -122,7 +123,7 @@ public class HubTest extends FloodlightTestCase {
         
         Capture<OFMessage> wc1 = new Capture<OFMessage>(CaptureType.ALL);
         
-        mockSwitch.write(capture(wc1));
+        expect(mockSwitch.write(capture(wc1))).andReturn(true).anyTimes();
 
         // Start recording the replay on the mocks
         replay(mockSwitch);
@@ -163,7 +164,7 @@ public class HubTest extends FloodlightTestCase {
         IOFSwitch mockSwitch = createMock(IOFSwitch.class);
         EasyMock.expect(mockSwitch.getOFFactory()).andReturn(OFFactories.getFactory(OFVersion.OF_13)).anyTimes();
         Capture<OFPacketOut> wc1 = new Capture<OFPacketOut>(CaptureType.ALL);
-        mockSwitch.write(capture(wc1));
+        expect(mockSwitch.write(capture(wc1))).andReturn(true).anyTimes();
 
         // Start recording the replay on the mocks
         replay(mockSwitch);

--- a/src/test/java/net/floodlightcontroller/learningswitch/LearningSwitchTest.java
+++ b/src/test/java/net/floodlightcontroller/learningswitch/LearningSwitchTest.java
@@ -190,8 +190,7 @@ public class LearningSwitchTest extends FloodlightTestCase {
         IOFSwitch mockSwitch = createMock(IOFSwitch.class);
         expect(mockSwitch.getId()).andReturn(DatapathId.of("00:11:22:33:44:55:66:77")).anyTimes();
         expect(mockSwitch.getOFFactory()).andReturn(factory).anyTimes();
-        mockSwitch.write(EasyMock.capture(wc1)); // expect po
-        EasyMock.expectLastCall().once();
+        expect(mockSwitch.write(EasyMock.capture(wc1))).andReturn(true).once(); // expect po
 
         // Start recording the replay on the mocks
         replay(mockSwitch);
@@ -269,12 +268,9 @@ public class LearningSwitchTest extends FloodlightTestCase {
         expect(mockSwitch.getBuffers()).andReturn((long)100).anyTimes();
         expect(mockSwitch.getOFFactory()).andReturn(factory).anyTimes();
         
-        mockSwitch.write(EasyMock.capture(wc1)); // expect packetOut
-        EasyMock.expectLastCall().once();
-        mockSwitch.write(EasyMock.capture(wc2)); // expect fm1
-        EasyMock.expectLastCall().once();
-        mockSwitch.write(EasyMock.capture(wc3)); // expect fm2
-        EasyMock.expectLastCall().once();
+        expect(mockSwitch.write(EasyMock.capture(wc1))).andReturn(true).once(); // expect packetOut
+        expect(mockSwitch.write(EasyMock.capture(wc2))).andReturn(true).once(); // expect fm1
+        expect(mockSwitch.write(EasyMock.capture(wc3))).andReturn(true).once(); // expect fm2
 
         // Start recording the replay on the mocks
         replay(mockSwitch);

--- a/src/test/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManagerTest.java
+++ b/src/test/java/net/floodlightcontroller/linkdiscovery/internal/LinkDiscoveryManagerTest.java
@@ -21,7 +21,6 @@ import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.*;
@@ -497,8 +496,7 @@ public class LinkDiscoveryManagerTest extends FloodlightTestCase {
         expect(sw1.getPort(OFPort.of(EasyMock.anyInt()))).andReturn(ofpp).anyTimes();
         expect(sw1.getOFFactory()).andReturn(OFFactories.getFactory(OFVersion.OF_13)).anyTimes();
         expect(sw1.getLatency()).andReturn(U64.ZERO).anyTimes();
-        sw1.write(capture(wc));
-        expectLastCall().anyTimes();
+        expect(sw1.write(capture(wc))).andReturn(true).anyTimes();
         replay(sw1);
 
         linkDiscovery.switchActivated(sw1.getId());

--- a/src/test/java/net/floodlightcontroller/loadbalancer/LoadBalancerTest.java
+++ b/src/test/java/net/floodlightcontroller/loadbalancer/LoadBalancerTest.java
@@ -446,8 +446,7 @@ public class LoadBalancerTest extends FloodlightTestCase {
 		expect(sw1.getId()).andReturn(DatapathId.of(1L)).anyTimes();
 		expect(sw1.hasAttribute(IOFSwitch.PROP_SUPPORTS_OFPP_TABLE)).andReturn(true).anyTimes();
 		expect(sw1.getOFFactory()).andReturn(factory).anyTimes();
-		sw1.write(capture(wc1));
-		expectLastCall().anyTimes();
+		expect(sw1.write(capture(wc1))).andReturn(true).anyTimes();
 		
 		replay(sw1);
 		sfp.switchAdded(DatapathId.of(1L));

--- a/src/test/java/net/floodlightcontroller/staticflowentry/StaticFlowTests.java
+++ b/src/test/java/net/floodlightcontroller/staticflowentry/StaticFlowTests.java
@@ -203,10 +203,8 @@ public class StaticFlowTests extends FloodlightTestCase {
 		writeCapture = new Capture<OFMessage>(CaptureType.ALL);
 		writeCaptureList = new Capture<List<OFMessage>>(CaptureType.ALL);
 
-		mockSwitch.write(capture(writeCapture));
-		expectLastCall().anyTimes();
-		mockSwitch.write(capture(writeCaptureList));
-		expectLastCall().anyTimes();
+		expect(mockSwitch.write(capture(writeCapture))).andReturn(true).anyTimes();
+		expect(mockSwitch.write(capture(writeCaptureList))).andReturn(Collections.<OFMessage>emptyList()).anyTimes();
 		expect(mockSwitch.getOFFactory()).andReturn(factory).anyTimes();
 		replay(mockSwitch);
 
@@ -247,10 +245,8 @@ public class StaticFlowTests extends FloodlightTestCase {
 
 		// if someone calls getId(), return this dpid instead
 		resetToNice(mockSwitch);
-		mockSwitch.write(capture(writeCapture));
-		expectLastCall().anyTimes();
-		mockSwitch.write(capture(writeCaptureList));
-		expectLastCall().anyTimes();
+		expect(mockSwitch.write(capture(writeCapture))).andReturn(true).anyTimes();
+		expect(mockSwitch.write(capture(writeCaptureList))).andReturn(Collections.<OFMessage> emptyList()).anyTimes();
 		expect(mockSwitch.getOFFactory()).andReturn(factory).anyTimes();
 		expect(mockSwitch.getId()).andReturn(DatapathId.of(dpid)).anyTimes();
 		replay(mockSwitch);

--- a/src/test/java/net/floodlightcontroller/util/OFMessageDamperMockSwitch.java
+++ b/src/test/java/net/floodlightcontroller/util/OFMessageDamperMockSwitch.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 
 import java.net.SocketAddress;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -203,14 +204,14 @@ public class OFMessageDamperMockSwitch implements IOFSwitch {
     }
 
 	@Override
-	public void write(OFMessage m) {
+	public boolean write(OFMessage m) {
 		writtenMessage = m;
-		// TODO Auto-generated method stub	
+		return true;
 	}
 
 	@Override
-	public void write(Iterable<OFMessage> msglist) {
-		// TODO Auto-generated method stub
+	public Collection<OFMessage> write(Iterable<OFMessage> msgList) {
+		return Collections.emptyList();
 	}
 
 	@Override
@@ -282,16 +283,14 @@ public class OFMessageDamperMockSwitch implements IOFSwitch {
 	}
 
 	@Override
-	public void write(OFMessage m, LogicalOFMessageCategory category) {
-		// TODO Auto-generated method stub
-		
+	public boolean write(OFMessage m, LogicalOFMessageCategory category) {
+		return true;
 	}
 
 	@Override
-	public void write(Iterable<OFMessage> msglist,
+	public Collection<OFMessage> write(Iterable<OFMessage> msgList,
 			LogicalOFMessageCategory category) {
-		// TODO Auto-generated method stub
-		
+		return Collections.emptyList();
 	}
 
 	@Override


### PR DESCRIPTION
@AndreMantas thanks for the support coming up with this solution!

Although the OpenFlow protocol dictates that an error message should be returned from the switch if any invalid, state-modifying message is sent to it from a controller in the SLAVE role, it is better to block the messages locally on the controller to avoid burdening the switch with such messages it will inevitably be required to process and kick back in error.

The previous filter in place in Floodlight filtered out *all* messages sent to a switch when a controller was in SLAVE role to that switch. A controller is however allowed to read the state from the switch with stats/multipart requests, as well as set its asynchronous communication preferences for events dispatched from the switch to the controller. The new implementation of the SLAVE state filter allows such messages through to the switch. It also informs the module of any "invalid" state modification messages, such as flow-mod, packet-out, etc., by passing back "false" if the message failed to pass the filter and was not written, or by passing back a collection of failed messages (in the case of a bulk write()). If "true" or an empty collection  is returned, the caller can assume the messages were successfully written. (Note that if the messages were to fail for another reason (e.g. invalid port, malformed, etc.) the user module must listen for the errors separately using an IOFMessageListener.)

It should be noted that at present, there is not a way to differentiate between those messages that were blocked due to being in the SLAVE state and failing the filter and those messages that could not be written due to a disconnected switch channel. We can try to work around this if it poses a problem, but since switch disconnections are presumed to be infrequent, it shouldn't be that big of a deal. An alternative solution would be to return an enum stating the reason why the message was not written (in lieu of true/false) or a list of new type/tuple of [(OFMessage, enum.SLAVE), (OFMessage, enum.DISCONNECTED), ...] that will give the reason for each failed message. This is a proposed solution if one wishes to differentiate between the two failure cases/reasons.