### PR TITLE
Improve getPath() functions in IRoutingService

### DIFF
--- a/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
+++ b/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
@@ -487,7 +487,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
 
         Match m = createMatchFromPacket(sw, srcPort, pi, cntx);
 
-        if (path != null) {
+        if (! path.getPath().isEmpty()) {
             if (log.isDebugEnabled()) {
                 log.debug("pushRoute inPort={} route={} " +
                         "destination={}:{}",
@@ -500,29 +500,15 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
             pushRoute(path, m, pi, sw.getId(), cookie, 
                     cntx, requestFlowRemovedNotifn,
                     OFFlowModCommand.ADD);	
-        } else {
-            /* Route traverses no links --> src/dst devices on same switch */
-            log.debug("Could not compute route. Devices should be on same switch src={} and dst={}", srcDevice, dstDevice);
-            path = new Path(srcDevice.getAttachmentPoints()[0].getNodeId(), dstDevice.getAttachmentPoints()[0].getNodeId());
-            List<NodePortTuple> npts = new ArrayList<NodePortTuple>(2);
-            npts.add(new NodePortTuple(srcDevice.getAttachmentPoints()[0].getNodeId(),
-                    srcDevice.getAttachmentPoints()[0].getPortId()));
-            npts.add(new NodePortTuple(dstDevice.getAttachmentPoints()[0].getNodeId(),
-                    dstDevice.getAttachmentPoints()[0].getPortId()));
-            path.setPath(npts);
-            pushRoute(path, m, pi, sw.getId(), cookie,
-                    cntx, requestFlowRemovedNotifn,
-                    OFFlowModCommand.ADD);
-        }
-
-        /* 
-         * Register this flowset with ingress and egress ports for link down
-         * flow removal. This is done after we push the path as it is blocking.
-         */
-        for (NodePortTuple npt : path.getPath()) {
-            flowSetIdRegistry.registerFlowSetId(npt, flowSetId);
-        }
-
+            
+            /* 
+             * Register this flowset with ingress and egress ports for link down
+             * flow removal. This is done after we push the path as it is blocking.
+             */
+            for (NodePortTuple npt : path.getPath()) {
+                flowSetIdRegistry.registerFlowSetId(npt, flowSetId);
+            }
+        } /* else no path was found */
     }
 
     /**

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
@@ -466,11 +466,11 @@ public class LoadBalancer implements IFloodlightModule,
                     // in: match src client (ip, port), rewrite dest from vip ip/port to member ip/port, forward
                     // out: match dest client (ip, port), rewrite src from member ip/port to vip ip/port, forward
                     
-                    if (routeIn != null) {
+                    if (! routeIn.getPath().isEmpty()) {
                         pushStaticVipRoute(true, routeIn, client, member, sw);
                     }
                     
-                    if (routeOut != null) {
+                    if (! routeOut.getPath().isEmpty()) {
                         pushStaticVipRoute(false, routeOut, client, member, sw);
                     }
 

--- a/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
@@ -1191,25 +1191,16 @@ public class TopologyInstance {
      */
     public Path getPath(DatapathId srcId, OFPort srcPort,
             DatapathId dstId, OFPort dstPort) {
-        // Return null if the route source and destination are the
-        // same switch ports.
-        if (srcId.equals(dstId) && srcPort.equals(dstPort)) {
-            return null;
-        }
-
-        List<NodePortTuple> nptList;
-        NodePortTuple npt;
         Path r = getPath(srcId, dstId);
-        if (r == null && !srcId.equals(dstId)) {
-            return null;
+        
+        /* Path cannot be null, but empty b/t 2 diff DPIDs -> not found */
+        if (! srcId.equals(dstId) && r.getPath().isEmpty()) {
+            return r;
         }
 
-        if (r != null) {
-            nptList= new ArrayList<NodePortTuple>(r.getPath());
-        } else {
-            nptList = new ArrayList<NodePortTuple>();
-        }
-        npt = new NodePortTuple(srcId, srcPort);
+        /* Else, path is valid (len=0) on the same DPID or (len>0) diff DPIDs */
+        List<NodePortTuple> nptList = new ArrayList<NodePortTuple>(r.getPath());
+        NodePortTuple npt = new NodePortTuple(srcId, srcPort);
         nptList.add(0, npt); // add src port to the front
         npt = new NodePortTuple(dstId, dstPort);
         nptList.add(npt); // add dst port to the end
@@ -1226,12 +1217,14 @@ public class TopologyInstance {
      * @param dstId
      * @return
      */
-
     public Path getPath(DatapathId srcId, DatapathId dstId) {
-        // Return null route if srcId equals dstId
-        if (srcId.equals(dstId)) return null;
-
         PathId id = new PathId(srcId, dstId);
+
+        /* Return empty route if srcId equals dstId */
+        if (srcId.equals(dstId)) {
+            return new Path(id, ImmutableList.of());
+        }
+
         Path result = null;
 
         try {
@@ -1245,7 +1238,7 @@ public class TopologyInstance {
         if (log.isTraceEnabled()) {
             log.trace("getPath: {} -> {}", id, result);
         }
-        return result == null ? new Path(id, ImmutableList.of()) : result; /* return empty route instead of null */
+        return result == null ? new Path(id, ImmutableList.of()) : result;
     }
 
     //


### PR DESCRIPTION
We will indicate a path was not found in a uniform fashion through an empty path instead of a null path. 

If getPath(src, dst) is invoked, an empty path will be returned if src == dst or if a path was not found in the case src != dst. It is up to the caller to differentiate between these two cases by comparing src and dst if necessary.

If getPath (src, srcPt, dst, dstPt) is invoked, an empty path will be returned if src == dst and srcPt == dstPt. If src == dst and srcPt != dstPt, the endpoints are on the same switch, and a path of length 2 will be returned. An empty path will also be returned if a path was not found in the case src != dst. It is up to the caller to differentiate between these cases by comparing src and dst if necessary.