### PR TITLE
Set version and name when compiling using ant

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -251,10 +251,15 @@
     <target name="coverage" depends="instrument,test,coverage-report"/>
 
     <target name="dist" depends="compile,compile-test">
+        <xmlproperty file="pom.xml" prefix="pom"/>
+        <echo message="Setting Floodlight version: ${pom.project.version}"/>
+        <echo message="Setting Floodlight name: ${pom.project.name}"/>
         <jar destfile="${floodlight-jar}" filesetmanifest="mergewithoutmain">
             <manifest>
                 <attribute name="Main-Class" value="${main-class}"/>
                 <attribute name="Class-Path" value="."/>
+                <attribute name="Implementation-Version" value="${pom.project.version}"/>
+                <attribute name="Implementation-Title" value="${pom.project.name}"/>
             </manifest>
             <fileset dir="${build}"/>
             <fileset dir="${resources}"/>


### PR DESCRIPTION
allow ant to read project version and name from pom.xml. Ideally, we'd put these constants in a separate file, but maven does not allow these tags to contain variable values