### PR TITLE
deserialize fix for not-known Ethernet types

### DIFF
--- a/src/main/java/net/floodlightcontroller/packet/Ethernet.java
+++ b/src/main/java/net/floodlightcontroller/packet/Ethernet.java
@@ -307,7 +307,9 @@ public class Ethernet extends BasePacket {
                 this.payload = new Data(data);
             }
         } else {
-            this.payload = new Data(data);
+            byte[] buf = new byte[bb.remaining()];
+            bb.get(buf);
+            this.payload = new Data(buf);
         }
         this.payload.setParent(this);
         return this;


### PR DESCRIPTION
For Ethernet types not in Ethernet.etherTypeClassMap, the deserialization would set the payload to the whole data array (including the mac addresses and eth type) instead of the rest of the data array.

For example, this would fail to print:

Ethernet l2 = new Ethernet();
l2.setEtherType(EthType.of(65535)); // some type
l2.setSourceMACAddress(MacAddress.of("00:00:00:00:00:01"));
l2.setDestinationMACAddress(MacAddress.BROADCAST);
Data packetData = new Data();
packetData.setData("some string".getBytes());
l2.setPayload(packetData);
byte[] l2bytes = l2.serialize();
Ethernet l2d = new Ethernet();
l2d.deserialize(l2bytes, 0, l2bytes.length);
Data packetDataDeserialized = (Data) l2d.getPayload();
// printing "new String(packetDataDeserialized.getData())" gives "?????"

I ran the JUnit tests in floodlightcontroller.core.internal, floodlightcontroller.core.test and floodlightcontroller.packet. Are there any more relevant tests?