### PR TITLE
manually set cookie while adding static entry flow

### DIFF
--- a/src/main/java/net/floodlightcontroller/staticentry/StaticEntries.java
+++ b/src/main/java/net/floodlightcontroller/staticentry/StaticEntries.java
@@ -165,6 +165,7 @@ public class StaticEntries {
 		entry.put(StaticEntryPusher.Columns.COLUMN_PRIORITY, Integer.toString(fm.getPriority()));
 		entry.put(StaticEntryPusher.Columns.COLUMN_IDLE_TIMEOUT, Integer.toString(fm.getIdleTimeout()));
 		entry.put(StaticEntryPusher.Columns.COLUMN_HARD_TIMEOUT, Integer.toString(fm.getHardTimeout()));
+		entry.put(StaticEntryPusher.Columns.COLUMN_COOKIE, Long.toString(fm.getCookie().getValue()));
 
 		switch (fm.getVersion()) {
 		case OF_10:


### PR DESCRIPTION
Without this line, the addFlow(String name, OFFlowMod fm, DatapathId swDpid) function in StaticEntryPusher.java won't be able to set the flow cookie even OFFlowMod fm has set the cookie.