### PR TITLE
Integer Division Problem at StatisticsCollector

### DIFF
--- a/src/main/java/net/floodlightcontroller/devicemanager/IDevice.java
+++ b/src/main/java/net/floodlightcontroller/devicemanager/IDevice.java
@@ -26,8 +26,7 @@ import org.projectfloodlight.openflow.types.VlanVid;
 
 
 /**
- * Represents an independent device on the network.  A device consists of a 
- * set of entities, and all the information known about a given device comes
+ * Represents an independent device on the network.  a, and all the information known about a given device comes
  * only from merging all associated entities for that device.
  * @author readams
  */

--- a/src/main/java/net/floodlightcontroller/statistics/StatisticsCollector.java
+++ b/src/main/java/net/floodlightcontroller/statistics/StatisticsCollector.java
@@ -483,7 +483,7 @@ public class StatisticsCollector implements IFloodlightModule, IStatisticsServic
 			try {
 				if (req != null) {
 					future = sw.writeStatsRequest(req); 
-					values = (List<OFStatsReply>) future.get(portStatsInterval / 2, TimeUnit.SECONDS);
+					values = (List<OFStatsReply>) future.get(portStatsInterval*1000 / 2, TimeUnit.MILLISECONDS);
 				}
 			} catch (Exception e) {
 				log.error("Failure retrieving statistics from switch {}. {}", sw, e);


### PR DESCRIPTION
@rizard 

Problem: 
When portStatsInterval set to 1, timeout will going to be 0, which immediate will throw the exception

Fix: 
Change TimeUnit to Milliseconds to give more granularity regarding time-scale, so as to avoid Integer Division problem when collection interval is set to 1.