### PR TITLE
Changed DeviceResource to return a JSON object instead of returning a list.

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/web/DeviceResource.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/web/DeviceResource.java
@@ -1,7 +1,7 @@
 /**
-*    Copyright 2012, Big Switch Networks, Inc. 
+*    Copyright 2012, Big Switch Networks, Inc.
 *    Originally created by David Erickson, Stanford University
-* 
+*
 *    Licensed under the Apache License, Version 2.0 (the "License"); you may
 *    not use this file except in compliance with the License. You may obtain
 *    a copy of the License at
@@ -17,7 +17,9 @@
 
 package net.floodlightcontroller.devicemanager.web;
 
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 import net.floodlightcontroller.devicemanager.IDevice;
 import org.restlet.resource.Get;
@@ -26,8 +28,14 @@ import org.restlet.resource.Get;
  * Resource for querying and displaying devices that exist in the system
  */
 public class DeviceResource extends AbstractDeviceResource {
-    @Get("json")
     public Iterator<? extends IDevice> getDevices() {
         return super.getDevices();
+    }
+
+    @Get("json")
+    public Map<String, Iterator<? extends IDevice>> getNamedDeviceList() {
+        Map<String, Iterator<? extends IDevice>> result = new HashMap<String, Iterator<? extends IDevice>>();
+        result.put("devices", getDevices());
+        return result;
     }
 }


### PR DESCRIPTION
Please consider this change to the REST API.  I expect to work through the rest of the resource calls if this change is adopted.

Many REST ingest schemes (e.g. Graylog "JSON path from HTTP") expect servers to return well-formed JSON objects.  Floodlight is sometimes returning values that lack root objects.  This can make ingestion engines ignore "non-JSON header fields" until they encounter the start of an object (that is, a "{" character).  In the case of a '/wm/device/' query from Graylog, this means only the first device in the list is recognized.

Was:
   [ \<list-of-device-objects\> ]

Now:
   { 'devices' : [ \<list-of-device-objects\> ] }