### PR TITLE
LoadBalancer - LBStats implementation through FlowStats message

### DIFF
--- a/src/main/java/net/floodlightcontroller/loadbalancer/ILoadBalancerService.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/ILoadBalancerService.java
@@ -170,5 +170,12 @@ public interface ILoadBalancerService extends IFloodlightService {
      * @return int: operation status
      */
 	public int setPriorityToMember(String poolId, String memberId);
+	
+	 /**
+     * Get statistics of an existing pool.
+     * @param String poolId 
+     * @return int[]: bytesIn, bytesOut, activeConnections , totalConnections 
+     */
+    public LBStats getPoolStats(String poolId);
     
 }

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Random;
+import java.util.Set;
 
 import org.projectfloodlight.openflow.types.U64;
 
@@ -59,6 +60,8 @@ public class LBPool {
 	protected String vipId;
 
 	protected int previousMemberIndex;
+	
+	protected LBStats poolStats;
 
 	public LBPool() {
 		id = String.valueOf((int) (Math.random()*10000));
@@ -72,6 +75,28 @@ public class LBPool {
 		adminState = 0;
 		status = 0;
 		previousMemberIndex = -1;
+		
+		poolStats = new LBStats();
+	}
+	
+	
+	public void setPoolStatistics(Set<Long> bytesIn,Set<Long> bytesOut,int activeFlows){
+		if(!bytesIn.isEmpty() && !bytesOut.isEmpty()){
+			long sumIn = 0;
+			long sumOut = 0; 
+			for(Long bytes: bytesIn){
+				sumIn += bytes;
+			}
+			poolStats.bytesIn = sumIn; 
+			
+			for(Long bytes: bytesOut){
+				sumOut += bytes;
+			}
+			poolStats.bytesOut = sumOut;
+
+			poolStats.activeFlows = activeFlows;
+			log.info("IN: " + sumIn + "OUT: " + sumOut);
+		}
 	}
 
 	public String pickMember(IPClient client, HashMap<String,U64> membersBandwidth,HashMap<String,Short> membersWeight) {

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
@@ -20,6 +20,7 @@ package net.floodlightcontroller.loadbalancer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Random;
 
 import org.projectfloodlight.openflow.types.U64;
@@ -50,6 +51,7 @@ public class LBPool {
 	protected byte protocol;
 	protected ArrayList<String> members;
 	protected ArrayList<String> monitors;
+	protected ArrayList<String> prevPicked;
 	protected short adminState;
 	protected short status;
 	protected final static short ROUND_ROBIN = 1;
@@ -59,7 +61,7 @@ public class LBPool {
 	protected String vipId;
 
 	protected int previousMemberIndex;
-	
+
 	protected LBStats poolStats;
 
 	public LBPool() {
@@ -69,26 +71,27 @@ public class LBPool {
 		netId = null;
 		lbMethod = 0;
 		protocol = 0;
+		prevPicked = new ArrayList<String>();
 		members = new ArrayList<String>();
 		monitors = new ArrayList<String>();
 		adminState = 0;
 		status = 0;
 		previousMemberIndex = -1;
-		
+
 		poolStats = new LBStats();
 	}
-	
-	
+
+
 	public void setPoolStatistics(ArrayList<Long> bytesIn,ArrayList<Long> bytesOut,int activeFlows){
 		if(!bytesIn.isEmpty() && !bytesOut.isEmpty()){
 			long sumIn = 0;
 			long sumOut = 0; 
-			
+
 			for(Long bytes: bytesIn){
 				sumIn += bytes;
 			}
 			poolStats.bytesIn = sumIn; 
-			
+
 			for(Long bytes: bytesOut){
 				sumOut += bytes;
 			}
@@ -112,13 +115,46 @@ public class LBPool {
 				}
 				// return the member which has the minimum bandwidth usage, out of this pool members
 				if(!poolMembersId.isEmpty()){
-					ArrayList<U64> bandwidthValues = new ArrayList<U64>();
+					ArrayList<U64> bandwidthValues = new ArrayList<U64>();	
+					ArrayList<String> membersWithMin = new ArrayList<String>();
+					Collections.sort(poolMembersId);
 
 					for(int j=0;j<poolMembersId.size();j++){
 						bandwidthValues.add(membersBandwidth.get(poolMembersId.get(j)));
 					}
-					log.debug("Member picked using LB statistics: {}", poolMembersId.get(bandwidthValues.indexOf(Collections.min(bandwidthValues))));
-					return poolMembersId.get(bandwidthValues.indexOf(Collections.min(bandwidthValues)));
+					U64 minBW = Collections.min(bandwidthValues);
+					String memberToPick = poolMembersId.get(bandwidthValues.indexOf(minBW));
+
+					for(Integer i=0;i<bandwidthValues.size();i++){
+						if(bandwidthValues.get(i).equals(minBW)){
+							membersWithMin.add(poolMembersId.get(i));
+						}
+					}
+					// size of the prev list is half of the number of available members
+					int sizeOfPrevPicked = bandwidthValues.size()/2;
+
+					// Remove previously picked members from being eligible for being picked now
+					for (Iterator<String> it = membersWithMin.iterator(); it.hasNext();){
+						String memberMin = it.next();
+						if(prevPicked.contains(memberMin)){
+							it.remove();
+						}
+					}
+					// Keep the previously picked list to a size based on the members of the pool
+					if(prevPicked.size() > sizeOfPrevPicked){					    
+						prevPicked.remove(prevPicked.size()-1);
+					}
+
+					// If there is only one member with min BW value and membersWithMin is empty
+					if(membersWithMin.isEmpty()){
+						memberToPick = prevPicked.get(prevPicked.size()-1); // means that the min member has been prevs picked
+					}else{
+						memberToPick = membersWithMin.get(0);
+					}
+
+					prevPicked.add(0, memberToPick); //set the first memberId of prevPicked to be the last member picked
+					log.debug("Member picked using Statistics: {}",memberToPick);
+					return memberToPick;
 				}
 				return null;
 			} else if(lbMethod == WEIGHTED_RR && !membersWeight.isEmpty()){

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Random;
-import java.util.Set;
 
 import org.projectfloodlight.openflow.types.U64;
 
@@ -80,7 +79,7 @@ public class LBPool {
 	}
 	
 	
-	public void setPoolStatistics(Set<Long> bytesIn,Set<Long> bytesOut,int activeFlows){
+	public void setPoolStatistics(ArrayList<Long> bytesIn,ArrayList<Long> bytesOut,int activeFlows){
 		if(!bytesIn.isEmpty() && !bytesOut.isEmpty()){
 			long sumIn = 0;
 			long sumOut = 0; 
@@ -95,7 +94,7 @@ public class LBPool {
 			poolStats.bytesOut = sumOut;
 
 			poolStats.activeFlows = activeFlows;
-			log.info("IN: " + sumIn + "OUT: " + sumOut);
+			log.info("IN: " + sumIn + " OUT: " + sumOut); // !!
 		}
 	}
 

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LBPool.java
@@ -83,6 +83,7 @@ public class LBPool {
 		if(!bytesIn.isEmpty() && !bytesOut.isEmpty()){
 			long sumIn = 0;
 			long sumOut = 0; 
+			
 			for(Long bytes: bytesIn){
 				sumIn += bytes;
 			}
@@ -92,9 +93,7 @@ public class LBPool {
 				sumOut += bytes;
 			}
 			poolStats.bytesOut = sumOut;
-
 			poolStats.activeFlows = activeFlows;
-			log.info("IN: " + sumIn + " OUT: " + sumOut); // !!
 		}
 	}
 

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LBStats.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LBStats.java
@@ -16,6 +16,8 @@
 
 package net.floodlightcontroller.loadbalancer;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 /**
  * Data structure for Load Balancer based on
  * Quantum proposal http://wiki.openstack.org/LBaaS/CoreResourceModel/proposal 
@@ -23,16 +25,54 @@ package net.floodlightcontroller.loadbalancer;
  * @author KC Wang
  */
 
+@JsonSerialize(using=LBStatsSerializer.class)
 public class LBStats {
-    protected int bytesIn;
-    protected int bytesOut;
-    protected int activeConnections;
-    protected int totalConnections;
+    protected long bytesIn;
+    protected long bytesOut;
+	protected int activeFlows;
+    protected int totalFlows;
     
     public LBStats() {
         bytesIn = 0;
         bytesOut = 0;
-        activeConnections = 0;
-        totalConnections = 0;
+        activeFlows = 0;
+        totalFlows = 0;
     }
+    
+    public int getActiveFlows() {
+		return activeFlows;
+	}
+
+	public void setActiveFlows(int activeFlows) {
+		this.activeFlows = activeFlows;
+	}
+
+	public int getTotalFlows() {
+		return totalFlows;
+	}
+
+	public void setTotalFlows(int totalFlows) {
+		this.totalFlows = totalFlows;
+	}
+
+	public LBStats getStats(){
+		return this;
+	}
+    
+    public long getBytesIn() {
+		return bytesIn;
+	}
+
+	public void setBytesIn(int bytesIn) {
+		this.bytesIn = bytesIn;
+	}
+
+	public long getBytesOut() {
+		return bytesOut;
+	}
+
+	public void setBytesOut(int bytesOut) {
+		this.bytesOut = bytesOut;
+	}
+
 }

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LBStatsSerializer.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LBStatsSerializer.java
@@ -1,0 +1,26 @@
+package net.floodlightcontroller.loadbalancer;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class LBStatsSerializer extends JsonSerializer<LBStats>{
+
+	@Override
+	public void serialize(LBStats poolStats, JsonGenerator jGen,
+			SerializerProvider serializer) throws IOException,
+	JsonProcessingException {
+		jGen.writeStartObject();
+
+		jGen.writeStringField("Bytes In", String.valueOf(poolStats.bytesIn));
+		jGen.writeStringField("Bytes Out", String.valueOf(poolStats.bytesOut));
+		jGen.writeStringField("Active Flows", String.valueOf(poolStats.activeFlows));
+		//jGen.writeStringField("Total Flows", String.valueOf(poolStats.totalFlows));
+
+		jGen.writeEndObject();
+
+	}
+}

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
@@ -128,7 +128,7 @@ ILoadBalancerService, IOFMessageListener {
 	protected HashMap<String, DatapathId> memberIdToDpid;
 	protected HashMap<Pair<Match,DatapathId>,String> flowToVipId;
 	
-	private static final int flowStatsInterval = 13;
+	private static final int flowStatsInterval = 13; /* (seconds) 2 more than threads in StatisticsCollector */
 
 	//Copied from Forwarding with message damper routine for pushing proxy Arp 
 	protected static String LB_ETHER_TYPE = "0x800";
@@ -627,7 +627,6 @@ ILoadBalancerService, IOFMessageListener {
 
 				}
 
-
 				fmb.setActions(actions);
 				fmb.setPriority(U16.t(LB_PRIORITY));
 				fmb.setMatch(mb.build());
@@ -640,8 +639,8 @@ ILoadBalancerService, IOFMessageListener {
 		return;
 	}
 
-	/**  working for OF  1.1?, 1.2?, 1.5? Periodical function to set LBPool statistics
-	 * Gets the statistics through StatisticsCollector.java and sets it to every LBPool
+	/** Periodical function to set LBPool statistics
+	 * Gets the statistics through StatisticsCollector and sets it to every LBPool
 	*/
 	private class SetPoolStats implements Runnable {
 		@Override

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancerWebRoutable.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancerWebRoutable.java
@@ -37,6 +37,7 @@ public class LoadBalancerWebRoutable implements RestletRoutable {
         router.attach("/members/{member}/{weight}", WRRResource.class); // PUT, POST
         router.attach("/pools/{pool}/members", PoolMemberResource.class); //GET
         router.attach("/pools/{pool}/members/{member}", PoolMemberResource.class); // PUT, POST
+        router.attach("/pools/{pool}/stats", PoolStatsResource.class); //GET
         router.attach("/health_monitors/", MonitorsResource.class); //GET, POST
         router.attach("/health_monitors/{monitor}", MonitorsResource.class); //GET, PUT, DELETE
         router.attachDefault(NoOp.class);

--- a/src/main/java/net/floodlightcontroller/loadbalancer/PoolStatsResource.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/PoolStatsResource.java
@@ -1,0 +1,23 @@
+package net.floodlightcontroller.loadbalancer;
+
+import org.restlet.resource.Get;
+import org.restlet.resource.ServerResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PoolStatsResource extends ServerResource {
+protected static Logger log = LoggerFactory.getLogger(PoolStatsResource.class);
+    
+    @Get("json")
+    public LBStats retrieve() {
+        ILoadBalancerService lbs =
+                (ILoadBalancerService)getContext().getAttributes().
+                    get(ILoadBalancerService.class.getCanonicalName());
+        
+        String poolId = (String) getRequestAttributes().get("pool");
+        if (poolId!=null)
+            return lbs.getPoolStats(poolId);
+        else
+            return null;
+    }
+}

--- a/src/main/java/net/floodlightcontroller/statistics/FlowRuleStats.java
+++ b/src/main/java/net/floodlightcontroller/statistics/FlowRuleStats.java
@@ -1,0 +1,108 @@
+package net.floodlightcontroller.statistics;
+
+
+import org.projectfloodlight.openflow.types.U64;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import net.floodlightcontroller.statistics.web.FlowRuleStatsSerializer;
+
+@JsonSerialize(using=FlowRuleStatsSerializer.class)
+public class FlowRuleStats {
+	
+	private U64 byteCount;
+	private U64 packetCount;
+	private int priority;
+	private int hardTimeout;
+	private int idleTimeout;
+	private long durationSec;
+	
+	private FlowRuleStats(U64 bytes, U64 packets, int priority, int hardTimeout, int idleTimeout,long durationSec) {
+		this.byteCount = bytes;
+		this.packetCount = packets;
+		this.priority = priority;
+		this.hardTimeout = hardTimeout;
+		this.idleTimeout = idleTimeout;
+		this.durationSec = durationSec;
+	}
+	
+
+	public U64 getByteCount() {
+		return byteCount;
+	}
+
+	public void setByteCount(U64 byteCount) {
+		this.byteCount = byteCount;
+	}
+
+	public U64 getPacketCount() {
+		return packetCount;
+	}
+
+	public void setPacketCount(U64 packetCount) {
+		this.packetCount = packetCount;
+	}
+	
+	public int getPriority() {
+		return priority;
+	}
+
+	public void setPriority(int priority) {
+		this.priority = priority;
+	}
+	
+	public long getDurationSec() {
+		return durationSec;
+	}
+
+	public void setDurationSec(long durationSec) {
+		this.durationSec = durationSec;
+	}
+	
+	public int getHardTimeout() {
+		return hardTimeout;
+	}
+
+	public void setHardTimeout(int hardTimeout) {
+		this.hardTimeout = hardTimeout;
+	}
+
+	public int getIdleTimeout() {
+		return idleTimeout;
+	}
+
+	public void setIdleTimeout(int idleTimeout) {
+		this.idleTimeout = idleTimeout;
+	}
+	public static FlowRuleStats of(U64 bytes, U64 packets, int priority, int hardTimeout, int idleTimeout, long durationSec) {
+		if (bytes == null) {
+			throw new IllegalArgumentException("Bytes cannot be null");
+		}
+		if (packets == null) {
+			throw new IllegalArgumentException("Packets cannot be null");
+		}
+		return new FlowRuleStats(bytes,packets,priority,hardTimeout,idleTimeout,durationSec);
+	}
+	
+//	@Override
+//	public boolean equals(Object obj) {
+//		if (this == obj)
+//			return true;
+//		if (obj == null)
+//			return false;
+//		if (getClass() != obj.getClass())
+//			return false;
+//		FlowRuleStats other = (FlowRuleStats) obj;
+//		if (byteCount == null) {
+//			if (other.byteCount != null)
+//				return false;
+//		} else if (!byteCount.equals(other.byteCount))
+//			return false;
+//		if (packetCount == null) {
+//			if (other.packetCount != null)
+//				return false;
+//		} else if (!packetCount.equals(other.packetCount))
+//			return false;
+//		return true;
+//	}
+}

--- a/src/main/java/net/floodlightcontroller/statistics/FlowRuleStats.java
+++ b/src/main/java/net/floodlightcontroller/statistics/FlowRuleStats.java
@@ -1,6 +1,7 @@
 package net.floodlightcontroller.statistics;
 
 
+import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.U64;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -9,15 +10,17 @@ import net.floodlightcontroller.statistics.web.FlowRuleStatsSerializer;
 
 @JsonSerialize(using=FlowRuleStatsSerializer.class)
 public class FlowRuleStats {
-	
+
+	private DatapathId dpid;
 	private U64 byteCount;
 	private U64 packetCount;
 	private int priority;
 	private int hardTimeout;
 	private int idleTimeout;
 	private long durationSec;
-	
-	private FlowRuleStats(U64 bytes, U64 packets, int priority, int hardTimeout, int idleTimeout,long durationSec) {
+
+	private FlowRuleStats(DatapathId dpid, U64 bytes, U64 packets, int priority, int hardTimeout, int idleTimeout,long durationSec) {
+		this.dpid = dpid;
 		this.byteCount = bytes;
 		this.packetCount = packets;
 		this.priority = priority;
@@ -25,84 +28,70 @@ public class FlowRuleStats {
 		this.idleTimeout = idleTimeout;
 		this.durationSec = durationSec;
 	}
-	
+
+	public DatapathId getDpid() {
+		return dpid;
+	}
+
 
 	public U64 getByteCount() {
 		return byteCount;
 	}
 
-	public void setByteCount(U64 byteCount) {
-		this.byteCount = byteCount;
-	}
 
 	public U64 getPacketCount() {
 		return packetCount;
 	}
 
-	public void setPacketCount(U64 packetCount) {
-		this.packetCount = packetCount;
-	}
-	
 	public int getPriority() {
 		return priority;
 	}
 
-	public void setPriority(int priority) {
-		this.priority = priority;
-	}
-	
+
 	public long getDurationSec() {
 		return durationSec;
 	}
 
-	public void setDurationSec(long durationSec) {
-		this.durationSec = durationSec;
-	}
-	
 	public int getHardTimeout() {
 		return hardTimeout;
-	}
-
-	public void setHardTimeout(int hardTimeout) {
-		this.hardTimeout = hardTimeout;
 	}
 
 	public int getIdleTimeout() {
 		return idleTimeout;
 	}
 
-	public void setIdleTimeout(int idleTimeout) {
-		this.idleTimeout = idleTimeout;
-	}
-	public static FlowRuleStats of(U64 bytes, U64 packets, int priority, int hardTimeout, int idleTimeout, long durationSec) {
+	public static FlowRuleStats of(DatapathId dpid, U64 bytes, U64 packets, int priority, int hardTimeout, int idleTimeout, long durationSec) {
+		if (dpid == null) {
+			throw new IllegalArgumentException("Datapath Id cannot be null");
+		}
 		if (bytes == null) {
 			throw new IllegalArgumentException("Bytes cannot be null");
 		}
 		if (packets == null) {
 			throw new IllegalArgumentException("Packets cannot be null");
 		}
-		return new FlowRuleStats(bytes,packets,priority,hardTimeout,idleTimeout,durationSec);
+		return new FlowRuleStats(dpid,bytes,packets,priority,hardTimeout,idleTimeout,durationSec);
 	}
-	
-//	@Override
-//	public boolean equals(Object obj) {
-//		if (this == obj)
-//			return true;
-//		if (obj == null)
-//			return false;
-//		if (getClass() != obj.getClass())
-//			return false;
-//		FlowRuleStats other = (FlowRuleStats) obj;
-//		if (byteCount == null) {
-//			if (other.byteCount != null)
-//				return false;
-//		} else if (!byteCount.equals(other.byteCount))
-//			return false;
-//		if (packetCount == null) {
-//			if (other.packetCount != null)
-//				return false;
-//		} else if (!packetCount.equals(other.packetCount))
-//			return false;
-//		return true;
-//	}
+
+	//	@Override
+	//	public boolean equals(Object obj) {
+	//		if (this == obj)
+	//			return true;
+	//		if (obj == null)
+	//			return false;
+	//		if (getClass() != obj.getClass())
+	//			return false;
+	//		FlowRuleStats other = (FlowRuleStats) obj;
+	//		if (byteCount == null) {
+	//			if (other.byteCount != null)
+	//				return false;
+	//		} else if (!byteCount.equals(other.byteCount))
+	//			return false;
+	//		if (packetCount == null) {
+	//			if (other.packetCount != null)
+	//				return false;
+	//		} else if (!packetCount.equals(other.packetCount))
+	//			return false;
+	//		return true;
+	//	}
 }

--- a/src/main/java/net/floodlightcontroller/statistics/IStatisticsService.java
+++ b/src/main/java/net/floodlightcontroller/statistics/IStatisticsService.java
@@ -2,12 +2,21 @@ package net.floodlightcontroller.statistics;
 
 import net.floodlightcontroller.core.module.IFloodlightService;
 import net.floodlightcontroller.core.types.NodePortTuple;
+
+import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFPort;
 
+import javafx.util.Pair;
+
 import java.util.Map;
+import java.util.Set;
 
 public interface IStatisticsService extends IFloodlightService {
+	
+	public Map<Pair<Match,DatapathId>, FlowRuleStats> getFlowStats();
+	
+	public Set<FlowRuleStats> getFlowStats(DatapathId dpid);
 
 	public SwitchPortBandwidth getBandwidthConsumption(DatapathId dpid, OFPort p);
 		

--- a/src/main/java/net/floodlightcontroller/statistics/StatisticsCollector.java
+++ b/src/main/java/net/floodlightcontroller/statistics/StatisticsCollector.java
@@ -39,25 +39,25 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 	private static IRestApiService restApiService;
 
 	private static boolean isEnabled = false;
-	
+
 	private static int portStatsInterval = 10; /* could be set by REST API, so not final */
 	private static int flowStatsInterval = 11;
-	
+
 	private static ScheduledFuture<?> portStatsCollector;
 	private static ScheduledFuture<?> flowStatsCollector;
 
 	private static final long BITS_PER_BYTE = 8;
 	private static final long MILLIS_PER_SEC = 1000;
-	
+
 	private static final String INTERVAL_PORT_STATS_STR = "collectionIntervalPortStatsSeconds";
 	private static final String ENABLED_STR = "enable";
 
 	private static final HashMap<NodePortTuple, SwitchPortBandwidth> portStats = new HashMap<NodePortTuple, SwitchPortBandwidth>();
 	private static final HashMap<NodePortTuple, SwitchPortBandwidth> tentativePortStats = new HashMap<NodePortTuple, SwitchPortBandwidth>();
-	
+
 	private static final HashMap<Pair<Match,DatapathId>, FlowRuleStats> flowStats = new HashMap<Pair<Match,DatapathId>,FlowRuleStats>();
-	
-	
+
+
 
 	/**
 	 * Run periodically to collect all port statistics. This only collects
@@ -125,7 +125,7 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 									U64.ofRaw((txBytesCounted.getValue() * BITS_PER_BYTE) / timeDifSec), 
 									pse.getRxBytes(), pse.getTxBytes())
 									);
-							
+
 						} else { /* initialize */
 							tentativePortStats.put(npt, SwitchPortBandwidth.of(npt.getNodeId(), npt.getPortId(), U64.ZERO, U64.ZERO, U64.ZERO, pse.getRxBytes(), pse.getTxBytes()));
 						}
@@ -144,27 +144,27 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 			/* getCurrSpeed() should handle different OpenFlow Version */
 			OFVersion detectedVersion = sw.getOFFactory().getVersion();
 			switch(detectedVersion){
-				case OF_10:
-					log.debug("Port speed statistics not supported in OpenFlow 1.0");
-					break;
+			case OF_10:
+				log.debug("Port speed statistics not supported in OpenFlow 1.0");
+				break;
 
-				case OF_11:
-				case OF_12:
-				case OF_13:
-					speed = sw.getPort(npt.getPortId()).getCurrSpeed();
-					break;
+			case OF_11:
+			case OF_12:
+			case OF_13:
+				speed = sw.getPort(npt.getPortId()).getCurrSpeed();
+				break;
 
-				case OF_14:
-				case OF_15:
-					for(OFPortDescProp p : sw.getPort(npt.getPortId()).getProperties()){
-						if( p.getType() == 0 ){ /* OpenFlow 1.4 and OpenFlow 1.5 will return zero */
-							speed = ((OFPortDescPropEthernet) p).getCurrSpeed();
-						}
+			case OF_14:
+			case OF_15:
+				for(OFPortDescProp p : sw.getPort(npt.getPortId()).getProperties()){
+					if( p.getType() == 0 ){ /* OpenFlow 1.4 and OpenFlow 1.5 will return zero */
+						speed = ((OFPortDescPropEthernet) p).getCurrSpeed();
 					}
-					break;
+				}
+				break;
 
-				default:
-					break;
+			default:
+				break;
 			}
 
 			return speed;
@@ -172,7 +172,7 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 		}
 
 	}
-	
+
 	/**
 	 * Run periodically to collect all flow statistics from every switch.
 	 */
@@ -182,18 +182,24 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 			flowStats.clear(); // to clear expired flows
 			Map<DatapathId, List<OFStatsReply>> replies = getSwitchStatistics(switchService.getAllSwitchDpids(), OFStatsType.FLOW);
 			for (Entry<DatapathId, List<OFStatsReply>> e : replies.entrySet()) {
+				IOFSwitch sw = switchService.getSwitch(e.getKey());
 				for (OFStatsReply r : e.getValue()) {
 					OFFlowStatsReply psr = (OFFlowStatsReply) r;
 					for (OFFlowStatsEntry pse : psr.getEntries()) {
-						Pair<Match, DatapathId> pair = new Pair<Match,DatapathId>(pse.getMatch(),e.getKey());
-						flowStats.put(pair,FlowRuleStats.of(
-								e.getKey(),
-								pse.getByteCount(),
-								pse.getPacketCount(),
-								pse.getPriority(),
-								pse.getHardTimeout(),
-								pse.getIdleTimeout(),
-								pse.getDurationSec()));
+						if(sw.getOFFactory().getVersion().compareTo(OFVersion.OF_15) == 0){
+							log.warn("Flow Stats not supported in OpenFlow 1.5.");
+
+						} else {
+							Pair<Match, DatapathId> pair = new Pair<Match,DatapathId>(pse.getMatch(),e.getKey());
+							flowStats.put(pair,FlowRuleStats.of(
+									e.getKey(),
+									pse.getByteCount(),
+									pse.getPacketCount(),
+									pse.getPriority(),
+									pse.getHardTimeout(),
+									pse.getIdleTimeout(),
+									pse.getDurationSec()));
+						}
 					}
 				}
 			}
@@ -231,11 +237,11 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 			statsReply = getSwitchStatistics(switchId, statType);
 		}
 	}
-	
+
 	/*
 	 * IFloodlightModule implementation
 	 */
-	
+
 	@Override
 	public Collection<Class<? extends IFloodlightService>> getModuleServices() {
 		Collection<Class<? extends IFloodlightService>> l =
@@ -301,7 +307,7 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 	/*
 	 * IStatisticsService implementation
 	 */
-	
+
 	@Override
 	public Map<Pair<Match, DatapathId>, FlowRuleStats> getFlowStats(){		 
 		return Collections.unmodifiableMap(flowStats);
@@ -316,12 +322,12 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 		}
 		return frs;
 	}
-	
+
 	@Override
 	public SwitchPortBandwidth getBandwidthConsumption(DatapathId dpid, OFPort p) {
 		return portStats.get(new NodePortTuple(dpid, p));
 	}
-	
+
 	@Override
 	public Map<NodePortTuple, SwitchPortBandwidth> getBandwidthConsumption() {
 		return Collections.unmodifiableMap(portStats);
@@ -338,11 +344,11 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 		} 
 		/* otherwise, state is not changing; no-op */
 	}
-	
+
 	/*
 	 * Helper functions
 	 */
-	
+
 	/**
 	 * Start all stats threads.
 	 */
@@ -352,7 +358,7 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 		flowStatsCollector = threadPoolService.getScheduledExecutor().scheduleAtFixedRate(new FlowStatsCollector(), flowStatsInterval, flowStatsInterval, TimeUnit.SECONDS);
 		log.warn("Statistics collection thread(s) started");
 	}
-	
+
 	/**
 	 * Stop all stats threads.
 	 */
@@ -399,7 +405,7 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 			for (GetStatisticsThread curThread : pendingRemovalThreads) {
 				activeThreads.remove(curThread);
 			}
-			
+
 			/* clear the list so we don't try to double remove them */
 			pendingRemovalThreads.clear();
 

--- a/src/main/java/net/floodlightcontroller/statistics/StatisticsCollector.java
+++ b/src/main/java/net/floodlightcontroller/statistics/StatisticsCollector.java
@@ -41,7 +41,7 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 	private static boolean isEnabled = false;
 	
 	private static int portStatsInterval = 10; /* could be set by REST API, so not final */
-	private static int flowStatsInterval = 12;
+	private static int flowStatsInterval = 11;
 	
 	private static ScheduledFuture<?> portStatsCollector;
 	private static ScheduledFuture<?> flowStatsCollector;
@@ -174,9 +174,9 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 	}
 	
 	/**
-	 * Run periodically to collect all flow statistics.
+	 * Run periodically to collect all flow statistics from every switch.
 	 */
-	private class FlowStatsCollector implements Runnable {
+	protected class FlowStatsCollector implements Runnable {
 		@Override
 		public void run() {
 			flowStats.clear(); // to clear expired flows

--- a/src/main/java/net/floodlightcontroller/statistics/StatisticsCollector.java
+++ b/src/main/java/net/floodlightcontroller/statistics/StatisticsCollector.java
@@ -41,7 +41,7 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 	private static boolean isEnabled = false;
 	
 	private static int portStatsInterval = 10; /* could be set by REST API, so not final */
-	private static int flowStatsInterval = 15;
+	private static int flowStatsInterval = 12;
 	
 	private static ScheduledFuture<?> portStatsCollector;
 	private static ScheduledFuture<?> flowStatsCollector;
@@ -139,6 +139,9 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 		}
 	}
 	
+	/**
+	 * Run periodically to collect all flow statistics.
+	 */
 	private class FlowStatsCollector implements Runnable {
 		@Override
 		public void run() {
@@ -272,7 +275,6 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 
 	@Override
 	public Set<FlowRuleStats> getFlowStats(DatapathId dpid){
-		//!!! heavy load
 		Set<FlowRuleStats> frs = new HashSet<FlowRuleStats>();
 		for(Pair<Match,DatapathId> pair: flowStats.keySet()){
 			if(pair.getValue().equals(dpid))

--- a/src/main/java/net/floodlightcontroller/statistics/web/FlowResource.java
+++ b/src/main/java/net/floodlightcontroller/statistics/web/FlowResource.java
@@ -1,0 +1,45 @@
+package net.floodlightcontroller.statistics.web;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.projectfloodlight.openflow.types.DatapathId;
+
+import org.restlet.resource.Get;
+import org.restlet.resource.ServerResource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import net.floodlightcontroller.statistics.FlowRuleStats;
+import net.floodlightcontroller.statistics.IStatisticsService;
+
+
+public class FlowResource extends ServerResource {
+	private static final Logger log = LoggerFactory.getLogger(FlowResource.class);
+	
+	@Get("json")
+	public Object retrieve() {
+		IStatisticsService statisticsService = (IStatisticsService) getContext().getAttributes().get(IStatisticsService.class.getCanonicalName());
+		
+        String d = (String) getRequestAttributes().get(SwitchStatisticsWebRoutable.DPID_STR);
+        
+        DatapathId dpid = DatapathId.NONE;
+        
+        HashSet<FlowRuleStats> frss;
+        if (!d.trim().equalsIgnoreCase("all")) {
+            try {
+                dpid = DatapathId.of(d);
+            } catch (Exception e) {
+                log.error("Could not parse DPID {}", d);
+                return Collections.singletonMap("ERROR", "Could not parse DPID " + d);
+            }
+            
+    		frss = new HashSet<FlowRuleStats>(statisticsService.getFlowStats(dpid));
+    		return frss;
+        }
+        frss = new HashSet<FlowRuleStats>(statisticsService.getFlowStats().values());
+        return frss;
+	}
+}

--- a/src/main/java/net/floodlightcontroller/statistics/web/FlowRuleStatsSerializer.java
+++ b/src/main/java/net/floodlightcontroller/statistics/web/FlowRuleStatsSerializer.java
@@ -15,6 +15,7 @@ public class FlowRuleStatsSerializer extends JsonSerializer<FlowRuleStats>{
 	public void serialize(FlowRuleStats frs, JsonGenerator jGen, SerializerProvider serializer) throws IOException, JsonProcessingException {
 
 		jGen.writeStartObject();
+		jGen.writeStringField("Dpid", String.valueOf(frs.getDpid()));
 		jGen.writeStringField("Bytes", String.valueOf(frs.getByteCount().getValue()));
 		jGen.writeStringField("Packets", String.valueOf(frs.getPacketCount().getValue()));
 		jGen.writeStringField("Priority", String.valueOf(frs.getPriority()));

--- a/src/main/java/net/floodlightcontroller/statistics/web/FlowRuleStatsSerializer.java
+++ b/src/main/java/net/floodlightcontroller/statistics/web/FlowRuleStatsSerializer.java
@@ -1,0 +1,26 @@
+package net.floodlightcontroller.statistics.web;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import net.floodlightcontroller.statistics.FlowRuleStats;
+
+public class FlowRuleStatsSerializer extends JsonSerializer<FlowRuleStats>{
+
+	@Override
+	public void serialize(FlowRuleStats frs, JsonGenerator jGen, SerializerProvider serializer) throws IOException, JsonProcessingException {
+
+		jGen.writeStartObject();
+		jGen.writeStringField("Bytes", String.valueOf(frs.getByteCount().getValue()));
+		jGen.writeStringField("Packets", String.valueOf(frs.getPacketCount().getValue()));
+		jGen.writeStringField("Priority", String.valueOf(frs.getPriority()));
+		jGen.writeStringField("Hard Timeout", String.valueOf(frs.getIdleTimeout()));
+		jGen.writeStringField("Idle Timeout", String.valueOf(frs.getHardTimeout()));
+		jGen.writeStringField("Duration in seconds", String.valueOf(frs.getDurationSec()));
+		jGen.writeEndObject();
+	}
+}

--- a/src/main/java/net/floodlightcontroller/statistics/web/SwitchStatisticsWebRoutable.java
+++ b/src/main/java/net/floodlightcontroller/statistics/web/SwitchStatisticsWebRoutable.java
@@ -16,6 +16,7 @@ public class SwitchStatisticsWebRoutable implements RestletRoutable {
     public Router getRestlet(Context context) {
         Router router = new Router(context);
         router.attach("/bandwidth/{" + DPID_STR + "}/{" + PORT_STR + "}/json", BandwidthResource.class);
+        router.attach("/flow/{" + DPID_STR + "}/json", FlowResource.class);
         router.attach("/config/enable/json", ConfigResource.class);
         router.attach("/config/disable/json", ConfigResource.class);
         return router;

--- a/src/test/java/net/floodlightcontroller/loadbalancer/LoadBalancerTest.java
+++ b/src/test/java/net/floodlightcontroller/loadbalancer/LoadBalancerTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMock;
@@ -787,5 +788,27 @@ public class LoadBalancerTest extends FloodlightTestCase {
 		assertTrue(memberPickedNoData.equals("1")); // simple round robin
 		
 		assertTrue(noMembers==null);
+	}
+	
+	@Test
+	public void testPoolStats() {	
+		testCreateVip();
+		testCreatePool();
+		testCreateMember();
+		
+		ArrayList<Long> bytesIn = new ArrayList<Long>();
+		bytesIn.add((long) 10);
+
+		ArrayList<Long> bytesOut = new ArrayList<Long>();
+		bytesOut.add((long) 20);
+		
+		int activeFlows = 30;
+		
+		pool1.setPoolStatistics(bytesIn, bytesOut, activeFlows);
+		
+		assertTrue(pool1.poolStats.getBytesIn() == 10);
+		assertTrue(pool1.poolStats.getBytesOut() == 20);
+		assertTrue(pool1.poolStats.getActiveFlows() == 30);
+		
 	}
 }


### PR DESCRIPTION
Implemented the statistics of a LBPool.

By creating a routine in StatisticsCollector.java to fetch the switch flow statistics for all the DPIDs and creating a class to store the important information about these flows. (similar to the PortStatsCollector function).
Then, the LB will use the IStatisticsService to get these statistics and filter them by LBPool.
Through the REST API, it is possible to know the bytes in, bytes out and active flows of each Pool.
It is also possible to retrieve flow statistics per DPID.

For instance:
curl -X GET http://localhost:8080/wm/statistics/flow/1/json, for DPID=1 
curl -X GET http://localhost:8080/quantum/v1.0/pools/1/stats , for LBPool with id=1

A simple test was created to evaluate the correctness of the function to set the statistics of each LBPool.
OF/Loxigen documentation was checked and all functions used by OFFlowStatsEntry to retrieve the parameters (byte count, packet count, priority...) are compatible with all versions, except OF1.5.

In OF1.5 there is no implementation to get some of the parameters used (as far as I know, feedback appreciated) so it simply logs a warning.  