### PR TITLE
Extract possible VLAN tag from packet-in's match

### DIFF
--- a/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
+++ b/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
@@ -374,7 +374,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
 
     protected void doDropFlow(IOFSwitch sw, OFPacketIn pi, IRoutingDecision decision, FloodlightContext cntx) {
         OFPort inPort = OFMessageUtils.getInPort(pi);
-        Match m = createMatchFromPacket(sw, inPort, cntx);
+        Match m = createMatchFromPacket(sw, inPort, pi, cntx);
         OFFlowMod.Builder fmb = sw.getOFFactory().buildFlowAdd();
         List<OFAction> actions = new ArrayList<OFAction>(); // set no action to drop
         U64 flowSetId = flowSetIdRegistry.generateFlowSetId();
@@ -485,7 +485,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                 dstAp.getNodeId(),
                 dstAp.getPortId());
 
-        Match m = createMatchFromPacket(sw, srcPort, cntx);
+        Match m = createMatchFromPacket(sw, srcPort, pi, cntx);
 
         if (path != null) {
             if (log.isDebugEnabled()) {
@@ -536,11 +536,14 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
      * @param cntx, the current context which contains the deserialized packet
      * @return a composed Match object based on the provided information
      */
-    protected Match createMatchFromPacket(IOFSwitch sw, OFPort inPort, FloodlightContext cntx) {
+    protected Match createMatchFromPacket(IOFSwitch sw, OFPort inPort, OFPacketIn pi, FloodlightContext cntx) {
         // The packet in match will only contain the port number.
         // We need to add in specifics for the hosts we're routing between.
         Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
-        VlanVid vlan = VlanVid.ofVlan(eth.getVlanID());
+
+        VlanVid vlan = pi.getMatch().get(MatchField.VLAN_VID) == null ? 
+                VlanVid.ofVlan(eth.getVlanID()) : /* VLAN in packet or untagged */
+            pi.getMatch().get(MatchField.VLAN_VID).getVlanVid(); /* VLAN may have been popped by switch */
         MacAddress srcMac = eth.getSourceMACAddress();
         MacAddress dstMac = eth.getDestinationMACAddress();
 


### PR DESCRIPTION
Allow retrieval of VLAN tag from packet-in match. The VLAN tag might be here if the switch popped the VLAN tag from the packet itself prior to encapsulating it in the packet-in message.