### PR TITLE
fix concurrency issue in Statistics

### DIFF
--- a/src/main/java/net/floodlightcontroller/statistics/web/BandwidthResource.java
+++ b/src/main/java/net/floodlightcontroller/statistics/web/BandwidthResource.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.internal.IOFSwitchService;
 import net.floodlightcontroller.statistics.IStatisticsService;
 import net.floodlightcontroller.statistics.SwitchPortBandwidth;
@@ -66,7 +67,9 @@ public class BandwidthResource extends ServerResource {
                 spbs = new HashSet<SwitchPortBandwidth>(Collections.singleton(statisticsService.getBandwidthConsumption(dpid, port)));
             } else {
                 spbs = new HashSet<SwitchPortBandwidth>();
-                for (OFPortDesc pd : switchService.getSwitch(dpid).getPorts()) { /* do specific DPID; do all ports */
+                //fix concurrency scenario
+                IOFSwitch sw = switchService.getSwitch(dpid);
+                for (OFPortDesc pd : sw.getPorts()) { /* do specific DPID; do all ports */
                     SwitchPortBandwidth spb = statisticsService.getBandwidthConsumption(dpid, pd.getPortNo());
                     if (spb != null) {
                         spbs.add(spb);

--- a/src/main/java/net/floodlightcontroller/statistics/web/BandwidthResource.java
+++ b/src/main/java/net/floodlightcontroller/statistics/web/BandwidthResource.java
@@ -69,6 +69,9 @@ public class BandwidthResource extends ServerResource {
                 spbs = new HashSet<SwitchPortBandwidth>();
                 //fix concurrency scenario
                 IOFSwitch sw = switchService.getSwitch(dpid);
+                if (sw == null){
+                		return Collections.singletonMap("ERROR", "Switch was not online: " + dpid);
+                }
                 for (OFPortDesc pd : sw.getPorts()) { /* do specific DPID; do all ports */
                     SwitchPortBandwidth spb = statisticsService.getBandwidthConsumption(dpid, pd.getPortNo());
                     if (spb != null) {

--- a/src/main/java/net/floodlightcontroller/statistics/web/BandwidthResource.java
+++ b/src/main/java/net/floodlightcontroller/statistics/web/BandwidthResource.java
@@ -70,7 +70,7 @@ public class BandwidthResource extends ServerResource {
                 //fix concurrency scenario
                 IOFSwitch sw = switchService.getSwitch(dpid);
                 if (sw == null){
-                		return Collections.singletonMap("ERROR", "Switch was not online: " + dpid);
+                	return Collections.singletonMap("ERROR", "Switch was not online: " + dpid);
                 }
                 for (OFPortDesc pd : sw.getPorts()) { /* do specific DPID; do all ports */
                     SwitchPortBandwidth spb = statisticsService.getBandwidthConsumption(dpid, pd.getPortNo());

--- a/src/main/java/net/floodlightcontroller/statistics/web/BandwidthResource.java
+++ b/src/main/java/net/floodlightcontroller/statistics/web/BandwidthResource.java
@@ -70,7 +70,7 @@ public class BandwidthResource extends ServerResource {
                 //fix concurrency scenario
                 IOFSwitch sw = switchService.getSwitch(dpid);
                 if (sw == null){
-                	return Collections.singletonMap("ERROR", "Switch was not online: " + dpid);
+                    return Collections.singletonMap("ERROR", "Switch was not online: " + dpid);
                 }
                 for (OFPortDesc pd : sw.getPorts()) { /* do specific DPID; do all ports */
                     SwitchPortBandwidth spb = statisticsService.getBandwidthConsumption(dpid, pd.getPortNo());


### PR DESCRIPTION
Check the value of switchService.getSwitch() to avoid NullPointerException in the case of concurrency switch leave.