### PR TITLE
Fix guava library version in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -74,7 +74,7 @@
         <include name="concurrentlinkedhashmap-lru-1.2.jar"/>
         <include name="jython-2.5.2.jar"/>
         <include name="libthrift-0.9.0.jar"/>
-        <include name="guava-13.0.1.jar" />
+        <include name="guava-20.0.jar" />
         <include name="findbugs-annotations-2.0.1.jar" />
         <include name="findbugs-jsr305-2.0.1.jar" />
         <include name="derby-10.9.1.0.jar"/>


### PR DESCRIPTION
@rizard guava library version in build.xml is out-of-date, it was V13.0.1, and it should be V20.0.

Update Google guava library version to the correct one "guava-20.0.jar", so that at the runtime it will be loaded correctly.