### PR TITLE
Fixed ConcurrentModificationException error in StaticEntryPusher.java

### DIFF
--- a/src/main/java/net/floodlightcontroller/staticentry/StaticEntryPusher.java
+++ b/src/main/java/net/floodlightcontroller/staticentry/StaticEntryPusher.java
@@ -312,7 +312,7 @@ implements IOFSwitchListener, IFloodlightModule, IStaticEntryPusherService, ISto
 			} /* else use default of flow */
 
 			if (!entries.containsKey(switchName)) {
-				entries.put(switchName, new HashMap<String, OFMessage>());
+				entries.put(switchName, new ConcurrentHashMap<String, OFMessage>());
 			}
 
 			/* get the correct builder for the OF version supported by the switch */


### PR DESCRIPTION
There was a ConcurrentModificationException error occurring when the LoadBalancer module was used with httperf (relatively high rates) and python's SimpleHTTPServer. 

After modifying HashMap to ConcurrentHashMap as can be seen below, no such errors occurred. 