### PR TITLE
Fix bug to correctly build Packet-Out message for OpenFlow 1.5

### DIFF
--- a/src/main/java/net/floodlightcontroller/learningswitch/LearningSwitch.java
+++ b/src/main/java/net/floodlightcontroller/learningswitch/LearningSwitch.java
@@ -320,7 +320,7 @@ implements IFloodlightModule, ILearningSwitchService, IOFMessageListener, IContr
 			pob.setBufferId(pi.getBufferId());
 		}
 
-		pob.setInPort(inPort);
+		OFMessageUtils.setInPort(pob, inPort);
 
 		// If the buffer id is none or the switch doesn's support buffering
 		// we send the data with the packet out

--- a/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
+++ b/src/main/java/net/floodlightcontroller/loadbalancer/LoadBalancer.java
@@ -384,7 +384,7 @@ ILoadBalancerService, IOFMessageListener {
 
 		// set buffer_id, in_port
 		pob.setBufferId(bufferId);
-		pob.setInPort(inPort);
+		OFMessageUtils.setInPort(pob, inPort);
 
 		// set data - only if buffer_id == -1
 		if (pob.getBufferId() == OFBufferId.NO_BUFFER) {

--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -365,7 +365,7 @@ public abstract class ForwardingBase implements IOFMessageListener {
         pob.setActions(actions);
 
         pob.setBufferId(OFBufferId.NO_BUFFER);
-        pob.setInPort(inPort);
+        OFMessageUtils.setInPort(pob, inPort);
 
         pob.setData(packetData);
 

--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -40,10 +40,7 @@ import net.floodlightcontroller.routing.IRoutingService;
 import net.floodlightcontroller.routing.IRoutingDecision;
 import net.floodlightcontroller.routing.Path;
 import net.floodlightcontroller.topology.ITopologyService;
-import net.floodlightcontroller.util.FlowModUtils;
-import net.floodlightcontroller.util.MatchUtils;
-import net.floodlightcontroller.util.OFDPAUtils;
-import net.floodlightcontroller.util.OFMessageDamper;
+import net.floodlightcontroller.util.*;
 
 import org.projectfloodlight.openflow.protocol.OFFlowMod;
 import org.projectfloodlight.openflow.protocol.match.Match;
@@ -340,7 +337,7 @@ public abstract class ForwardingBase implements IOFMessageListener {
             pob.setData(packetData);
         }
 
-        pob.setInPort((pi.getVersion().compareTo(OFVersion.OF_12) < 0 ? pi.getInPort() : pi.getMatch().get(MatchField.IN_PORT)));
+        OFMessageUtils.setInPort(pob, OFMessageUtils.getInPort(pi));
         messageDamper.write(sw, pob.build());
     }
 

--- a/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyManager.java
@@ -38,6 +38,7 @@ import net.floodlightcontroller.routing.web.RoutingWebRoutable;
 import net.floodlightcontroller.statistics.IStatisticsService;
 import net.floodlightcontroller.threadpool.IThreadPoolService;
 import net.floodlightcontroller.topology.web.TopologyWebRoutable;
+import net.floodlightcontroller.util.OFMessageUtils;
 import org.projectfloodlight.openflow.protocol.*;
 import org.projectfloodlight.openflow.protocol.action.OFAction;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
@@ -745,7 +746,7 @@ ITopologyManagerBackend, ILinkDiscoveryListener, IOFMessageListener {
         // set buffer-id to BUFFER_ID_NONE
         pob.setBufferId(OFBufferId.NO_BUFFER);
         // set in-port to OFPP_NONE
-        pob.setInPort(OFPort.ZERO);
+        OFMessageUtils.setInPort(pob, OFPort.ZERO);
 
         // set packet data
         pob.setData(packetData);

--- a/src/main/java/net/floodlightcontroller/util/OFMessageUtils.java
+++ b/src/main/java/net/floodlightcontroller/util/OFMessageUtils.java
@@ -163,9 +163,7 @@ public class OFMessageUtils {
 
 		// Set buffer_id, in_port, actions_len
 		pob.setBufferId(packetInMessage.getBufferId());
-		pob.setInPort(packetInMessage.getVersion().compareTo(OFVersion.OF_12) < 0 ? packetInMessage
-				.getInPort() : packetInMessage.getMatch().get(
-						MatchField.IN_PORT));
+		setInPort(pob, getInPort(packetInMessage));
 
 		// set actions
 		List<OFAction> actions = new ArrayList<OFAction>(1);


### PR DESCRIPTION
@rizard 
@geddings 

Problem:
While building out Packet-Out message in OpenFlow 1.5 environment (i.e., BBDP/LLDP packet-out message), those Packet-Out messages are not built correctly.

Solution:
This is because "in_port" attribute was replaced with a "match" in OpenFlow 1.5, therefore we should use OFMessageUtils.setInPort to correctly build up packet-out messages.

