### PR TITLE
Fixed bug at dropFilter(...) method.

### DIFF
--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -934,8 +934,9 @@ public class TopologyManager implements IFloodlightModule, ITopologyService, IRo
 			if (log.isTraceEnabled()) {
 				log.trace("Ignoring packet because of topology " +
 						"restriction on switch={}, port={}", sw.getLong(), inPort.getPortNumber());
-				result = Command.STOP;
+				
 			}
+			result = Command.STOP;
 		}
 		return result;
 	}

--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -933,8 +933,7 @@ public class TopologyManager implements IFloodlightModule, ITopologyService, IRo
 		if (isAllowed(sw, inPort) == false) {
 			if (log.isTraceEnabled()) {
 				log.trace("Ignoring packet because of topology " +
-						"restriction on switch={}, port={}", sw.getLong(), inPort.getPortNumber());
-				
+						"restriction on switch={}, port={}", sw.getLong(), inPort.getPortNumber());				
 			}
 			result = Command.STOP;
 		}


### PR DESCRIPTION
Moved **result = Command.STOP;** to outside of log level. 