### PR TITLE
Each hop of path should optionally ignore in-port in flow match

### DIFF
--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -250,7 +250,9 @@ public abstract class ForwardingBase implements IOFMessageListener {
             // set input and output ports on the switch
             OFPort outPort = switchPortList.get(indx).getPortId();
             OFPort inPort = switchPortList.get(indx - 1).getPortId();
-            mb.setExact(MatchField.IN_PORT, inPort);
+            if (FLOWMOD_DEFAULT_MATCH_IN_PORT) {
+                mb.setExact(MatchField.IN_PORT, inPort);
+            }
             aob.setPort(outPort);
             aob.setMaxLen(Integer.MAX_VALUE);
             actions.add(aob.build());


### PR DESCRIPTION
ForwardingBase should also abide by Forwarding's match fields, including in-port.