### PR TITLE
Improve Forwarding link/port down handler

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/util/AppCookie.java
+++ b/src/main/java/net/floodlightcontroller/core/util/AppCookie.java
@@ -36,48 +36,37 @@ import org.projectfloodlight.openflow.types.U64;
  *
  * The 64 bit OpenFlow cookie field used in the following way
  * <li> Bit 63 -- 52 (12 bit): the AppId
- * <li> Bit 51 -- 32 (20 bit): currently unused. Set to 0.
- * <li> Bit 31 -- 0  (32 bit): user data
+ * <li> Bit 51 -- 0  (52 bit): user data
  *
  * FIXME: The class should be a singleton. The registration method should
  * return an instance of class. This instance should then be used to generate
  * flow cookies. Ideally, we would also represent a flow cookie as a class
  * instance.
  *
- *
  * @author capveg
- *
  */
 
 public class AppCookie {
-    static final int APP_ID_BITS = 12;
-    static final long APP_ID_MASK = (1L << APP_ID_BITS) - 1;
-    static final int APP_ID_SHIFT = (64 - APP_ID_BITS);
+    private static final int APP_ID_BITS = 12;
+    private static final long APP_ID_MASK = (1L << APP_ID_BITS) - 1;
+    private static final int APP_ID_SHIFT = 64 - APP_ID_BITS;
 
-    static final long USER_MASK = 0x00000000FFFFFFFFL;
+    private static final long USER_MASK = 0x000FFFFFFFFFFFFFL;
 
-    /**the following bit will be set accordingly if the field is rewritten by application. e.g. VRS or floating IP
-     * FIXME: these should not be in AppCookie and they shoul not use
-     * the reserved bit range*/
-    static final int SRC_MAC_REWRITE_BIT=33;
-    static final int DEST_MAC_REWRITE_BIT=34;
-    static final int SRC_IP_REWRITE_BIT=35;
-    static final int DEST_IP_REWRITE_BIT=36;
-
-
-    static final long REWRITE_MASK= 0x000f00000000L;
-    private static ConcurrentMap<Integer, String> appIdMap =
-            new ConcurrentHashMap<Integer, String>();
+    private static ConcurrentMap<Long, String> appIdMap =
+            new ConcurrentHashMap<Long, String>();
 
     /**
-     * Returns a mask suitable for matching the App ID within a cookie.
+     * Returns a mask suitable for matching the app ID within a cookie.
+     * @return a mask representing the bits used for the app ID in the cookie
      */
     static public U64 getAppFieldMask() {
         return U64.of(APP_ID_MASK << APP_ID_SHIFT);
     }
 
     /**
-     * Returns a mask suitable for matching the User field within a cookie.
+     * Returns a mask suitable for matching the user field within a cookie.
+     * @return a mask representing the bits used for user data in the cookie
      */
     static public U64 getUserFieldMask() {
         return U64.of(USER_MASK);
@@ -92,76 +81,43 @@ public class AppCookie {
      * @throws IllegalStateException if the application has not been registered
      */
 
-    static public U64 makeCookie(int application, int user) {
+    static public U64 makeCookie(long application, long user) {
         if (!appIdMap.containsKey(application)) {
             throw new AppIDNotRegisteredException(application);
         }
-        long longApp = application;
-        long longUser = user & USER_MASK; // mask to prevent sign extend
-        return U64.of((longApp << APP_ID_SHIFT) | longUser);
+        user = user & USER_MASK; // mask to prevent sign extend
+        return U64.of((application << APP_ID_SHIFT) | user);
     }
 
     /**
-     * Extract the application id from a flow cookie. Does <em>not</em> check
-     * whether the application id is registered
+     * Extract the application id from a flow cookie. Does <em>not</em>
+     * check whether the application id is registered. The app ID is 
+     * defined by the {@link #getAppFieldMask()} bits
      * @param cookie
      * @return
      */
-    static public int extractApp(U64 cookie) {
-        return (int)((cookie.getValue() >>> APP_ID_SHIFT) & APP_ID_MASK);
+    static public long extractApp(U64 cookie) {
+        return (cookie.getValue() >>> APP_ID_SHIFT) & APP_ID_MASK;
     }
 
-    static public int extractUser(U64 cookie) {
-        return (int)(cookie.getValue() & USER_MASK);
+    /**
+     * Extract the user portion from a flow cookie, defined
+     * by the {@link #getUserFieldMask()} bits
+     * @param cookie
+     * @return
+     */
+    static public long extractUser(U64 cookie) {
+        return cookie.getValue() & USER_MASK;
     }
 
-    static public boolean isRewriteFlagSet(U64 cookie) {
-        if ((cookie.getValue() & REWRITE_MASK) !=0L)
-            return true;
-        return false;
-    }
-    static public boolean isSrcMacRewriteFlagSet(U64 cookie) {
-        if ((cookie.getValue() & (1L << (SRC_MAC_REWRITE_BIT-1))) !=0L)
-            return true;
-        return false;
-    }
-    static public boolean isDestMacRewriteFlagSet(U64 cookie) {
-        if ((cookie.getValue() & (1L << (DEST_MAC_REWRITE_BIT-1))) !=0L)
-            return true;
-        return false;
-    }
-    static public boolean isSrcIpRewriteFlagSet(U64 cookie) {
-        if ((cookie.getValue() & (1L << (SRC_IP_REWRITE_BIT-1))) !=0L)
-            return true;
-        return false;
-    }
-    static public boolean isDestIpRewriteFlagSet(U64 cookie) {
-        if ((cookie.getValue() & (1L << (DEST_IP_REWRITE_BIT-1))) !=0L)
-            return true;
-        return false;
-    }
-    static public U64 setSrcMacRewriteFlag(U64 cookie) {
-        return U64.of(cookie.getValue() | (1L << (SRC_MAC_REWRITE_BIT-1)));
-    }
-    static public U64 setDestMacRewriteFlag(U64 cookie) {
-        return U64.of(cookie.getValue() | (1L << (DEST_MAC_REWRITE_BIT-1)));
-    }
-    static public U64 setSrcIpRewriteFlag(U64 cookie) {
-        return U64.of(cookie.getValue() | (1L << (SRC_IP_REWRITE_BIT-1)));
-    }
-    static public U64 setDestIpRewriteFlag(U64 cookie) {
-        return U64.of(cookie.getValue() | (1L << (DEST_IP_REWRITE_BIT-1)));
-    }
     /**
      * A lame attempt to prevent duplicate application ID.
-     * TODO: We should expose appID->appName map
-     *       via REST API so CLI doesn't need a separate copy of the map.
      *
      * @param application
      * @param appName
      * @throws AppIDInUseException
      */
-    public static void registerApp(int application, String appName)
+    public static void registerApp(long application, String appName)
         throws AppIDException
     {
         if ((application & APP_ID_MASK) != application) {
@@ -179,7 +135,7 @@ public class AppCookie {
      * @param application
      * @return
      */
-    public static String getAppName(int application) {
+    public static String getAppName(long application) {
         return appIdMap.get(application);
     }
 }

--- a/src/main/java/net/floodlightcontroller/core/util/AppIDInUseException.java
+++ b/src/main/java/net/floodlightcontroller/core/util/AppIDInUseException.java
@@ -3,9 +3,9 @@ package net.floodlightcontroller.core.util;
 public class AppIDInUseException extends AppIDException {
     private static final long serialVersionUID = 3167241821651094997L;
 
-    public AppIDInUseException(int appId, String oldAppName,
+    public AppIDInUseException(long application, String oldAppName,
                                String newAppName) {
-        super(String.format("Tried to register application IdD %s for %s, but" +
-                "already registered for %s.", appId, oldAppName, newAppName));
+        super(String.format("Tried to register application ID %s for %s, but" +
+                "already registered for %s.", application, oldAppName, newAppName));
     }
 }

--- a/src/main/java/net/floodlightcontroller/core/util/AppIDNotRegisteredException.java
+++ b/src/main/java/net/floodlightcontroller/core/util/AppIDNotRegisteredException.java
@@ -3,7 +3,7 @@ package net.floodlightcontroller.core.util;
 public class AppIDNotRegisteredException extends AppIDException {
     private static final long serialVersionUID = -9195312786292237763L;
 
-    public AppIDNotRegisteredException(int application) {
+    public AppIDNotRegisteredException(long application) {
         super("Application Id " + application + " has not been registered");
     }
 

--- a/src/main/java/net/floodlightcontroller/firewall/Firewall.java
+++ b/src/main/java/net/floodlightcontroller/firewall/Firewall.java
@@ -66,6 +66,7 @@ import net.floodlightcontroller.routing.RoutingDecision;
 import net.floodlightcontroller.storage.IResultSet;
 import net.floodlightcontroller.storage.IStorageSourceService;
 import net.floodlightcontroller.storage.StorageException;
+import net.floodlightcontroller.util.OFMessageUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,10 +87,10 @@ IFloodlightModule {
 	static {
 		AppCookie.registerApp(APP_ID, "Firewall");
 	}
-	private static final U64 DENY_BCAST_COOKIE = AppCookie.makeCookie(APP_ID, 0xaaaaaaaa);
-	private static final U64 ALLOW_BCAST_COOKIE = AppCookie.makeCookie(APP_ID, 0x55555555);
-	private static final U64 RULE_MISS_COOKIE = AppCookie.makeCookie(APP_ID, -1);
-	static final U64 DEFAULT_COOKIE = AppCookie.makeCookie(APP_ID, 0);
+	private static final U64 DENY_BCAST_COOKIE = AppCookie.makeCookie(APP_ID, 0xaaaaaaL);
+	private static final U64 ALLOW_BCAST_COOKIE = AppCookie.makeCookie(APP_ID, 0x555555L);
+	private static final U64 RULE_MISS_COOKIE = AppCookie.makeCookie(APP_ID, 0xffffffL);
+	static final U64 DEFAULT_COOKIE = AppCookie.makeCookie(APP_ID, 0xffffffL);
 
 	// service modules needed
 	protected IFloodlightProviderService floodlightProvider;
@@ -592,7 +593,7 @@ IFloodlightModule {
 
 	public Command processPacketInMessage(IOFSwitch sw, OFPacketIn pi, IRoutingDecision decision, FloodlightContext cntx) {
 		Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
-		OFPort inPort = (pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT));
+		OFPort inPort = OFMessageUtils.getInPort(pi);
 
 		// Allowing L2 broadcast + ARP broadcast request (also deny malformed
 		// broadcasts -> L2 broadcast + L3 unicast)

--- a/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
+++ b/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
@@ -163,16 +163,13 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                 log.warn("Flowset IDs have exceeded capacity of {}. Flowset ID generator resetting back to 0", FLOWSET_MAX);
             }
             U64 id = U64.of(flowSetGenerator << FLOWSET_SHIFT);
-            log.warn("Generating flowset ID {}, shifted {}", flowSetGenerator, id.toString());
+            log.debug("Generating flowset ID {}, shifted {}", flowSetGenerator, id);
             return id;
         }
 
         private void registerFlowSetId(NodePortTuple npt, U64 flowSetId) {
             if (nptToFlowSetIds.containsKey(npt)) {
                 Set<U64> ids = nptToFlowSetIds.get(npt);
-                if (ids == null) {
-                    ids = new HashSet<U64>();
-                }
                 ids.add(flowSetId);
             } else {
                 Set<U64> ids = new HashSet<U64>();
@@ -182,9 +179,6 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
 
             if (flowSetIdToNpts.containsKey(flowSetId)) {
                 Set<NodePortTuple> npts = flowSetIdToNpts.get(flowSetId);
-                if (npts == null) {
-                    npts = new HashSet<NodePortTuple>();
-                }
                 npts.add(npt);
             } else {
                 Set<NodePortTuple> npts = new HashSet<NodePortTuple>();
@@ -944,8 +938,8 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                                         .setOutPort(u.getSrcPort())
                                         .build());
                                 messageDamper.write(srcSw, msgs);
-                                log.warn("Removing flows to/from DPID={}, port={}", u.getSrc(), u.getSrcPort());
-                                log.warn("Cookie/mask {}/{}", cookie, cookieMask);
+                                log.debug("src: Removing flows to/from DPID={}, port={}", u.getSrc(), u.getSrcPort());
+                                log.debug("src: Cookie/mask {}/{}", cookie, cookieMask);
                                 
                                 /* 
                                  * Now, for each ID on this particular failed link, remove
@@ -971,8 +965,8 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                                                     .setOutPort(npt.getPortId())
                                                     .build());
                                             messageDamper.write(sw, msgs);
-                                            log.warn("Removing flows to/from DPID={}, port={}", npt.getNodeId(), npt.getPortId());
-                                            log.warn("Cookie/mask {}/{}", cookie, cookieMask);
+                                            log.debug("src: Removing same-cookie flows to/from DPID={}, port={}", npt.getNodeId(), npt.getPortId());
+                                            log.debug("src: Cookie/mask {}/{}", cookie, cookieMask);
                                         }
                                     }
                                 }
@@ -989,7 +983,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                     IOFSwitch dstSw = switchService.getSwitch(u.getDst());
                     if (dstSw != null) {
                         Set<U64> ids = flowSetIdRegistry.getFlowSetIds(
-                                new NodePortTuple(u.getSrc(), u.getSrcPort()));
+                                new NodePortTuple(u.getDst(), u.getDstPort()));
                         if (ids != null) {
                             for (U64 id : ids) {
                                 U64 cookie = id.or(DEFAULT_FORWARDING_COOKIE);
@@ -1010,8 +1004,8 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                                         .setOutPort(u.getDstPort())
                                         .build());
                                 messageDamper.write(dstSw, msgs);
-                                log.warn("Removing flows to/from DPID={}, port={}", u.getDst(), u.getDstPort());
-                                log.warn("Cookie/mask {}/{}", cookie, cookieMask);
+                                log.debug("dst: Removing flows to/from DPID={}, port={}", u.getDst(), u.getDstPort());
+                                log.debug("dst: Cookie/mask {}/{}", cookie, cookieMask);
 
                                 /* 
                                  * Now, for each ID on this particular failed link, remove
@@ -1037,8 +1031,8 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                                                     .setOutPort(npt.getPortId())
                                                     .build());
                                             messageDamper.write(sw, msgs);
-                                            log.warn("Removing flows to/from DPID={}, port={}", npt.getNodeId(), npt.getPortId());
-                                            log.warn("Cookie/mask {}/{}", cookie, cookieMask);
+                                            log.debug("dst: Removing same-cookie flows to/from DPID={}, port={}", npt.getNodeId(), npt.getPortId());
+                                            log.debug("dst: Cookie/mask {}/{}", cookie, cookieMask);
                                         }
                                     }
                                 }

--- a/src/test/java/net/floodlightcontroller/core/util/AppCookieTest.java
+++ b/src/test/java/net/floodlightcontroller/core/util/AppCookieTest.java
@@ -41,10 +41,10 @@ public class AppCookieTest {
 
     @Test
     public void testAppCookie(){
-        int user = 0xF123F123; // MSB set
-        int user2 = 0x42;      // MSB cleared
-        U64 expectedCookie11 =  U64.of(0xF4200000F123F123L); // app1, user1
-        U64 expectedCookie21 =  U64.of(0x74300000F123F123L); // app2, user1
+        long user = 0xF123F123F1234L; // MSB set
+        long user2 = 0x42L;      // MSB cleared
+        U64 expectedCookie11 =  U64.of(0xF42F123F123F1234L); // app1, user1
+        U64 expectedCookie21 =  U64.of(0x743F123F123F1234L); // app2, user1
         U64 expectedCookie12 =  U64.of(0xF420000000000042L); // app1, user2
         U64 expectedCookie22 =  U64.of(0x7430000000000042L); // app2, user2
         String name = "FooBar";

--- a/src/test/java/net/floodlightcontroller/firewall/FirewallTest.java
+++ b/src/test/java/net/floodlightcontroller/firewall/FirewallTest.java
@@ -98,9 +98,9 @@ public class FirewallTest extends FloodlightTestCase {
     static {
                 AppCookie.registerApp(APP_ID, "Firewall");
         }
-    private static final U64 DENY_BCAST_COOKIE = AppCookie.makeCookie(APP_ID, 0xaaaaaaaa);
-    private static final U64 ALLOW_BCAST_COOKIE = AppCookie.makeCookie(APP_ID, 0x55555555);
-    private static final U64 RULE_MISS_COOKIE = AppCookie.makeCookie(APP_ID, -1);
+    private static final U64 DENY_BCAST_COOKIE = AppCookie.makeCookie(APP_ID, 0xaaaaaaL);
+    private static final U64 ALLOW_BCAST_COOKIE = AppCookie.makeCookie(APP_ID, 0x555555L);
+    private static final U64 RULE_MISS_COOKIE = AppCookie.makeCookie(APP_ID, 0xffffffL);
 
 
     @Override
@@ -684,10 +684,11 @@ public class FirewallTest extends FloodlightTestCase {
     @Test
     public void cookieAddedSuccessfully() {
     	assertEquals("DENY_BCAST_COOKIE app_id is not correct", APP_ID, AppCookie.extractApp(DENY_BCAST_COOKIE));
-    	assertEquals("DENY_BCAST_COOKIE user_id is not correct", 0xaaaaaaaa, AppCookie.extractUser(DENY_BCAST_COOKIE));
+    	
+    	assertEquals("DENY_BCAST_COOKIE user_id is not correct", 0xaaaaaaL, AppCookie.extractUser(DENY_BCAST_COOKIE));
     	assertEquals("ALLOW_BCAST_COOKIE app_id is not correct", APP_ID, AppCookie.extractApp(DENY_BCAST_COOKIE));
-    	assertEquals("ALLOW_BCAST_COOKIE user_id is not correct", 0x55555555, AppCookie.extractUser(ALLOW_BCAST_COOKIE));
+    	assertEquals("ALLOW_BCAST_COOKIE user_id is not correct", 0x555555L, AppCookie.extractUser(ALLOW_BCAST_COOKIE));
       	assertEquals("RULE_MISS_COOKIE app_id is not correct", APP_ID, AppCookie.extractApp(DENY_BCAST_COOKIE));
-      	assertEquals("RULE_MISS_COOKIE user_id is not correct", -1, AppCookie.extractUser(RULE_MISS_COOKIE));
+      	assertEquals("RULE_MISS_COOKIE user_id is not correct", 0xffffffL, AppCookie.extractUser(RULE_MISS_COOKIE));
     }
 }


### PR DESCRIPTION
When a link or port fails, we should remove the flows to/from the port(s). This works great in some simple topologies, but in a general case, the flows on the "source" side of the link all the way to the source device will remain installed until either they timeout (a few seconds idle) or the source device stops generating traffic. The flows on the "destination" side of the link all the way to the destination device will time out after the idle timeout interval. 

So, the problem is primarily on the source side, which might result in flows that are never removed. This means that if there are multiple paths available in the topology and the chosen link fails, the packets will never be able to be rerouted to another available link until the source device ceases all traffic, the flows expire, and then starts producing traffic again.

Obviously, this is not ideal, is confusing, and shouldn't be necessary. The forwarding module will now track "flowsets", which is simply the flows installed along the path from a source device to a destination device. Tracking is done by assigning a unique flowset ID within the cookie of the flows of the flowset (i.e. a given flowset will have the same unique cookie in each flow).

When forwarding installs a flowset, it will track where the flowset ID has been installed in the network per switch and switch-port (i.e. NodePortTuple). If and when a link or port fails, the failure can be identified by a NodePortTuple. All the flowset IDs installed on this NodePortTuple will be removed. Furthermore, the flowset IDs on the failed NodePortTuple will also be removed from all other NodePortTuples on which they are installed. This, in effect, removes the flows along the original path, allowing a packet-in message from the source device, a new path to be computed, and a new flowset to be installed and recorded.

Limitation: at present, forwarding does not set the SEND_FLOW_REM flag by default (it's an option in floodlightdefault.properties). Thus, there isn't a way to remove recorded flowset IDs when their flows are removed in the network (due to a timeout or explicit removal). The only way the recorded flowset IDs are removed is when a link or port fails, at which point the aforementioned procedure will occur. Thus, the recorded flowset IDs can grow arbitrarily large, potentially eating up the JVM's available memory. Since the size of the data/objects recorded is minimal, this is a remote possibility, yet still *a* possibility.