### PR TITLE
Fixing squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/module/FloodlightModuleLoader.java
+++ b/src/main/java/net/floodlightcontroller/core/module/FloodlightModuleLoader.java
@@ -323,7 +323,7 @@ public class FloodlightModuleLoader {
                 if (m == null) {
                     Collection<IFloodlightModule> mods = serviceMap.get(c);
                     // Make sure only one module is loaded
-                    if ((mods == null) || (mods.size() == 0)) {
+                    if ((mods == null) || mode.isEmpty()) {
                         throw new FloodlightModuleException("ERROR! Could not " +
                                 "find an IFloodlightModule that provides service " +
                                 c.toString());

--- a/src/main/java/net/floodlightcontroller/core/util/ListenerDispatcher.java
+++ b/src/main/java/net/floodlightcontroller/core/util/ListenerDispatcher.java
@@ -80,7 +80,7 @@ public class ListenerDispatcher<U, T extends IListener<U>> {
             }
         }
 
-        if (terminals.size() == 0) {
+        if (terminals.isEmpty()) {
             logger.error("No listener dependency solution: " +
                          "No listeners without incoming dependencies");
             listeners = newlisteners;

--- a/src/main/java/net/floodlightcontroller/debugcounter/CounterNode.java
+++ b/src/main/java/net/floodlightcontroller/debugcounter/CounterNode.java
@@ -84,7 +84,7 @@ class CounterNode implements Iterable<DebugCounterImpl> {
 
     /** verify that this node is the root */
     private void verifyIsRoot() {
-        if (hierarchyElements.isEmpty() != 0) {
+        if (!hierarchyElements.isEmpty()) {
             throw new IllegalStateException("This is not the root. Can "
                     + "only call addCounter() on the root node. Current node: "
                     + hierarchy);

--- a/src/main/java/net/floodlightcontroller/debugcounter/CounterNode.java
+++ b/src/main/java/net/floodlightcontroller/debugcounter/CounterNode.java
@@ -84,7 +84,7 @@ class CounterNode implements Iterable<DebugCounterImpl> {
 
     /** verify that this node is the root */
     private void verifyIsRoot() {
-        if (hierarchyElements.size() != 0) {
+        if (hierarchyElements.isEmpty() != 0) {
             throw new IllegalStateException("This is not the root. Can "
                     + "only call addCounter() on the root node. Current node: "
                     + hierarchy);

--- a/src/main/java/net/floodlightcontroller/debugevent/CustomFormatters.java
+++ b/src/main/java/net/floodlightcontroller/debugevent/CustomFormatters.java
@@ -26,7 +26,7 @@ class CustomFormatterCollectionAttachmentPoint implements
                          EventResourceBuilder edb) {
         if (aps2 != null) {
             StringBuilder apsStr2 = new StringBuilder();
-            if (aps2.size() == 0) {
+            if (aps2.isEmpty()) {
                 apsStr2.append("--");
             } else {
                 for (SwitchPort ap : aps2) {
@@ -71,7 +71,7 @@ class CustomFormatterCollectionObject implements
                          EventResourceBuilder edb) {
         if (obl2 != null) {
             StringBuilder sbldr2 = new StringBuilder();
-            if (obl2.size() == 0) {
+            if (obl2.isEmpty()) {
                 sbldr2.append("--");
             } else {
                 for (Object o : obl2) {
@@ -167,7 +167,7 @@ class CustomFormatterSrefCollectionObject implements
             Collection<Object> ol2 = srefCollectionObj2.get();
             if (ol2 != null) {
                 StringBuilder sb = new StringBuilder();
-                if (ol2.size() == 0) {
+                if (ol2.isEmpty()) {
                     sb.append("--");
                 } else {
                     for (Object o : ol2) {

--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/Device.java
@@ -312,7 +312,7 @@ public class Device implements IDevice {
 				expiredAPs.add(ap);
 			}
 		}
-		if (expiredAPs.size() > 0) {
+		if (!expiredAPs.isEmpty()) {
 			apList.removeAll(expiredAPs);
 			return true;
 		} else

--- a/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/internal/DeviceManagerImpl.java
@@ -1663,7 +1663,7 @@ public class DeviceManagerImpl implements IDeviceService, IOFMessageListener, IT
 				// We need to count here after all the possible "continue"
 				// statements in this branch
 				cntNewEntity.increment();
-				if (changedFields.size() > 0) {
+				if (!changedFields.isEmpty()) {
 					cntDeviceChanged.increment();
 					deviceUpdates =
 							updateUpdates(deviceUpdates,
@@ -1966,7 +1966,7 @@ public class DeviceManagerImpl implements IDeviceService, IOFMessageListener, IT
 						 toKeep.add(e);
 					 }
 				 }
-				 if (toRemove.size() == 0) {
+				 if (toRemove.isEmpty()) {
 					 break;
 				 }
 
@@ -1975,7 +1975,7 @@ public class DeviceManagerImpl implements IDeviceService, IOFMessageListener, IT
 					 removeEntity(e, d.getEntityClass(), d.getDeviceKey(), toKeep);
 				 }
 
-				 if (toKeep.size() > 0) {
+				 if (!toKeep.isEmpty()) {
 					 Device newDevice = allocateDevice(d.getDeviceKey(),
 							 d.getDHCPClientName(),
 							 d.oldAPs,
@@ -1989,7 +1989,7 @@ public class DeviceManagerImpl implements IDeviceService, IOFMessageListener, IT
 						 changedFields.addAll(findChangedFields(newDevice, e));
 					 }
 					 DeviceUpdate update = null;
-					 if (changedFields.size() > 0) {
+					 if (!changedFields.isEmpty()) {
 						 update = new DeviceUpdate(d, CHANGE, changedFields);
 					 }
 

--- a/src/main/java/net/floodlightcontroller/flowcache/FlowReconcileManager.java
+++ b/src/main/java/net/floodlightcontroller/flowcache/FlowReconcileManager.java
@@ -292,7 +292,7 @@ public class FlowReconcileManager implements IFloodlightModule, IFlowReconcileSe
 
 		// Run the flow through all the flow reconcile listeners
 		IFlowReconcileListener.Command retCmd;
-		if (ofmRcList.size() > 0) {
+		if (!ofmRcList.isEmpty()) {
 			List<IFlowReconcileListener> listeners =
 					flowReconcileListeners.getOrderedListeners();
 			if (listeners == null) {

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
@@ -63,7 +63,7 @@ public class LBPool {
     
     public String pickMember(IPClient client) {
         // simple round robin for now; add different lbmethod later
-        if (members.size() > 0) {
+        if (!members.isEmpty()) {
             previousMemberIndex = (previousMemberIndex + 1) % members.size();
             return members.get(previousMemberIndex);
         } else {

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LBVip.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LBVip.java
@@ -71,7 +71,7 @@ public class LBVip {
     
     public String pickPool(IPClient client) {
         // for now, return the first pool; consider different pool choice policy later
-        if (pools.size() > 0)
+        if (!pools.isEmpty())
             return pools.get(0);
         else
             return null;

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
@@ -495,7 +495,7 @@ public class LoadBalancer implements IFloodlightModule,
      */
     public void pushStaticVipRoute(boolean inBound, Route route, IPClient client, LBMember member, IOFSwitch pinSwitch) {
         List<NodePortTuple> path = route.getPath();
-        if (path.size() > 0) {
+        if (!path.isEmpty()) {
            for (int i = 0; i < path.size(); i+=2) {
                DatapathId sw = path.get(i).getNodeId();
                String entryName;

--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -1295,7 +1295,7 @@ public class TopologyManager implements IFloodlightModule, ITopologyService, IRo
 			}
 		}
 
-		if (additionalNpt.size() > 0) {
+		if (!additionalNpt.isEmpty()) {
 			log.warn("The following switch ports have multiple " +
 					"links incident on them, so these ports will be treated " +
 					" as braodcast domain ports. {}", additionalNpt);

--- a/src/main/java/org/sdnplatform/sync/internal/DefaultStoreClient.java
+++ b/src/main/java/org/sdnplatform/sync/internal/DefaultStoreClient.java
@@ -138,7 +138,7 @@ public class DefaultStoreClient<K, V> extends AbstractStoreClient<K, V> {
                                           Versioned<V> defaultValue,
                                           List<Versioned<V>> items)
              throws InconsistentDataException {
-        if(items.size() == 0)
+        if(items.isEmpty())
             return defaultValue(defaultValue);
         else if(items.size() == 1)
             return items.get(0);

--- a/src/main/java/org/sdnplatform/sync/internal/SyncManager.java
+++ b/src/main/java/org/sdnplatform/sync/internal/SyncManager.java
@@ -320,7 +320,7 @@ public class SyncManager extends AbstractSyncManager {
 		if (store == null) return true;
 
 		List<Versioned<byte[]>> values = store.get(new ByteArray(key));
-		if (values == null || values.size() == 0) return true;
+		if (values == null || values.isEmpty()) return true;
 
 		// check whether any of the versions are not older than what we have
 		for (VectorClock vc : versions) {

--- a/src/main/java/org/sdnplatform/sync/internal/config/StorageCCProvider.java
+++ b/src/main/java/org/sdnplatform/sync/internal/config/StorageCCProvider.java
@@ -131,7 +131,7 @@ public class StorageCCProvider
             if (res != null) res.close();
         }
 
-        if (nodes.size() == 0)
+        if (nodes.isEmpty())
             throw new SyncException("No valid nodes found");
         if (thisNodeId < 0)
             throw new SyncException("Could not find a node for the local node");

--- a/src/main/java/org/sdnplatform/sync/internal/rpc/RPCChannelHandler.java
+++ b/src/main/java/org/sdnplatform/sync/internal/rpc/RPCChannelHandler.java
@@ -335,7 +335,7 @@ public class RPCChannelHandler extends AbstractRPCChannelHandler {
                 ByteArray keyArray = new ByteArray(key.array());
                 List<Versioned<byte[]>> values =
                         store.get(keyArray);
-                if (values == null || values.size() == 0) continue;
+                if (values == null || values.isEmpty()) continue;
                 KeyedValues kv =
                         TProtocolUtil.getTKeyedValues(keyArray, values);
                 svm.addToValues(kv);

--- a/src/main/java/org/sdnplatform/sync/internal/version/VectorClock.java
+++ b/src/main/java/org/sdnplatform/sync/internal/version/VectorClock.java
@@ -147,7 +147,7 @@ public class VectorClock implements IVersion, Serializable, Cloneable {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("version(");
-        if(this.versions.size() > 0) {
+        if(!this.versions.isEmpty()) {
             for(int i = 0; i < this.versions.size() - 1; i++) {
                 builder.append(this.versions.get(i));
                 builder.append(", ");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 -  Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1155


Please let me know if you have any questions.
Sameer Misger