### PR TITLE
Fixing squid:S1596 -  Collections.emptyList() should be used instead of 

### DIFF
--- a/src/test/java/net/floodlightcontroller/core/internal/OFSwitchHandlerTestBase.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/OFSwitchHandlerTestBase.java
@@ -524,13 +524,13 @@ public abstract class OFSwitchHandlerTestBase {
 		// again it looks odd. Maybe change
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
 		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
-		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.emptyList()).anyTimes();
 		expect(sw.getNumTables()).andStubReturn((short)0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, supportsNxRole);
 		expectLastCall().anyTimes();
 		if (SwitchStatus.MASTER == newStatus) {
 			if (factory.getVersion().compareTo(OFVersion.OF_13) >= 0) {
-				expect(sw.getTables()).andReturn(Collections.EMPTY_LIST).once();
+				expect(sw.getTables()).andReturn(Collections.emptyList()).once();
 				expect(sw.getTableFeatures(TableId.ZERO)).andReturn(TableFeatures.of(createTableFeaturesStatsReply().getEntries().get(0))).anyTimes();
 			}
 		}
@@ -600,8 +600,8 @@ public abstract class OFSwitchHandlerTestBase {
 		reset(sw);
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
 		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
-		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
-		expect(sw.getTables()).andStubReturn(Collections.EMPTY_LIST);
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.emptyList()).anyTimes();
+		expect(sw.getTables()).andStubReturn(Collections.emptyList());
 		expect(sw.getNumTables()).andStubReturn((short) 0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, true);
 		expectLastCall().once();
@@ -694,7 +694,7 @@ public abstract class OFSwitchHandlerTestBase {
 		reset(sw);
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
 		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
-		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.emptyList()).anyTimes();
 		expect(sw.getNumTables()).andStubReturn((short)0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, false);
 		expectLastCall().once();
@@ -704,7 +704,7 @@ public abstract class OFSwitchHandlerTestBase {
 		sw.setStatus(SwitchStatus.MASTER);
 		expectLastCall().once();
 		if (factory.getVersion().compareTo(OFVersion.OF_13) >= 0) {
-			expect(sw.getTables()).andReturn(Collections.EMPTY_LIST).once();
+			expect(sw.getTables()).andReturn(Collections.emptyList()).once();
 			expect(sw.getTableFeatures(TableId.ZERO)).andReturn(TableFeatures.of(createTableFeaturesStatsReply().getEntries().get(0))).anyTimes();
 		}
 		replay(sw);
@@ -755,7 +755,7 @@ public abstract class OFSwitchHandlerTestBase {
 		reset(sw);
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
 		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
-		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.emptyList()).anyTimes();
 		expect(sw.getNumTables()).andStubReturn((short)0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, false);
 		expectLastCall().once();
@@ -765,7 +765,7 @@ public abstract class OFSwitchHandlerTestBase {
 		sw.setStatus(SwitchStatus.MASTER);
 		expectLastCall().once();
 		if (factory.getVersion().compareTo(OFVersion.OF_13) >= 0) {
-			expect(sw.getTables()).andReturn(Collections.EMPTY_LIST).once();
+			expect(sw.getTables()).andReturn(Collections.emptyList()).once();
 			expect(sw.getTableFeatures(TableId.ZERO)).andReturn(TableFeatures.of(createTableFeaturesStatsReply().getEntries().get(0))).anyTimes();
 		}
 		replay(sw);
@@ -917,7 +917,7 @@ public abstract class OFSwitchHandlerTestBase {
 		reset(sw);
 		expect(sw.getOFFactory()).andReturn(factory).anyTimes();
 		expect(sw.write(anyObject(OFMessage.class))).andReturn(true).anyTimes();
-		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.EMPTY_LIST).anyTimes();
+		expect(sw.write(anyObject(Iterable.class))).andReturn(Collections.emptyList()).anyTimes();
 		expect(sw.getNumTables()).andStubReturn((short)0);
 		sw.setAttribute(IOFSwitch.SWITCH_SUPPORTS_NX_ROLE, true);
 		expectLastCall().once();
@@ -926,7 +926,7 @@ public abstract class OFSwitchHandlerTestBase {
 		expect(sw.getStatus()).andReturn(SwitchStatus.HANDSHAKE).once();
 		sw.setStatus(SwitchStatus.MASTER);
 		expectLastCall().once();
-		expect(sw.getTables()).andReturn(Collections.EMPTY_LIST).once();
+		expect(sw.getTables()).andReturn(Collections.emptyList()).once();
 		replay(sw);
 
 		reset(switchManager);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1596 -   Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1596



Please let me know if you have any questions.
Sameer Misger