### PR TITLE
Add setup table default flows toggle

### DIFF
--- a/src/main/java/net/floodlightcontroller/core/internal/OFSwitchHandshakeHandler.java
+++ b/src/main/java/net/floodlightcontroller/core/internal/OFSwitchHandshakeHandler.java
@@ -1366,8 +1366,10 @@ public class OFSwitchHandshakeHandler implements IOFConnectionListener {
 				clearAllTables();
 			}
 
-			sendBarrier(); /* Need to make sure the tables are clear before adding default flows */
-			addDefaultFlows();
+			if (OFSwitchManager.setupTablesDefaultFlows) {
+				sendBarrier(); /* Need to make sure the tables are clear before adding default flows */
+				addDefaultFlows();
+			}
 
 			/*
 			 * We also need a barrier between adding flows and notifying modules of the

--- a/src/test/java/net/floodlightcontroller/core/internal/OFSwitchHandlerTestBase.java
+++ b/src/test/java/net/floodlightcontroller/core/internal/OFSwitchHandlerTestBase.java
@@ -486,7 +486,7 @@ public abstract class OFSwitchHandlerTestBase {
 	 * @param role The role to send
 	 * @throws IOException
 	 */
-	private long setupSwitchSendRoleRequestAndVerify(Boolean supportsNxRole,
+	protected long setupSwitchSendRoleRequestAndVerify(Boolean supportsNxRole,
 			OFControllerRole role) throws IOException {
 		assertTrue("This internal test helper method most not be called " +
 				"with supportsNxRole==false. Test setup broken",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Setup table default flows is a part of switch handshake process. But
there are cases when we must not alter switch behaviour(set of installed
OF flows). To "cover" such scenarios new boolean option
"setupTablesDefaultFlows" was added for module
net.floodlightcontroller.core.internal.OFSwitchManager.

It it set to "YES" (default), FL will setup table's default rules on
transition to master state(same as current). If it set to "NO", FL will
not setup table's default flows.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New functionality is covered by unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
