### PR TITLE
Fix bugs in PerfMon module 

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/Controller.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/Controller.java
@@ -399,7 +399,9 @@ public class Controller implements IFloodlightProviderService, IStorageSourceLis
                     // Get the starting time (overall and per-component) of
                     // the processing chain for this packet if performance
                     // monitoring is turned on
-                    pktinProcTimeService.bootstrap(listeners);
+                    for (IOFMessageListener l : listeners) {
+                        pktinProcTimeService.addListener(l);
+                    }
                     pktinProcTimeService.recordStartTimePktIn();
                     Command cmd;
                     for (IOFMessageListener listener : listeners) {
@@ -678,6 +680,9 @@ public class Controller implements IFloodlightProviderService, IStorageSourceLis
         // Switch Service Startup
         switchService.registerLogicalOFMessageCategory(LogicalOFMessageCategory.MAIN);
         counters = new ControllerCounters(debugCounterService);
+
+        pktinProcTimeService.bootstrap();
+
      }
 
     /**

--- a/src/main/java/net/floodlightcontroller/core/internal/Controller.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/Controller.java
@@ -683,8 +683,6 @@ public class Controller implements IFloodlightProviderService, IStorageSourceLis
         switchService.registerLogicalOFMessageCategory(LogicalOFMessageCategory.MAIN);
         counters = new ControllerCounters(debugCounterService);
 
-//        pktinProcTimeService.bootstrap();
-
      }
 
     /**

--- a/src/main/java/net/floodlightcontroller/core/internal/Controller.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/Controller.java
@@ -399,6 +399,8 @@ public class Controller implements IFloodlightProviderService, IStorageSourceLis
                     // Get the starting time (overall and per-component) of
                     // the processing chain for this packet if performance
                     // monitoring is turned on
+                    pktinProcTimeService.bootstrap();
+
                     for (IOFMessageListener l : listeners) {
                         pktinProcTimeService.addListener(l);
                     }
@@ -681,7 +683,7 @@ public class Controller implements IFloodlightProviderService, IStorageSourceLis
         switchService.registerLogicalOFMessageCategory(LogicalOFMessageCategory.MAIN);
         counters = new ControllerCounters(debugCounterService);
 
-        pktinProcTimeService.bootstrap();
+//        pktinProcTimeService.bootstrap();
 
      }
 

--- a/src/main/java/net/floodlightcontroller/perfmon/CumulativeTimeBucket.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/CumulativeTimeBucket.java
@@ -69,13 +69,16 @@ public class CumulativeTimeBucket {
         return compStats.values();
     }
 
-    public CumulativeTimeBucket(List<IOFMessageListener> listeners) {
-        compStats = new ConcurrentHashMap<Integer, OneComponentTime>(listeners.size());
-        for (IOFMessageListener l : listeners) {
-            OneComponentTime oct = new OneComponentTime(l);
+    public CumulativeTimeBucket() {
+        compStats = new ConcurrentHashMap<>();
+        startTime_ns = System.nanoTime();
+    }
+
+    public void addListener(IOFMessageListener listener) {
+        if (!compStats.containsKey(listener.hashCode())) {
+            OneComponentTime oct = new OneComponentTime(listener);
             compStats.put(oct.hashCode(), oct);
         }
-        startTime_ns = System.nanoTime();
     }
 
     private void updateSquaredProcessingTime(long curTimeNs) {

--- a/src/main/java/net/floodlightcontroller/perfmon/CumulativeTimeBucketJSONSerializer.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/CumulativeTimeBucketJSONSerializer.java
@@ -36,7 +36,10 @@ public class CumulativeTimeBucketJSONSerializer
                    SerializerProvider serializer) 
                    throws IOException, JsonProcessingException {
        jGen.writeStartObject();
-       Timestamp ts = new Timestamp(System.currentTimeMillis() - (System.nanoTime() - ctb.getStartTimeNs())/1000000);
+       // System.nanoTime() used for computing "elapsed time"
+       long elapsedTimeMillis = (System.nanoTime() - ctb.getStartTimeNs())/1000000;
+       // System.currentTimeMillis() used for computing "dates"
+       Timestamp ts = new Timestamp(System.currentTimeMillis() - elapsedTimeMillis);
        jGen.writeStringField("start-time", ts.toString());
        jGen.writeStringField("current-time", 
          new Timestamp(System.currentTimeMillis()).toString());

--- a/src/main/java/net/floodlightcontroller/perfmon/CumulativeTimeBucketJSONSerializer.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/CumulativeTimeBucketJSONSerializer.java
@@ -36,7 +36,7 @@ public class CumulativeTimeBucketJSONSerializer
                    SerializerProvider serializer) 
                    throws IOException, JsonProcessingException {
        jGen.writeStartObject();
-       Timestamp ts = new Timestamp(ctb.getStartTimeNs()/1000000);
+       Timestamp ts = new Timestamp(System.currentTimeMillis() - (System.nanoTime() - ctb.getStartTimeNs())/1000000);
        jGen.writeStringField("start-time", ts.toString());
        jGen.writeStringField("current-time", 
          new Timestamp(System.currentTimeMillis()).toString());

--- a/src/main/java/net/floodlightcontroller/perfmon/CumulativeTimeBucketJSONSerializer.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/CumulativeTimeBucketJSONSerializer.java
@@ -36,10 +36,7 @@ public class CumulativeTimeBucketJSONSerializer
                    SerializerProvider serializer) 
                    throws IOException, JsonProcessingException {
        jGen.writeStartObject();
-       // System.nanoTime() used for computing "elapsed time"
-       long elapsedTimeMillis = (System.nanoTime() - ctb.getStartTimeNs())/1000000;
-       // System.currentTimeMillis() used for computing "dates"
-       Timestamp ts = new Timestamp(System.currentTimeMillis() - elapsedTimeMillis);
+       Timestamp ts = new Timestamp(System.currentTimeMillis() - (System.nanoTime() - ctb.getStartTimeNs())/1000000);
        jGen.writeStringField("start-time", ts.toString());
        jGen.writeStringField("current-time", 
          new Timestamp(System.currentTimeMillis()).toString());

--- a/src/main/java/net/floodlightcontroller/perfmon/IPktInProcessingTimeService.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/IPktInProcessingTimeService.java
@@ -29,10 +29,15 @@ public interface IPktInProcessingTimeService extends IFloodlightService {
 
     /**
      * Creates time buckets for a set of modules to measure their performance
-     * @param listeners The message listeners to create time buckets for
      */
