### PR TITLE
OF1.4 bug fixes

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitch.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitch.java
@@ -682,29 +682,39 @@ public class OFSwitch implements IOFSwitchBackend {
 	}
 
 	protected static class SwitchRoleMessageValidator {
-		private static final Map<OFVersion, Set<OFType>> validSlaveMsgsByOFVersion;
+		private static final Map<OFVersion, Set<OFType>> invalidSlaveMsgsByOFVersion;
 		static {
 			Map<OFVersion, Set<OFType>> m = new HashMap<OFVersion, Set<OFType>>();
 			Set<OFType> s = new HashSet<OFType>();
-			s.add(OFType.ROLE_REQUEST);
-			s.add(OFType.SET_ASYNC);
-			s.add(OFType.SET_CONFIG);
-			s.add(OFType.GET_ASYNC_REQUEST);
-			s.add(OFType.ECHO_REQUEST);
-			s.add(OFType.GET_CONFIG_REQUEST);
-			s.add(OFType.STATS_REQUEST);
-			s.add(OFType.FEATURES_REQUEST);
+			s.add(OFType.PACKET_OUT);
+			s.add(OFType.FLOW_MOD);
+			s.add(OFType.PORT_MOD);
+			s.add(OFType.TABLE_MOD);
+			s.add(OFType.BARRIER_REQUEST);
 			m.put(OFVersion.OF_10, Collections.unmodifiableSet(s));
+			
 			s = new HashSet<OFType>();
+			s.addAll(m.get(OFVersion.OF_10));
+			s.add(OFType.GROUP_MOD);
+			s.add(OFType.TABLE_MOD);
 			m.put(OFVersion.OF_11, Collections.unmodifiableSet(s));
+			
 			s = new HashSet<OFType>();
+			s.addAll(m.get(OFVersion.OF_11));
 			m.put(OFVersion.OF_12, Collections.unmodifiableSet(s));
+			
 			s = new HashSet<OFType>();
+			s.addAll(m.get(OFVersion.OF_12));
+			s.add(OFType.METER_MOD);
 			m.put(OFVersion.OF_13, Collections.unmodifiableSet(s));
+			
 			s = new HashSet<OFType>();
+			s.addAll(m.get(OFVersion.OF_13));
+			s.add(OFType.BUNDLE_ADD_MESSAGE);
+			s.add(OFType.BUNDLE_CONTROL);
 			m.put(OFVersion.OF_14, Collections.unmodifiableSet(s));
 
-			validSlaveMsgsByOFVersion = Collections.unmodifiableMap(m);
+			invalidSlaveMsgsByOFVersion = Collections.unmodifiableMap(m);
 		}
 
 		/**
@@ -724,12 +734,12 @@ public class OFSwitch implements IOFSwitchBackend {
 				valid.addAll(IterableUtils.toCollection(msgList));
 				return Collections.emptyList();
 			} else { /* slave */
-				Set<OFType> validSlaveMsgs = validSlaveMsgsByOFVersion.get(swVersion);
+				Set<OFType> invalidSlaveMsgs = invalidSlaveMsgsByOFVersion.get(swVersion);
 				List<OFMessage> invalid = new ArrayList<OFMessage>();
 				Iterator<OFMessage> itr = msgList.iterator();
 				while (itr.hasNext()) {
 					OFMessage m = itr.next();
-					if (!validSlaveMsgs.contains(m.getType())) {
+					if (invalidSlaveMsgs.contains(m.getType())) {
 						invalid.add(m);
 					} else {
 						valid.add(m);

--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitchHandshakeHandler.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitchHandshakeHandler.java
@@ -3,6 +3,7 @@ package net.floodlightcontroller.core.internal;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -12,7 +13,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 
 import io.netty.util.Timer;
-
 import net.floodlightcontroller.core.HARole;
 import net.floodlightcontroller.core.IOFConnection;
 import net.floodlightcontroller.core.IOFConnectionBackend;
@@ -68,6 +68,7 @@ import org.projectfloodlight.openflow.protocol.action.OFAction;
 import org.projectfloodlight.openflow.protocol.actionid.OFActionId;
 import org.projectfloodlight.openflow.protocol.errormsg.OFBadRequestErrorMsg;
 import org.projectfloodlight.openflow.protocol.errormsg.OFFlowModFailedErrorMsg;
+import org.projectfloodlight.openflow.protocol.instruction.OFInstruction;
 import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFAuxId;
 import org.projectfloodlight.openflow.types.OFGroup;
@@ -518,7 +519,7 @@ public class OFSwitchHandshakeHandler implements IOFConnectionListener {
 								OFFlowAdd defaultFlow = this.factory.buildFlowAdd()
 										.setTableId(tid)
 										.setPriority(0)
-										.setActions(actions)
+										.setInstructions(Collections.singletonList((OFInstruction) this.factory.instructions().buildApplyActions().setActions(actions).build()))
 										.build();
 								flows.add(defaultFlow);
 								break; /* Stop searching for actions and go to the next table in the list */

--- a/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
+++ b/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
@@ -51,6 +51,7 @@ import net.floodlightcontroller.routing.IRoutingService;
 import net.floodlightcontroller.routing.Route;
 import net.floodlightcontroller.topology.ITopologyService;
 import net.floodlightcontroller.topology.NodePortTuple;
+import net.floodlightcontroller.util.FlowModUtils;
 import net.floodlightcontroller.util.OFDPAUtils;
 import net.floodlightcontroller.util.OFPortMode;
 import net.floodlightcontroller.util.OFPortModeTuple;
@@ -139,8 +140,9 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
 		.setIdleTimeout(FLOWMOD_DEFAULT_IDLE_TIMEOUT)
 		.setBufferId(OFBufferId.NO_BUFFER)
 		.setMatch(m)
-		.setActions(actions) // empty list
 		.setPriority(FLOWMOD_DEFAULT_PRIORITY);
+		
+		FlowModUtils.setActions(fmb, actions, sw);
 
 		try {
 			if (log.isDebugEnabled()) {

--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -41,6 +41,7 @@ import net.floodlightcontroller.routing.IRoutingDecision;
 import net.floodlightcontroller.routing.Route;
 import net.floodlightcontroller.topology.ITopologyService;
 import net.floodlightcontroller.topology.NodePortTuple;
+import net.floodlightcontroller.util.FlowModUtils;
 import net.floodlightcontroller.util.MatchUtils;
 import net.floodlightcontroller.util.OFDPAUtils;
 import net.floodlightcontroller.util.OFMessageDamper;
@@ -247,13 +248,14 @@ public abstract class ForwardingBase implements IOFMessageListener {
 			}
 			
 			fmb.setMatch(mb.build())
-			.setActions(actions)
 			.setIdleTimeout(FLOWMOD_DEFAULT_IDLE_TIMEOUT)
 			.setHardTimeout(FLOWMOD_DEFAULT_HARD_TIMEOUT)
 			.setBufferId(OFBufferId.NO_BUFFER)
 			.setCookie(cookie)
 			.setOutPort(outPort)
 			.setPriority(FLOWMOD_DEFAULT_PRIORITY);
+			
+			FlowModUtils.setActions(fmb, actions, sw);
 			
 			try {
 				if (log.isTraceEnabled()) {
@@ -445,8 +447,9 @@ public abstract class ForwardingBase implements IOFMessageListener {
 		.setIdleTimeout(FLOWMOD_DEFAULT_IDLE_TIMEOUT)
 		.setPriority(FLOWMOD_DEFAULT_PRIORITY)
 		.setBufferId(OFBufferId.NO_BUFFER)
-		.setMatch(mb.build())
-		.setActions(actions);
+		.setMatch(mb.build());
+		
+		FlowModUtils.setActions(fmb, actions, sw);
 
 		log.debug("write drop flow-mod sw={} match={} flow-mod={}",
 					new Object[] { sw, mb.build(), fmb.build() });

--- a/src/main/java/net/floodlightcontroller/util/FlowModUtils.java
+++ b/src/main/java/net/floodlightcontroller/util/FlowModUtils.java
@@ -1,5 +1,10 @@
 package net.floodlightcontroller.util;
 
+import java.util.Collections;
+import java.util.List;
+
+import net.floodlightcontroller.core.IOFSwitch;
+
 import org.projectfloodlight.openflow.protocol.OFFactories;
 import org.projectfloodlight.openflow.protocol.OFFlowAdd;
 import org.projectfloodlight.openflow.protocol.OFFlowDelete;
@@ -8,6 +13,8 @@ import org.projectfloodlight.openflow.protocol.OFFlowMod;
 import org.projectfloodlight.openflow.protocol.OFFlowModify;
 import org.projectfloodlight.openflow.protocol.OFFlowModifyStrict;
 import org.projectfloodlight.openflow.protocol.OFVersion;
+import org.projectfloodlight.openflow.protocol.action.OFAction;
+import org.projectfloodlight.openflow.protocol.instruction.OFInstruction;
 
 /**
  * Convert an OFFlowMod to a specific OFFlowMod-OFFlowModCommand.
@@ -219,6 +226,25 @@ public class FlowModUtils {
 					.setTableId(fm.getTableId())
 					.setXid(fm.getXid())
 					.build();
+		}
+	}
+	
+	/**
+	 * Sets the actions in fmb according to the sw version.
+	 * 
+	 * @param fmb the FlowMod Builder that is being built
+	 * @param actions the actions to set
+	 * @param sw the switch that will receive the FlowMod
+	 */
+	public static void setActions(OFFlowMod.Builder fmb,
+			List<OFAction> actions, IOFSwitch sw) {
+		if (sw.getOFFactory().getVersion().compareTo(OFVersion.OF_11) >= 0) {
+			// Instructions are used starting in OF 1.1
+			fmb.setInstructions(Collections.singletonList((OFInstruction) sw
+					.getOFFactory().instructions().applyActions(actions)));
+		} else {
+			// OF 1.0 only supports actions
+			fmb.setActions(actions);
 		}
 	}
 }

--- a/src/test/java/net/floodlightcontroller/core/internal/OFSwitchTest.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/OFSwitchTest.java
@@ -49,116 +49,116 @@ import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFAuxId;
 
 public class OFSwitchTest {
-    protected OFSwitch sw;
-    protected OFFactory factory = OFFactories.getFactory(OFVersion.OF_13);
+	protected OFSwitch sw;
+	protected OFFactory factory = OFFactories.getFactory(OFVersion.OF_13);
 
-    @Before
-    public void setUp() throws Exception {
-        MockOFConnection mockConnection = new MockOFConnection(DatapathId.of(1), OFAuxId.MAIN);
-        sw = new OFSwitch(mockConnection, OFFactories.getFactory(OFVersion.OF_10),
-                EasyMock.createMock(IOFSwitchManager.class), DatapathId.of(1));
-    }
+	@Before
+	public void setUp() throws Exception {
+		MockOFConnection mockConnection = new MockOFConnection(DatapathId.of(1), OFAuxId.MAIN);
+		sw = new OFSwitch(mockConnection, OFFactories.getFactory(OFVersion.OF_10),
+				EasyMock.createMock(IOFSwitchManager.class), DatapathId.of(1));
+	}
 
-    @Test
-    public void testSetHARoleReply() {
-        sw.setControllerRole(OFControllerRole.ROLE_MASTER);
-        assertEquals(OFControllerRole.ROLE_MASTER, sw.getControllerRole());
+	@Test
+	public void testSetHARoleReply() {
+		sw.setControllerRole(OFControllerRole.ROLE_MASTER);
+		assertEquals(OFControllerRole.ROLE_MASTER, sw.getControllerRole());
 
-        sw.setControllerRole(OFControllerRole.ROLE_EQUAL);
-        assertEquals(OFControllerRole.ROLE_EQUAL, sw.getControllerRole());
+		sw.setControllerRole(OFControllerRole.ROLE_EQUAL);
+		assertEquals(OFControllerRole.ROLE_EQUAL, sw.getControllerRole());
 
-        sw.setControllerRole(OFControllerRole.ROLE_SLAVE);
-        assertEquals(OFControllerRole.ROLE_SLAVE, sw.getControllerRole());
-    }
+		sw.setControllerRole(OFControllerRole.ROLE_SLAVE);
+		assertEquals(OFControllerRole.ROLE_SLAVE, sw.getControllerRole());
+	}
 
-    @Test
-    public void testSubHandshake() {
-        OFFactory factory = OFFactories.getFactory(OFVersion.OF_10);
-        OFMessage m = factory.buildNiciraControllerRoleReply()
-                .setXid(1)
-                .setRole(OFNiciraControllerRole.ROLE_MASTER)
-                .build();
-        // test exceptions before handshake is started
-        try {
-            sw.processDriverHandshakeMessage(m);
-            fail("expected exception not thrown");
-        } catch (SwitchDriverSubHandshakeNotStarted e) { /* expected */ }
-        try {
-            sw.isDriverHandshakeComplete();
-            fail("expected exception not thrown");
-        } catch (SwitchDriverSubHandshakeNotStarted e) { /* expected */ }
+	@Test
+	public void testSubHandshake() {
+		OFFactory factory = OFFactories.getFactory(OFVersion.OF_10);
+		OFMessage m = factory.buildNiciraControllerRoleReply()
+				.setXid(1)
+				.setRole(OFNiciraControllerRole.ROLE_MASTER)
+				.build();
+		// test exceptions before handshake is started
+		try {
+			sw.processDriverHandshakeMessage(m);
+			fail("expected exception not thrown");
+		} catch (SwitchDriverSubHandshakeNotStarted e) { /* expected */ }
+		try {
+			sw.isDriverHandshakeComplete();
+			fail("expected exception not thrown");
+		} catch (SwitchDriverSubHandshakeNotStarted e) { /* expected */ }
 
-        // start the handshake -- it should immediately complete
-        sw.startDriverHandshake();
-        assertTrue("Handshake should be complete",
-                   sw.isDriverHandshakeComplete());
+		// start the handshake -- it should immediately complete
+		sw.startDriverHandshake();
+		assertTrue("Handshake should be complete",
+				sw.isDriverHandshakeComplete());
 
-        // test exceptions after handshake is completed
-        try {
-            sw.processDriverHandshakeMessage(m);
-            fail("expected exception not thrown");
-        } catch (SwitchDriverSubHandshakeCompleted e) { /* expected */ }
-        try {
-            sw.startDriverHandshake();
-            fail("Expected exception not thrown");
-        } catch (SwitchDriverSubHandshakeAlreadyStarted e) { /* expected */ }
-    }
+		// test exceptions after handshake is completed
+		try {
+			sw.processDriverHandshakeMessage(m);
+			fail("expected exception not thrown");
+		} catch (SwitchDriverSubHandshakeCompleted e) { /* expected */ }
+		try {
+			sw.startDriverHandshake();
+			fail("Expected exception not thrown");
+		} catch (SwitchDriverSubHandshakeAlreadyStarted e) { /* expected */ }
+	}
 
-    /**
-     * Helper to load controller connection messages into a switch for testing.
-     * @param sw the switch to insert the message on
-     * @param role the role for the controller connection message
-     * @param state the state for the controller connection message
-     * @param uri the URI for the controller connection message
-     */
-    public void updateControllerConnections(IOFSwitchBackend sw, OFControllerRole role1, OFBsnControllerConnectionState state1, String uri1
-                                            ,  OFControllerRole role2, OFBsnControllerConnectionState state2, String uri2) {
-        OFBsnControllerConnection connection1 = factory.buildBsnControllerConnection()
-                .setAuxiliaryId(OFAuxId.MAIN)
-                .setRole(role1)
-                .setState(state1)
-                .setUri(uri1)
-                .build();
+	/**
+	 * Helper to load controller connection messages into a switch for testing.
+	 * @param sw the switch to insert the message on
+	 * @param role the role for the controller connection message
+	 * @param state the state for the controller connection message
+	 * @param uri the URI for the controller connection message
+	 */
+	public void updateControllerConnections(IOFSwitchBackend sw, OFControllerRole role1, OFBsnControllerConnectionState state1, String uri1
+			,  OFControllerRole role2, OFBsnControllerConnectionState state2, String uri2) {
+		OFBsnControllerConnection connection1 = factory.buildBsnControllerConnection()
+				.setAuxiliaryId(OFAuxId.MAIN)
+				.setRole(role1)
+				.setState(state1)
+				.setUri(uri1)
+				.build();
 
-        OFBsnControllerConnection connection2 = factory.buildBsnControllerConnection()
-                .setAuxiliaryId(OFAuxId.MAIN)
-                .setRole(role2)
-                .setState(state2)
-                .setUri(uri2)
-                .build();
+		OFBsnControllerConnection connection2 = factory.buildBsnControllerConnection()
+				.setAuxiliaryId(OFAuxId.MAIN)
+				.setRole(role2)
+				.setState(state2)
+				.setUri(uri2)
+				.build();
 
-        List<OFBsnControllerConnection> connections = new ArrayList<OFBsnControllerConnection>();
-        connections.add(connection1);
-        connections.add(connection2);
+		List<OFBsnControllerConnection> connections = new ArrayList<OFBsnControllerConnection>();
+		connections.add(connection1);
+		connections.add(connection2);
 
-        OFBsnControllerConnectionsReply reply = factory.buildBsnControllerConnectionsReply()
-                .setConnections(connections)
-                .build();
+		OFBsnControllerConnectionsReply reply = factory.buildBsnControllerConnectionsReply()
+				.setConnections(connections)
+				.build();
 
-        sw.updateControllerConnections(reply);
-    }
+		sw.updateControllerConnections(reply);
+	}
 
-    /**
-     * This test ensures that the switch accurately determined if another master
-     * exists in the cluster by examining the controller connections it has.
-     */
-    @Test
-    public void testHasAnotherMaster() {
-        URI cokeUri = URIUtil.createURI("1.2.3.4", 6653);
-        InetSocketAddress address = (InetSocketAddress) sw.getConnection(OFAuxId.MAIN).getLocalInetAddress();
-        URI pepsiUri = URIUtil.createURI(address.getHostName(), address.getPort());
+	/**
+	 * This test ensures that the switch accurately determined if another master
+	 * exists in the cluster by examining the controller connections it has.
+	 */
+	@Test
+	public void testHasAnotherMaster() {
+		URI cokeUri = URIUtil.createURI("1.2.3.4", 6653);
+		InetSocketAddress address = (InetSocketAddress) sw.getConnection(OFAuxId.MAIN).getLocalInetAddress();
+		URI pepsiUri = URIUtil.createURI(address.getHostName(), address.getPort());
 
-        updateControllerConnections(sw, OFControllerRole.ROLE_SLAVE, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, cokeUri.toString(),
-                                    OFControllerRole.ROLE_MASTER, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, pepsiUri.toString());
+		updateControllerConnections(sw, OFControllerRole.ROLE_SLAVE, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, cokeUri.toString(),
+				OFControllerRole.ROLE_MASTER, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, pepsiUri.toString());
 
-        // From the perspective of pepsi, the cluster currently does NOT have another master controller
-        assertFalse(sw.hasAnotherMaster());
+		// From the perspective of pepsi, the cluster currently does NOT have another master controller
+		assertFalse(sw.hasAnotherMaster());
 
-        // Switch the controller connections so that pepsi is no longer master
-        updateControllerConnections(sw, OFControllerRole.ROLE_MASTER, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, cokeUri.toString(),
-                                    OFControllerRole.ROLE_SLAVE, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, pepsiUri.toString());
+		// Switch the controller connections so that pepsi is no longer master
+		updateControllerConnections(sw, OFControllerRole.ROLE_MASTER, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, cokeUri.toString(),
+				OFControllerRole.ROLE_SLAVE, OFBsnControllerConnectionState.BSN_CONTROLLER_CONNECTION_STATE_CONNECTED, pepsiUri.toString());
 
-        // From the perspective of pepsi, the cluster currently has another master controller
-        assertTrue(sw.hasAnotherMaster());
-    }
+		// From the perspective of pepsi, the cluster currently has another master controller
+		assertTrue(sw.hasAnotherMaster());
+	}
 }


### PR DESCRIPTION
Fix OF1.4 table features properties byte-align to 8 bytes. This required a Loxi update. Also updated handshake handler to not use action but instead instructions w/apply-actions.

In an upcoming commit, will update Forwarding and others that use the flowMod.setActions(actions) shortcut for flowMod.setInstructions(Collections.singletonList((OFInstruction) actions)). Either that, or will update Loxi again with the prewritten Java for an OF1.4 equivalent shortcut.