### PR TITLE
add tcp_flags matching to forwarding module

### DIFF
--- a/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
+++ b/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
@@ -87,6 +87,7 @@ import org.projectfloodlight.openflow.types.OFGroup;
 import org.projectfloodlight.openflow.types.OFPort;
 import org.projectfloodlight.openflow.types.OFVlanVidMatch;
 import org.projectfloodlight.openflow.types.TableId;
+import org.projectfloodlight.openflow.types.U16;
 import org.projectfloodlight.openflow.types.U64;
 import org.projectfloodlight.openflow.types.VlanVid;
 import org.python.google.common.collect.ImmutableList;
@@ -607,6 +608,9 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                     if (FLOWMOD_DEFAULT_MATCH_TRANSPORT_DST) {
                         mb.setExact(MatchField.TCP_DST, tcp.getDestinationPort());
                     }
+                    if(FLOWMOD_DEFAULT_MATCH_TCP_FLAG){
+                        mb.setExact(MatchField.OVS_TCP_FLAGS, U16.of(tcp.getFlags()));
+                    }
                 } else if (ip.getProtocol().equals(IpProtocol.UDP)) {
                     UDP udp = (UDP) ip.getPayload();
                     mb.setExact(MatchField.IP_PROTO, IpProtocol.UDP);
@@ -652,6 +656,9 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                     }
                     if (FLOWMOD_DEFAULT_MATCH_TRANSPORT_DST) {
                         mb.setExact(MatchField.TCP_DST, tcp.getDestinationPort());
+                    }
+                    if(FLOWMOD_DEFAULT_MATCH_TCP_FLAG){
+                        mb.setExact(MatchField.OVS_TCP_FLAGS, U16.of(tcp.getFlags()));
                     }
                 } else if (ip.getNextHeader().equals(IpProtocol.UDP)) {
                     UDP udp = (UDP) ip.getPayload();
@@ -789,7 +796,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
             tmp = tmp.toLowerCase();
             if (!tmp.contains("in-port") && !tmp.contains("vlan") 
                     && !tmp.contains("mac") && !tmp.contains("ip") 
-                    && !tmp.contains("transport")) {
+                    && !tmp.contains("transport") && !tmp.contains("flag")) {
                 /* leave the default configuration -- blank or invalid 'match' value */
             } else {
                 FLOWMOD_DEFAULT_MATCH_IN_PORT = tmp.contains("in-port") ? true : false;
@@ -797,13 +804,15 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                 FLOWMOD_DEFAULT_MATCH_MAC = tmp.contains("mac") ? true : false;
                 FLOWMOD_DEFAULT_MATCH_IP = tmp.contains("ip") ? true : false;
                 FLOWMOD_DEFAULT_MATCH_TRANSPORT = tmp.contains("transport") ? true : false;
+                FLOWMOD_DEFAULT_MATCH_TCP_FLAG = tmp.contains("flag") ? true : false;
             }
         }
         log.info("Default flow matches set to: IN_PORT=" + FLOWMOD_DEFAULT_MATCH_IN_PORT
                 + ", VLAN=" + FLOWMOD_DEFAULT_MATCH_VLAN
                 + ", MAC=" + FLOWMOD_DEFAULT_MATCH_MAC
                 + ", IP=" + FLOWMOD_DEFAULT_MATCH_IP
-                + ", TPPT=" + FLOWMOD_DEFAULT_MATCH_TRANSPORT);
+                + ", TPPT=" + FLOWMOD_DEFAULT_MATCH_TRANSPORT)
+                + ", FLAG=" + FLOWMOD_DEFAULT_MATCH_TCP_FLAG);
 
         tmp = configParameters.get("detailed-match");
         if (tmp != null) {

--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -94,6 +94,7 @@ public abstract class ForwardingBase implements IOFMessageListener {
     protected static boolean FLOWMOD_DEFAULT_MATCH_IP_DST = true;
     protected static boolean FLOWMOD_DEFAULT_MATCH_TRANSPORT_SRC = true;
     protected static boolean FLOWMOD_DEFAULT_MATCH_TRANSPORT_DST = true;
+    protected static boolean FLOWMOD_DEFAULT_MATCH_TCP_FLAG = true;
 
     protected static boolean FLOOD_ALL_ARP_PACKETS = false;
 

--- a/src/main/java/net/floodlightcontroller/util/MatchUtils.java
+++ b/src/main/java/net/floodlightcontroller/util/MatchUtils.java
@@ -136,6 +136,7 @@ public class MatchUtils {
 	public static final String STR_PBB_UCA = "pbb_uca";
 
 	public static final String STR_TCP_FLAGS = "tcp_flags";
+    public static final String STR_OVS_TCP_FLAGS = "ovs_tcp_flags";//experimenter OXM before floodlight completely support of1.5
 	public static final String STR_ACTSET_OUTPUT = "actset_output";
 	public static final String STR_PACKET_TYPE = "packet_type";
 
@@ -361,6 +362,9 @@ public class MatchUtils {
 		case TCP_FLAGS:
 			key = STR_TCP_FLAGS;
 			break;
+        case OVS_TCP_FLAGS:
+            key = STR_OVS_TCP_FLAGS;
+            break;
 		case ACTSET_OUTPUT:
 			key = STR_ACTSET_OUTPUT;
 			break;
@@ -1015,6 +1019,14 @@ public class MatchUtils {
 							U16.of(ParseUtils.parseHexOrDecInt(dataMask[1])));
 				}
 				break;
+            case STR_OVS_TCP_FLAGS:
+                if (dataMask.length == 1) {
+                    mb.setExact(MatchField.OVS_TCP_FLAGS, U16.of(ParseUtils.parseHexOrDecInt(dataMask[0])));
+                } else {
+                    mb.setMasked(MatchField.OVS_TCP_FLAGS, U16.of(ParseUtils.parseHexOrDecInt(dataMask[0])), 
+                            U16.of(ParseUtils.parseHexOrDecInt(dataMask[1])));
+                }
+                break;
 			case STR_ACTSET_OUTPUT: 
 				/* TODO when loxi bug fixed if (!mb.supports(MatchField.ACTSET_OUTPUT)) {
 					log.warn("Match {} unsupported in OpenFlow version {}", MatchField.ACTSET_OUTPUT, ofVersion);

--- a/src/main/resources/floodlightdefault.properties
+++ b/src/main/resources/floodlightdefault.properties
@@ -29,7 +29,7 @@ org.sdnplatform.sync.internal.SyncManager.nodes=[\
 {"nodeId": 1, "domainId": 1, "hostname": "192.168.1.100", "port": 6642},\
 {"nodeId": 2, "domainId": 1, "hostname": "192.168.1.100", "port": 6643}\
 ]
-net.floodlightcontroller.forwarding.Forwarding.match=in-port, vlan, mac, ip, transport
+net.floodlightcontroller.forwarding.Forwarding.match=in-port, vlan, mac, ip, transport, flag
 net.floodlightcontroller.forwarding.Forwarding.detailed-match=src-mac, dst-mac, src-ip, dst-ip, src-transport, dst-transport
 net.floodlightcontroller.forwarding.Forwarding.flood-arp=NO
 net.floodlightcontroller.forwarding.Forwarding.idle-timeout=5


### PR DESCRIPTION
add tcp_flags matching to forwarding module based on work on loxigen
as discussed at https://groups.google.com/a/openflowhub.org/forum/#!topic/floodlight-dev/uSnA0IgkBJs

users can choose to match on tcp_flags or not by configuring net.floodlightcontroller.forwarding.Forwarding.match of floodlightdefault.properties (there is a flag option added)