### PR TITLE
Changed version in pom.xml to 1.2 for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.projectfloodlight</groupId>
 	<artifactId>floodlight</artifactId>
-	<version>1.2-SNAPSHOT</version>
+	<version>1.2</version>
 	<name>floodlight</name>
 	<repositories>
 		<repository>


### PR DESCRIPTION
The pom.xml in the release v1.2 branch still contains a SNAPSHOT tag, causing issues with some deployments.