### PR TITLE
Fixing squid:S2259 - Null pointers should not be dereferenced

### DIFF
--- a/src/main/java/org/sdnplatform/sync/internal/store/JavaDBStorageEngine.java
+++ b/src/main/java/org/sdnplatform/sync/internal/store/JavaDBStorageEngine.java
@@ -197,10 +197,12 @@ public class JavaDBStorageEngine implements IStorageEngine<ByteArray, byte[]> {
                 update.execute();
                 dbConnection.commit();
             } catch (SyncException e) {
-                dbConnection.rollback();
+            	if(dbConnection != null)
+            		dbConnection.rollback();
                 throw e;
             } catch (Exception e) {
-                dbConnection.rollback();
+            	if(dbConnection != null)
+            		dbConnection.rollback();
                 throw new PersistException("Could not retrieve key from database",
                                            e);
             } finally {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - “Null pointers should not be dereferenced”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Sameer Misger