### PR TITLE
Update ACL.java

### DIFF
--- a/src/main/java/net/floodlightcontroller/accesscontrollist/ACL.java
+++ b/src/main/java/net/floodlightcontroller/accesscontrollist/ACL.java
@@ -351,7 +351,11 @@ public class ACL implements IACLService, IFloodlightModule, IDeviceListener {
 
 	@Override
 	public void deviceAdded(IDevice device) {
-		SwitchPort[] switchPort = device.getAttachmentPoints();
+		SwitchPort[] switchPort = device.getAttachmentPoints(); 
+		if (switchPort.length == 0) {
+                        //Device manager does not yet know an attachment point for a device (Bug Fix) 
+                        return;
+                }
 		IPv4Address[] ips = device.getIPv4Addresses();
 		if (ips.length == 0) {
 			// A new no-ip device added


### PR DESCRIPTION
In the event the device manger does not yet know an attachment point for a device, the ACL should detect that and perform a noop. Simply checking the length of the SwitchPort[] returned from the device manger should fix the problem. If the length is zero, return; else, proceed.