### PR TITLE
Convert any format DPID to hex string DPID for static entry pusher's 'switch' key

### DIFF
--- a/src/main/java/net/floodlightcontroller/staticentry/StaticEntryPusher.java
+++ b/src/main/java/net/floodlightcontroller/staticentry/StaticEntryPusher.java
@@ -300,7 +300,7 @@ implements IOFSwitchListener, IFloodlightModule, IStaticEntryPusherService, ISto
 		}
 		
 		try {
-			switchName = (String) row.get(Columns.COLUMN_SWITCH);
+			switchName = DatapathId.of((String) row.get(Columns.COLUMN_SWITCH)).toString();
 			entryName = (String) row.get(Columns.COLUMN_NAME);
 
 			String tmp = (String) row.get(Columns.COLUMN_ENTRY_TYPE);
@@ -399,7 +399,7 @@ implements IOFSwitchListener, IFloodlightModule, IStaticEntryPusherService, ISto
 					matchString.append(key + "=" + row.get(key).toString());
 				}
 			}
-		} catch (ClassCastException e) {
+		} catch (Exception e) {
 			if (entryName != null && switchName != null) {
 				log.warn("Skipping entry {} on switch {} with bad data : " + e.getMessage(), entryName, switchName);
 			} else {

--- a/src/main/java/net/floodlightcontroller/util/ActionUtils.java
+++ b/src/main/java/net/floodlightcontroller/util/ActionUtils.java
@@ -110,6 +110,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
+
 import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import com.fasterxml.jackson.core.JsonParser;
 
@@ -184,7 +185,7 @@ public class ActionUtils {
             }
             switch(a.getType()) {
             case OUTPUT:
-                sb.append(STR_OUTPUT).append("=").append(Integer.toString(((OFActionOutput)a).getPort().getPortNumber()));
+                sb.append(STR_OUTPUT).append("=").append(ActionUtils.portToString(((OFActionOutput)a).getPort()));
                 break;
             case ENQUEUE:
                 long queue = ((OFActionEnqueue)a).getQueueId();


### PR DESCRIPTION
convert integer DPIDs specified to the SEP to DatapathId to prevent duplicate DPID flow sets listed just because the DPID was entered in a different format. hexstring is what will be used

Piggybacked here is the display of special ports in any flow-mod JSON serialization. This avoids the display of negative numbers for ports like "in_port", "local", etc. Instead, their string keys will be displayed