### PR TITLE
Trivial support for HA role setting in REST API

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/Controller.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/Controller.java
@@ -134,6 +134,7 @@ public class Controller implements IFloodlightProviderService, IStorageSourceLis
      * based on parameters that are only available in init()
      */
     private static RoleManager roleManager;
+    protected static boolean shutdownOnTransitionToStandby = false;
 
     /* Storage table names */
     protected static final String CONTROLLER_TABLE_NAME = "controller_controller";
@@ -620,10 +621,21 @@ public class Controller implements IFloodlightProviderService, IStorageSourceLis
         }        
         log.info("ControllerId set to {}", this.controllerId);
         
+        String shutdown = configParams.get("shutdownOnTransitionToStandby");
+        if (!Strings.isNullOrEmpty(shutdown)) {
+            try {
+                shutdownOnTransitionToStandby = Boolean.parseBoolean(shutdown.trim());
+            } catch (Exception e) {
+                log.error("Could not parse 'shutdownOnTransitionToStandby' of {}. Using default setting of {}", 
+                        shutdown, shutdownOnTransitionToStandby);
+            }
+        }        
+        log.info("Shutdown when controller transitions to STANDBY HA role: {}", shutdownOnTransitionToStandby);
+        
         String decodeEth = configParams.get("deserializeEthPacketIns");
         if (!Strings.isNullOrEmpty(decodeEth)) {
         	try {
-        		alwaysDecodeEth = Boolean.parseBoolean(decodeEth);
+        		alwaysDecodeEth = Boolean.parseBoolean(decodeEth.trim());
         	} catch (Exception e) {
         		log.error("Could not parse 'deserializeEthPacketIns' of {}. Using default setting of {}", decodeEth, alwaysDecodeEth);
         	}

--- a/src/main/java/net/floodlightcontroller/core/internal/RoleManager.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/RoleManager.java
@@ -219,7 +219,7 @@ public class RoleManager {
 
            controller.setNotifiedRole(newRole);
 
-           if(newRole == HARole.STANDBY) {
+           if (newRole == HARole.STANDBY && Controller.shutdownOnTransitionToStandby) {
                String reason = String.format("Received role request to "
                        + "transition from ACTIVE to STANDBY (reason: %s)",
                        getRoleInfo().getRoleChangeDescription());

--- a/src/main/java/net/floodlightcontroller/core/web/ControllerRoleResource.java
+++ b/src/main/java/net/floodlightcontroller/core/web/ControllerRoleResource.java
@@ -16,11 +16,13 @@
 
 package net.floodlightcontroller.core.web;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.restlet.resource.ServerResource;
 
+import net.floodlightcontroller.core.HARole;
 import net.floodlightcontroller.core.IFloodlightProviderService;
 import net.floodlightcontroller.core.RoleInfo;
 
@@ -30,17 +32,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 public class ControllerRoleResource extends ServerResource {
 
     protected static Logger log = LoggerFactory.getLogger(ControllerRoleResource.class);
     
-    private static final String STR_ACTIVE = "ACTIVE";
-    private static final String STR_STANDBY = "STANDBY";
     private static final String STR_ROLE = "role";
-    private static final String STR_ROLE_CHANGE_DESC = "role-change-description";
-    private static final String STR_ROLE_CHANGE_DATE_TIME = "role-change-date-time";
+    private static final String STR_ROLE_CHANGE_DESC = "role_change_description";
+    private static final String STR_ROLE_CHANGE_DATE_TIME = "role_change_date_time";
 
     @Get("json")
     public Map<String, String> getRole() {
@@ -68,12 +69,9 @@ public class ControllerRoleResource extends ServerResource {
 		String role = null;
 		String roleChangeDesc = null;
 		
-		retValue.put("TBD", "Not yet implemented");
-		return retValue;
-		/*
 		try {
 			try {
-				jp = f.createJsonParser(json);
+				jp = f.createParser(json);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
@@ -106,16 +104,14 @@ public class ControllerRoleResource extends ServerResource {
 			}
 		} catch (IOException e) {
 			e.printStackTrace();
-			retValue.put("ERROR", "Caught IOException while parsing JSON POST request in role request.");
+			retValue.put("ERROR", "Caught exception while parsing controller role request. Supported roles: ACTIVE, STANDBY (or MASTER, SLAVE)");
 		}
     
         HARole harole = null;
         try {
-        	harole = HARole.valueOfBackwardsCompatible(role);
+        	harole = HARole.valueOfBackwardsCompatible(role.toUpperCase().trim());
         } catch (IllegalArgumentException | NullPointerException e) {
-            // The role value in the REST call didn't match a valid
-            // role name, so just leave the role as null and handle
-            // the error below.
+            retValue.put("ERROR", "Caught exception while parsing controller role request. Supported roles: ACTIVE, STANDBY (or MASTER, SLAVE)");
         }
 
         if (roleChangeDesc == null) {
@@ -129,6 +125,6 @@ public class ControllerRoleResource extends ServerResource {
         retValue.put(STR_ROLE_CHANGE_DESC, ri.getRoleChangeDescription());
         retValue.put(STR_ROLE_CHANGE_DATE_TIME, ri.getRoleChangeDateTime().toString());
         
-		return retValue;*/
+		return retValue;
     }
 }

--- a/src/main/resources/floodlightdefault.properties
+++ b/src/main/resources/floodlightdefault.properties
@@ -37,6 +37,7 @@ net.floodlightcontroller.core.internal.FloodlightProvider.role=ACTIVE
 net.floodlightcontroller.core.internal.FloodlightProvider.controllerId=1
 net.floodlightcontroller.linkdiscovery.internal.LinkDiscoveryManager.latency-history-size=10
 net.floodlightcontroller.linkdiscovery.internal.LinkDiscoveryManager.latency-update-threshold=0.5
+net.floodlightcontroller.core.internal.FloodlightProvider.shutdownOnTransitionToStandby=true
 net.floodlightcontroller.core.internal.OFSwitchManager.openFlowPort=6653
 net.floodlightcontroller.core.internal.OFSwitchManager.openFlowAddresses=0.0.0.0
 net.floodlightcontroller.core.internal.OFSwitchManager.workerThreads=16


### PR DESCRIPTION
Add new option in properties to allow user to choose behavior upon transition to STANDBY. Default w/o setting in properties is to keep the controller running and wait for a transition to ACTIVE before dispatching any messages to modules. Since HA support hasn't been widely integrated in the controller, this default is overridden in floodlightdefault.properties to shutdown the controller when a transition to STANDBY takes place.