-    public void bootstrap(List<IOFMessageListener> listeners);
-    
+    public void bootstrap();
+
+    /**
+     * Add module message listeners to measure their performance
+     * @param listener
+     */
+    public void addListener(IOFMessageListener listener);
+
     /**
      * Stores a timestamp in ns. Used right before a service handles an
      * OF message. Only stores if the service is enabled.

--- a/src/main/java/net/floodlightcontroller/perfmon/NullPktInProcessingTime.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/NullPktInProcessingTime.java
@@ -87,9 +87,14 @@ public class NullPktInProcessingTime
     }
 
     @Override
-    public void bootstrap(List<IOFMessageListener> listeners) {
+    public void bootstrap() {
         if (!inited)
-            ctb = new CumulativeTimeBucket(listeners);
+            ctb = new CumulativeTimeBucket();
+    }
+
+    @Override
+    public void addListener(IOFMessageListener listener) {
+        ctb.addListener(listener);
     }
 
     @Override

--- a/src/main/java/net/floodlightcontroller/perfmon/PerfWebRoutable.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/PerfWebRoutable.java
@@ -28,6 +28,7 @@ public class PerfWebRoutable implements RestletRoutable {
     public Restlet getRestlet(Context context) {
         Router router = new Router(context);
         router.attach("/data/json", PerfMonDataResource.class);
+        router.attach("/json", PerfMonToggleResource.class);
         router.attach("/{perfmonstate}/json", PerfMonToggleResource.class); // enable, disable, or reset
         return router;
     }

--- a/src/main/java/net/floodlightcontroller/perfmon/PktInProcessingTime.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/PktInProcessingTime.java
@@ -96,12 +96,17 @@ public class PktInProcessingTime
     protected static final int ONE_BUCKET_DURATION_SECONDS = 10;// seconds
     protected static final long ONE_BUCKET_DURATION_NANOSECONDS  =
                                 ONE_BUCKET_DURATION_SECONDS * 1000000000;
-    
+
     @Override
-    public void bootstrap(List<IOFMessageListener> listeners) {
-            ctb = new CumulativeTimeBucket(listeners);
+    public void bootstrap() {
+        ctb = new CumulativeTimeBucket();
     }
-    
+
+    @Override
+    public void addListener(IOFMessageListener listener) {
+        ctb.addListener(listener);
+    }
+
     @Override
     public boolean isEnabled() {
         return isEnabled;
@@ -110,7 +115,8 @@ public class PktInProcessingTime
     @Override
     public void setEnabled(boolean enabled) {
     	if(enabled){
-    		bootstrap(floodlightProvider.getListeners().get(OFType.PACKET_IN));
+//    		bootstrap(floodlightProvider.getListeners().get(OFType.PACKET_IN));
+            bootstrap();
     	}
         this.isEnabled = enabled;
         logger.debug("Setting module to " + isEnabled);

--- a/src/main/java/net/floodlightcontroller/perfmon/PktInProcessingTime.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/PktInProcessingTime.java
@@ -99,7 +99,9 @@ public class PktInProcessingTime
 
     @Override
     public void bootstrap() {
-        ctb = new CumulativeTimeBucket();
+        if (ctb == null) {
+            ctb = new CumulativeTimeBucket();
+        }
     }
 
     @Override

--- a/src/main/java/net/floodlightcontroller/perfmon/PktInProcessingTime.java
+++ b/src/main/java/net/floodlightcontroller/perfmon/PktInProcessingTime.java
@@ -117,7 +117,6 @@ public class PktInProcessingTime
     @Override
     public void setEnabled(boolean enabled) {
     	if(enabled){
-//    		bootstrap(floodlightProvider.getListeners().get(OFType.PACKET_IN));
             bootstrap();
     	}
         this.isEnabled = enabled;


### PR DESCRIPTION
@rizard @geddings 
This pull request fixed:
1) StartTime now is correctly 2) Previously this module only monitor one OF packet performance and reset the counter, which doesn't make sense at all as it is designed for "cumulative time bucket" -- Now it count all OF packets and computes the performance metrics(i.e. avg time in a cumulative amount of time). 3) Also rewrite the REST API.

Please let me know your thoughts, thanks! 