### PR TITLE
Generic Multicasting Module

### DIFF
--- a/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
+++ b/src/main/java/net/floodlightcontroller/forwarding/Forwarding.java
@@ -17,6 +17,7 @@
 
 package net.floodlightcontroller.forwarding;
 
+import java.math.BigInteger;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,6 +50,12 @@ import net.floodlightcontroller.util.*;
 
 import org.projectfloodlight.openflow.protocol.*;
 import org.projectfloodlight.openflow.protocol.action.OFAction;
+import org.projectfloodlight.openflow.protocol.action.OFActionGroup;
+import org.projectfloodlight.openflow.protocol.action.OFActionOutput;
+import org.projectfloodlight.openflow.protocol.action.OFActions;
+import org.projectfloodlight.openflow.protocol.instruction.OFInstruction;
+import org.projectfloodlight.openflow.protocol.instruction.OFInstructionApplyActions;
+import org.projectfloodlight.openflow.protocol.instruction.OFInstructions;
 import org.projectfloodlight.openflow.protocol.match.Match;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.protocol.oxm.OFOxms;
@@ -90,7 +97,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
     private static final short DECISION_SHIFT = 0;
     private static final long DECISION_MASK = ((1L << DECISION_BITS) - 1) << DECISION_SHIFT;
 
-    private static final short FLOWSET_BITS = 28;
+    private static final short FLOWSET_BITS = 24; // usable bits from OFPG_MAX
     protected static final short FLOWSET_SHIFT = DECISION_BITS;
     private static final long FLOWSET_MASK = ((1L << FLOWSET_BITS) - 1) << FLOWSET_SHIFT;
     private static final long FLOWSET_MAX = (long) (Math.pow(2, FLOWSET_BITS) - 1);
@@ -220,8 +227,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                     return Command.CONTINUE;
 
                 case MULTICAST:
-                    // treat as broadcast
-                    doFlood(sw, pi, decision, cntx);
+                    doMulticast(sw, pi, decision, cntx, false);
                     return Command.CONTINUE;
 
                 case DROP:
@@ -237,7 +243,7 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
         else { // No routing decision was found
             switch(determineRoutingType()) {
                 case FORWARDING:
-                    // L2 Forward to destination or flood if bcast or mcast
+                    // L2 Forward to destination or doMulticast if mcast or flood if bcast
                     if (log.isTraceEnabled()) {
                         log.trace("No decision was made for PacketIn={}, do L2 forwarding", pi);
                     }
@@ -314,15 +320,6 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
 
         MacAddress gatewayMac = gatewayInstance.getGatewayMac();
 
-        if (eth.getEtherType() == EthType.IPv4) {
-            IPv4Address intfIpAddress = findInterfaceIP(gatewayInstance, ((IPv4) eth.getPayload()).getDestinationAddress());
-            if (intfIpAddress == null) {
-                log.debug("Can not locate corresponding interface for gateway {}, check its interface configuration",
-                        gatewayInstance.getName());
-                return;
-            }
-        }
-
         if (isBroadcastOrMulticast(eth)) {
             // When cross-subnet, host send ARP request to gateway. Gateway need to generate ARP response to host
             if (eth.getEtherType() == EthType.ARP && ((ARP) eth.getPayload()).getOpCode().equals(ARP.OP_REQUEST)
@@ -332,11 +329,26 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
                 log.debug("Virtual gateway pushing ARP reply message to source host");
             }
             else {
-                doFlood(sw, pi, decision, cntx);
+                if (eth.isMulticast()) {
+            		// Notice that there's no check for incoming interface address as it's a multicast address
+            		doMulticast(sw, pi, decision, cntx, true);
+            	}
+            	else {
+            		doFlood(sw, pi, decision, cntx);
+            	}
             }
         }
         else {
-            // This also includes L2 forwarding
+            if (eth.getEtherType() == EthType.IPv4) {
+                IPv4Address intfIpAddress = findInterfaceIP(gatewayInstance, ((IPv4) eth.getPayload()).getDestinationAddress());
+                if (intfIpAddress == null) {
+                    log.debug("Can not locate corresponding interface for gateway {}, check its interface configuration",
+                            gatewayInstance.getName());
+                    return;
+                }
+            }
+        	
+        	// This also includes L2 forwarding
             doL3ForwardFlow(sw, pi, decision, cntx, gatewayInstance, false);
         }
 
@@ -521,6 +533,662 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
     }
 
     /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * This function retrieves a patch from source device to destination devices in multicast group and then 
+     * install flows(L3/L2) over the path.
+     * In L3 case, virtual router replaces source mac with outgoing interface gateway mac.
+     * 
+     * @param sw Switch
+     * @param pi Packet-in
+     * @param decision Decision for packet
+     * @param cntx The FloodlightContext associated with this OFPacketIn
+     * 
+     * @return
+     */
+    private void doMulticast(IOFSwitch sw, OFPacketIn pi, IRoutingDecision decision, FloodlightContext cntx,
+    		boolean isL3) {	
+    	Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
+    	OFPort inPort = OFMessageUtils.getInPort(pi);
+        DatapathId curSwId = sw.getId();
+        IDevice srcDevice = IDeviceService.fcStore.get(cntx, IDeviceService.CONTEXT_SRC_DEVICE);
+        
+        if (srcDevice == null) {
+            log.error("No device entry found for source device. Is the device manager running? If so, report bug.");
+            return;
+        }
+
+        /* Some physical switches partially support or do not support ARP flows */
+        if (FLOOD_ALL_ARP_PACKETS &&
+        		eth.getEtherType() == EthType.ARP) {
+            log.debug("ARP flows disabled in Forwarding. Flooding ARP packet");
+            doFlood(sw, pi, decision, cntx);
+            return;
+        }
+
+        /* This packet-in is from a switch in the path before its flow was installed along the path */
+        if (!topologyService.isEdge(curSwId, inPort)) {
+            log.debug("Packet destination is known, but packet was not received on an edge port (rx on {}/{}). " + 
+            		"Flooding packet", curSwId, inPort);
+            doFlood(sw, pi, decision, cntx);
+            return;
+        }
+
+        if (eth.getEtherType().equals(EthType.IPv4) ||
+        		eth.getEtherType().equals(EthType.IPv6))
+        {
+        	U64 flowSetId = flowSetIdRegistry.generateFlowSetId();
+        	U64 cookie = makeForwardingCookie(decision, flowSetId);
+        	
+        	IPAddress<?> dstIp;
+        	if (eth.getEtherType().equals(EthType.IPv4)) {
+        		dstIp = ((IPv4) eth.getPayload()).getDestinationAddress();
+        	}
+        	else {
+        		dstIp = ((IPv6) eth.getPayload()).getDestinationAddress();
+        	}
+        			
+        	BigInteger mgId = MulticastUtils.MgIdFromMcastIP(dstIp);
+
+			MulticastPath mPath = routingEngineService.getMulticastPath(curSwId, mgId);
+
+	        if (! mPath.isEmpty()) {
+	        	Match m = createMatchFromPacket(sw, inPort, pi, cntx);
+	        	
+	            if (log.isDebugEnabled()) {
+	                log.debug("pushRouteMF swId={} inPort={} destination={}({})",
+	                        new Object[] { curSwId, inPort, dstIp, mgId});
+	                log.debug("Creating flow rules on the route, match rule: {}", m);
+	            }
+
+	            pushMulticastPath(mPath, m, pi, sw.getId(), inPort, cookie,
+	                    cntx, OFFlowModCommand.ADD, isL3);
+
+	            /*
+	             * Register this flowset with ingress and egress ports for link down
+	             * flow removal. This is done after we push the path as it is blocking.
+	             */
+	            for (Path path: mPath.getAllPaths()) {
+	            	for (NodePortTuple npt: path.getPath()) {
+	            		flowSetIdRegistry.registerFlowSetId(npt, flowSetId);
+	            	}
+	            	DatapathId dstSwId = path.getId().getDst();
+            		for (OFPort port: mPath.getApPorts(dstSwId)) {
+            			NodePortTuple npt = new NodePortTuple(dstSwId, port);
+            			flowSetIdRegistry.registerFlowSetId(npt, flowSetId);
+            		}
+	            }
+			} /* else no path was found */
+	        else {
+                log.debug("Flooding because path doesn't exist for swId={} inPort={}" +
+                        "destination={}({})",
+                new Object[] { curSwId, inPort,
+                		dstIp, mgId});
+                doFlood(sw, pi, decision, cntx);
+	        }
+        }
+        else {
+        	// Default action
+        	doFlood(sw, pi, decision, cntx);
+        }
+	}
+    
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Push multicast paths to destined switches
+     * 
+     * @param mPath Multicast Path to push
+     * @param match OpenFlow fields to match on
+     * @param pi PacketIn packet
+     * @param srcSwId Source switch dpid
+     * @param srcPort Source port
+     * @param cookie The cookie to set in each flow_mod
+     * @param cntx The floodlight context
+     * @param requestFlowRemovedNotification if set to true then the switch would
+     *        send a flow mod removal notification when the flow mod expires
+     * @param flowModCommand flow mod. command to use, e.g. OFFlowMod.OFPFC_ADD,
+     *        OFFlowMod.OFPFC_MODIFY etc.
+     *        
+     * @return true on success
+     */
+	public boolean pushMulticastPath(MulticastPath mPath, Match match, OFPacketIn pi,
+            DatapathId srcSwId, OFPort srcPort, U64 cookie, FloodlightContext cntx,
+            OFFlowModCommand flowModCommand, boolean isL3) {
+        Map<DatapathId, Set<OFPort>> swOutPorts = new HashMap<DatapathId, Set<OFPort>>();
+        Map<DatapathId, OFPort> swInPort = new HashMap<DatapathId, OFPort>();
+        List<DatapathId> swIdList = new LinkedList<DatapathId>();
+        
+        /*
+         *  Map inPort, outPorts and attachmentPoint (edge) ports
+         *  per switch from switchPortList per path in mPath
+         */
+        for (Path path: mPath.getAllPaths()) {
+        	List<NodePortTuple> switchPortList = path.getPath();
+        	for (int index = 0; index < switchPortList.size() - 1; index += 2) {
+    			NodePortTuple input = switchPortList.get(index + 1);
+    			NodePortTuple output = switchPortList.get(index);
+    			DatapathId inputSwId = input.getNodeId();
+    			DatapathId outputSwId = output.getNodeId();
+    			OFPort inputPort =  input.getPortId();
+    			OFPort outputPort =  output.getPortId();
+    			
+                // Add to inPort map
+            	swInPort.put(inputSwId, inputPort);
+            	
+            	// Add to outPorts map
+        		Set<OFPort> outPorts = swOutPorts.get(outputSwId);
+        		if (outPorts == null) {
+        			outPorts = new HashSet<OFPort>();
+        			swOutPorts.put(outputSwId, outPorts);
+        		}
+        		outPorts.add(outputPort);
+        		
+        		// Add to swList (O(1))
+        		swIdList.add(0, inputSwId);	
+            }
+        	
+        	// Add attachmentPoint (edge) ports to swOutPorts
+        	DatapathId dstSwId = path.getId().getDst();
+        	Set<OFPort> outPorts = swOutPorts.get(dstSwId);
+        	if (outPorts == null) {
+        		outPorts = new HashSet<OFPort>();
+        		swOutPorts.put(dstSwId, outPorts);
+        	}
+        	outPorts.addAll(mPath.getApPorts(dstSwId));
+        }
+        // Add flow entry point at the last
+        swInPort.put(srcSwId, srcPort);
+        swIdList.add(srcSwId);
+        
+        /*
+         *  Both swInPort and swOutPorts must have same keyset of switches
+         *  A switch without either of them makes the entire path invalid.
+         */
+        if (!swInPort.keySet().equals(swOutPorts.keySet())) {
+            if (log.isErrorEnabled()) {
+                log.error("Unable to push multicast route, broken path");
+            }
+            return false;
+        }
+        
+        /* 
+         * Build messages for switches
+         */
+        for (DatapathId swId: swIdList) {
+			IOFSwitch sw =  switchService.getSwitch(swId);
+            if (sw == null) {
+                if (log.isErrorEnabled()) {
+                    log.error("Unable to push multicast route, switch at DPID {} " +
+                "not available", sw);
+                }
+                return false;
+            }
+            List<OFMessage> msgList = new ArrayList<OFMessage>();
+        	
+            // Get inPort, edgePorts, outPorts of the switch
+            OFPort inPort = swInPort.get(swId);
+            Set<OFPort> outPorts = swOutPorts.get(swId);
+            Set<OFPort> edgePorts = mPath.getApPorts(swId);
+            if (log.isTraceEnabled()) {
+                log.trace(String.format("pushMulticastPath: Switch: {s%d}, inPort: {%s}, " +
+                		" outPorts: {%s}", 
+                		sw.getId().getLong(), inPort, outPorts));
+            }
+            
+            // Filter FlowModCommand & Create GroupModCommand
+            OFGroupModCommand groupModCommand;
+            switch(flowModCommand) {
+            case DELETE_STRICT:
+            	flowModCommand = OFFlowModCommand.DELETE;
+            case DELETE:
+            	groupModCommand = OFGroupModCommand.DELETE;
+            	break;
+            case MODIFY_STRICT:
+            case MODIFY:
+        		flowModCommand = OFFlowModCommand.ADD;
+            case ADD:
+            default:
+            	groupModCommand = OFGroupModCommand.ADD;
+                break;
+            }
+            
+            // Build PacketOut message (for edge destinations)
+            if (!edgePorts.isEmpty()) {
+	            if (isL3) {
+		            Optional<VirtualGatewayInstance> simpleGatewayInstance = 
+		            		getGatewayInstance(swId);
+		            if (simpleGatewayInstance.isPresent()) {
+		            	MacAddress simpleGatewayMac = simpleGatewayInstance.get()
+		            			.getGatewayMac();
+		                OFPacketOut packetOutMsg = createMulticastPacketOutMsg(sw, edgePorts, 
+		                		pi, cntx, simpleGatewayMac);
+		                if (packetOutMsg == null) {
+		                    if (log.isErrorEnabled()) {
+		                        log.error("Switch at DPID {} " +
+		                    "failed to create Multicast PacketOut message", sw);
+		                    }
+		                    return false;
+		                }
+		            	msgList.add(packetOutMsg);
+		            }
+		            else {
+		            	for (OFPort edgePort: edgePorts) {
+		            		Optional<VirtualGatewayInstance> gatewayInstance = 
+		            				getGatewayInstance(new NodePortTuple(swId, edgePort));
+		            		if (gatewayInstance.isPresent()) {
+		            			MacAddress gatewayMac = gatewayInstance.get().getGatewayMac();
+		                        OFPacketOut packetOutMsg = createMulticastPacketOutMsg(sw, 
+		                        		new HashSet<OFPort>(Arrays.asList(edgePort)), pi, cntx, 
+		                        		gatewayMac);
+		                        if (packetOutMsg == null) {
+		                            if (log.isErrorEnabled()) {
+		                                log.error("Switch at DPID {} " +
+		                            "failed to create Multicast PacketOut message", sw);
+		                            }
+		                            return false;
+		                        }
+		                    	msgList.add(packetOutMsg);
+		            		}
+		            	}
+		            }
+	            }
+	            else {
+	                OFPacketOut packetOutMsg = createMulticastPacketOutMsg(sw, edgePorts, 
+	                		pi, cntx, MacAddress.NONE);
+	                if (packetOutMsg == null) {
+	                    if (log.isErrorEnabled()) {
+	                        log.error("Switch at DPID {} " +
+	                    "failed to create Multicast PacketOut message", sw);
+	                    }
+	                    return false;
+	                }
+	            	msgList.add(packetOutMsg);
+	            }
+            }
+            
+            // Build GroupMod message
+            if (!groupModCommand.equals(OFGroupModCommand.DELETE)) {
+            	// First Delete Group to prevent GROUP_EXISTS error messages on Add Group
+                OFGroupMod groupModMsg = createMulticastGroupModMsg(sw, null, 
+                		cookie, OFGroupModCommand.DELETE, false);
+                if (groupModMsg == null) {
+                    if (log.isErrorEnabled()) {
+                        log.error("Switch at DPID {} " +
+                    "failed to create Multicast Group Mod message", sw);
+                    }
+                    return false;
+                }
+            	msgList.add(groupModMsg);
+            }
+            OFGroupMod groupModMsg = createMulticastGroupModMsg(sw, outPorts, 
+            		cookie, groupModCommand, isL3);
+            if (groupModMsg == null) {
+                if (log.isErrorEnabled()) {
+                    log.error("Switch at DPID {} " +
+                "failed to create Multicast Group Mod message", sw);
+                }
+                return false;
+            }
+        	msgList.add(groupModMsg);
+            
+            // Build FlowMod message
+        	if (!flowModCommand.equals(OFFlowModCommand.DELETE)) {
+        		// First Delete Flow to force FLOW_REMOVED required to 
+        		// sync Groups associated with flow.
+        		// Note that this wouldn't remove our current group because
+        		// it will ALWAYS have a different flowSetId/groupId and 
+        		// OFFlowDelete operation doesn't require cookie/flowSetId
+                OFFlowMod flowModMsg = createMulticastFlowModMsg(sw, inPort, match, 
+                		null, OFFlowModCommand.DELETE);
+                if (flowModMsg == null) {
+                    if (log.isErrorEnabled()) {
+                        log.error("Switch at DPID {} " +
+                    "failed to create Multicast Flow Mod message", sw);
+                    }
+                    return false;
+                }
+            	msgList.add(flowModMsg);
+        	}
+            OFFlowMod flowModMsg = createMulticastFlowModMsg(sw, inPort, match, 
+            		cookie, flowModCommand);
+            if (flowModMsg == null) {
+                if (log.isErrorEnabled()) {
+                    log.error("Switch at DPID {} " +
+                    		"failed to create Multicast Flow Mod message", sw);
+                }
+                return false;
+            }
+        	msgList.add(flowModMsg);
+	        
+            // Write msgList to switch
+        	// TODO: Fix OFMessageDamper for list of messages
+            if (!sw.write(msgList).isEmpty()) {
+                if (log.isErrorEnabled()) {
+                    log.error("Some message(s) couldn't be sent to switch at DPID {} " + 
+                    		"due to channel disconnect", sw);
+                }
+                return false;
+            }
+        }
+        
+        return true;
+    }
+	
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Create Multicast Group Mod for the Switch
+     * 
+     * @param sw Switch to send message to
+     * @param outPorts Output ports of the switch
+     * @param cookie The cookie to set in each flow_mod
+     * @param groupModCommand group mod. command to use, e.g. OFPGC_ADD,
+     *        OFPGC_MODIFY, OFPGC_DELETE etc.
+     * @param isL3 If L3 is enabled
+     *        
+     * @return
+     */
+	protected OFGroupMod createMulticastGroupModMsg(IOFSwitch sw, Set<OFPort> outPorts, 
+			U64 cookie, OFGroupModCommand groupModCommand, boolean isL3) {
+		DatapathId swId = sw.getId();
+        OFFactory factory = sw.getOFFactory();
+        OFActions factoryActions = factory.actions();
+        OFVersion factoryVersion = factory.getVersion();
+        
+        // Prepare GroupModBuilder
+        OFGroupMod.Builder groupModBuilder;
+        switch (groupModCommand) {
+        case DELETE:
+        	groupModBuilder = factory.buildGroupDelete();
+            break;
+        default:
+            log.error("Could not decode OFGroupModCommand. Using ADD. " +
+        			"(Should another be used as the default?)");        
+        case MODIFY:
+        case ADD:
+        	groupModBuilder = factory.buildGroupAdd();
+            break;
+        }
+        
+        // Calculate GroupId
+        int groupId = (int) ((AppCookie.extractUser(cookie) & FLOWSET_MASK) >> 
+    				(FLOWSET_SHIFT - 8)); // 24 flowset bits + 8 bit padding = 32 bit
+        OFGroup group = OFGroup.of(groupId);
+        
+        // Set Identifier
+        OFGroupType groupType = OFGroupType.ALL;
+        groupModBuilder.setXid(0)
+        .setGroup(group)
+        .setGroupType(groupType);
+        
+        if (!groupModBuilder.getCommand().equals(OFGroupModCommand.DELETE)) {
+        	// Prepare Bucket List
+        	List<OFBucket> bucketList = new ArrayList<OFBucket>();
+        	
+	        for (OFPort outPort: outPorts) {
+	        	MacAddress gatewayMac = MacAddress.NONE;
+	        	if (isL3) {
+		            Optional<VirtualGatewayInstance> gatewayInstance = getGatewayInstance(swId);
+		            if (!gatewayInstance.isPresent()) {
+		            	gatewayInstance = getGatewayInstance(new NodePortTuple(swId, outPort));
+		            }
+		        	if (gatewayInstance.isPresent()) {
+		        		gatewayMac = gatewayInstance.get().getGatewayMac();
+		        	}
+	        	}
+	        	
+	        	// Prepare Action List
+	        	List<OFAction> actions = new ArrayList<>();
+	        	
+	            OFActionOutput.Builder aob = factoryActions.buildOutput();
+	            aob.setMaxLen(Integer.MAX_VALUE);
+	            aob.setPort(outPort);
+	            actions.add(aob.build());
+	            
+	            if (!gatewayMac.equals(MacAddress.NONE)) {
+	                switch (factoryVersion) {
+	                    case OF_10:
+	                    case OF_11:
+	                        actions.add(factoryActions.setDlSrc(gatewayMac));
+	                        break;
+	                    case OF_12:
+	                    case OF_13:
+	                    case OF_14:
+	                    case OF_15:
+	                        actions.add(factoryActions.setField(factory.oxms().ethSrc(gatewayMac)));
+	                        break;
+	                    default:
+	                        break;
+	                }
+	    		}
+	            
+	            // Update Bucket List
+	            OFBucket myBucket = factory.buildBucket()
+	            	    .setActions(actions)
+	            	    .setWatchGroup(OFGroup.ANY)
+	            	    .setWatchPort(OFPort.ANY)
+	            	    .build();
+	            bucketList.add(myBucket);
+	        }
+	        
+	        // Update GroupModBuilder
+	        groupModBuilder.setBuckets(bucketList);
+        }
+        
+        // Create GroupMod
+        OFGroupMod groupMod = groupModBuilder.build();
+        
+        return groupMod;
+	}
+	
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Create Multicast Flow Mod for the Switch
+     * 
+     * @param sw Switch to p
+     * @param inPort Input port of the switch
+     * @param match OpenFlow fields to match on
+     * @param cookie The cookie to set in each flow_mod
+     * @param flowModCommand flow mod. command to use, e.g. OFFlowMod.OFPFC_ADD,
+     *        OFFlowMod.OFPFC_MODIFY etc.
+     *        
+     * @return
+     */
+    private OFFlowMod createMulticastFlowModMsg(IOFSwitch sw, OFPort inPort, Match match, 
+    		U64 cookie, OFFlowModCommand flowModCommand) {
+        OFFactory factory = sw.getOFFactory();
+        OFActions factoryActions = factory.actions();
+        OFVersion factoryVersion = factory.getVersion();
+        OFInstructions factoryInstructions = factory.instructions();
+    	
+    	// Prepare FlowModBuilder
+        OFFlowMod.Builder flowModBuilder;
+        switch (flowModCommand) {
+        case DELETE_STRICT:
+        case DELETE:
+        	flowModBuilder = factory.buildFlowDelete();
+            break;
+        default:
+            log.error("Could not decode OFFlowModCommand. Using ADD. " +
+        			"(Should another be used as the default?)");        
+        case MODIFY:
+        case MODIFY_STRICT:
+        case ADD:
+        	flowModBuilder = factory.buildFlowAdd();
+            break;
+        }
+        
+        // Prepare Match
+        Match.Builder matchBuilder = MatchUtils.convertToVersion(match, factoryVersion);
+        if (FLOWMOD_DEFAULT_MATCH_IN_PORT) {
+        	matchBuilder.setExact(MatchField.IN_PORT, inPort);
+        }
+        match = matchBuilder.build();
+        
+        // Set FlowMod Identifier
+        flowModBuilder.setXid(0)
+        .setMatch(match)
+        .setPriority(FLOWMOD_DEFAULT_PRIORITY)
+        .setCookieMask(U64.ZERO);
+        
+        if (factoryVersion.compareTo(OFVersion.OF_10) != 0) {
+        	flowModBuilder.setTableId(FLOWMOD_DEFAULT_TABLE_ID);
+        }
+        
+        if (flowModBuilder.getCommand().equals(OFFlowModCommand.DELETE)) {
+        	flowModBuilder.setCookie(U64.ZERO)
+        	.setOutPort(OFPort.ANY)
+        	.setOutGroup(OFGroup.ANY);
+        }
+        else {
+	        // Calculate GroupId
+            int groupId = (int) ((AppCookie.extractUser(cookie) & FLOWSET_MASK) >> 
+        				(FLOWSET_SHIFT - 8)); // 24 flowset bits + 8 bit padding = 32 bit
+            OFGroup group = OFGroup.of(groupId);
+	        
+	        // Prepare Actions
+	        List<OFAction> actionList = new ArrayList<>();
+	        OFActionGroup ofActionGroup = factoryActions.buildGroup()
+	        		.setGroup(group)
+	        		.build();
+			actionList.add(ofActionGroup);
+	        
+			// Prepare Instructions by adding actionList to instructionApplyActions
+			ArrayList<OFInstruction> instructions = new ArrayList<>();
+			OFInstructionApplyActions instructionApplyActions = 
+					factoryInstructions.buildApplyActions()
+				    .setActions(actionList)
+				    .build();
+			instructions.add(instructionApplyActions);
+			
+			// Update FlowModBuilder
+			flowModBuilder
+			.setActions(actionList)
+			.setInstructions(instructions)
+	        .setCookie(cookie)
+	        .setIdleTimeout(FLOWMOD_DEFAULT_IDLE_TIMEOUT)
+	        .setHardTimeout(FLOWMOD_DEFAULT_HARD_TIMEOUT)
+	        .setBufferId(OFBufferId.NO_BUFFER);
+			
+	        Set<OFFlowModFlags> flags = new HashSet<>();
+	        flags.add(OFFlowModFlags.SEND_FLOW_REM);
+	        flags.add(OFFlowModFlags.CHECK_OVERLAP);
+	        flowModBuilder.setFlags(flags);
+        }
+    	
+        // Create FlowMod
+    	OFFlowMod flowMod = flowModBuilder.build();
+    	
+    	return flowMod;
+	}
+    
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Create Multicast Packet Out for the Switch
+     * 
+     * @param sw switch that generated the packet-in, and from which packet-out is sent
+     * @param edgePorts attachment point (edge) ports
+     * @param pi packet-in
+     * @param cntx context of the packet
+     * @param gatewayMac MacAddress of the Gateway Interface
+     * 
+     * @return
+     */
+    protected OFPacketOut createMulticastPacketOutMsg(IOFSwitch sw, Set<OFPort> edgePorts, 
+    		OFPacketIn pi, FloodlightContext cntx, MacAddress gatewayMac) {
+        if (pi == null || edgePorts.isEmpty()) {
+            return null;
+        }
+        
+        OFFactory factory = sw.getOFFactory();
+        OFPacketOut.Builder pob = factory.buildPacketOut();
+        pob.setXid(pi.getXid());
+        List<OFAction> actions = new ArrayList<>();
+        for (OFPort edgePort: edgePorts) {
+        	actions.add(factory.actions().output(edgePort, Integer.MAX_VALUE));
+        }
+        pob.setActions(actions);
+
+        /* 
+         * If gateway interface is present, then force NO_BUFFER
+         * and change sourceMac to gatewayMac in PacketIn.
+         */
+    	if (gatewayMac.equals(MacAddress.NONE)) {
+    		pob.setBufferId(pi.getBufferId()); /* will be NO_BUFFER if there isn't one */
+    	}
+    	else {
+    		pob.setBufferId(OFBufferId.NO_BUFFER);
+    		
+    		Ethernet eth = IFloodlightProviderService.bcStore
+    			.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
+			eth.setSourceMACAddress(gatewayMac);
+        	OFPacketIn.Builder pib = pi.createBuilder();
+        	pib.setData(eth.serialize());
+        	pi = pib.build();
+    	}
+
+        if (pob.getBufferId().equals(OFBufferId.NO_BUFFER)) {
+            byte[] packetData = pi.getData();
+            pob.setData(packetData);
+        }
+
+        OFMessageUtils.setInPort(pob, OFMessageUtils.getInPort(pi));
+        
+        return pob.build();
+    }
+    
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Processes flow removed message
+     * 
+     * @param sw switch
+     * @param fr flowRemoved packet
+     * @param cntx The FloodlightContext associated with this OFPacketIn
+     * 
+     * @return
+     */
+	@Override
+	public Command processFlowRemovedMessage(IOFSwitch sw, OFFlowRemoved fr, 
+			FloodlightContext cntx) {
+		Match match = fr.getMatch();
+		
+		/* 
+		 * Delete GroupMod if a FlowMod is removed 
+		 * with destinationIp as a multicast address
+		 */
+		IPAddress<?> dstIp = match.get(MatchField.IPV4_DST);
+		if (dstIp == null) {
+			dstIp = match.get(MatchField.IPV6_DST);
+		}
+		if (dstIp != null &&
+				dstIp.isMulticast()) {
+			U64 cookie = fr.getCookie();
+			OFGroupMod groupModMsg = createMulticastGroupModMsg(sw, null, cookie, 
+					OFGroupModCommand.DELETE, false);
+	        if (groupModMsg == null) {
+	            if (log.isErrorEnabled()) {
+	                log.error("Switch at DPID {} " +
+	                		"failed to create Multicast Group Mod message", sw);
+	            }
+	        }
+	        else {
+	        	if (!sw.write(groupModMsg)) {
+	                if (log.isErrorEnabled()) {
+	                    log.error("Message couldn't be sent to switch at DPID {} " + 
+	                    		"due to channel disconnect", sw);
+	                }
+	        	}
+	        }
+		}
+
+		return Command.CONTINUE;
+	}
+    
+	/**
      * Virtual gateway insert flows on switch to rewrite source MAC to gateway MAC, also rewrite destination MAC
      * to destination host.
      *
@@ -611,9 +1279,13 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
      * @param cntx The FloodlightContext associated with this OFPacketIn
      */
     protected void doL2Forwarding(Ethernet eth, IOFSwitch sw, OFPacketIn pi, IRoutingDecision decision, FloodlightContext cntx) {
-        if (isBroadcastOrMulticast(eth)) {
+        if (eth.isBroadcast()) {
             doFlood(sw, pi, decision, cntx);
-        } else {
+        }
+        else if (eth.isMulticast()) {
+            doMulticast(sw, pi, decision, cntx, false);
+        }
+        else {
             doL2ForwardFlow(sw, pi, decision, cntx, false);
         }
     }
@@ -1894,6 +2566,4 @@ public class Forwarding extends ForwardingBase implements IFloodlightModule, IOF
         log.error("Could not locate a 'true' attachment point in {}", aps);
         return null;
     }
-
-
 }

--- a/src/main/java/net/floodlightcontroller/multicasting/IMulticastListener.java
+++ b/src/main/java/net/floodlightcontroller/multicasting/IMulticastListener.java
@@ -1,0 +1,24 @@
+package net.floodlightcontroller.multicasting;
+
+import org.projectfloodlight.openflow.types.IPAddress;
+
+import net.floodlightcontroller.core.types.MacVlanPair;
+import net.floodlightcontroller.core.types.NodePortTuple;
+
+/**
+ * @author Souvik Das (souvikdas95@yahoo.co.in)
+ * 
+ * Listener Interface for Multicasting
+ * 
+ */ 
+public interface IMulticastListener {
+	void ParticipantAdded(IPAddress<?> group, MacVlanPair intf, NodePortTuple ap);
+	
+	void ParticipantRemoved(IPAddress<?> group, MacVlanPair intf, NodePortTuple ap);
+	
+	void ParticipantGroupRemoved(IPAddress<?> group);
+	
+	void ParticipantIntfRemoved(MacVlanPair intf);
+	
+	void ParticipantsReset();
+}

--- a/src/main/java/net/floodlightcontroller/multicasting/IMulticastService.java
+++ b/src/main/java/net/floodlightcontroller/multicasting/IMulticastService.java
@@ -1,0 +1,47 @@
+package net.floodlightcontroller.multicasting;
+
+import java.util.Set;
+
+import org.projectfloodlight.openflow.types.IPAddress;
+
+import net.floodlightcontroller.core.module.IFloodlightService;
+import net.floodlightcontroller.core.types.MacVlanPair;
+import net.floodlightcontroller.core.types.NodePortTuple;
+
+/**
+ * @author Souvik Das (souvikdas95@yahoo.co.in)
+ * 
+ * Service Interface for Multicasting
+ * 
+ */ 
+public interface IMulticastService extends IFloodlightService {
+	public void addParticipant(IPAddress<?> group, MacVlanPair intf, NodePortTuple ap);
+	
+	public void removeParticipant(IPAddress<?> group, MacVlanPair intf, NodePortTuple ap);
+	
+	public boolean hasParticipant(IPAddress<?> group, MacVlanPair intf);
+	
+	public Set<NodePortTuple> getParticipantAP(IPAddress<?> group, MacVlanPair intf);
+	
+	public Set<MacVlanPair> getParticipantIntfs(IPAddress<?> group);
+	
+	public Set<IPAddress<?>> getParticipantGroups(MacVlanPair intf);
+	
+	public Set<MacVlanPair> getAllParticipantIntfs();
+	
+	public Set<IPAddress<?>> getAllParticipantGroups();
+	
+	public boolean hasParticipantIntf(MacVlanPair intf);
+	
+	public boolean hasParticipantGroup(IPAddress<?> group);
+	
+	public void deleteParticipantGroup(IPAddress<?> group);
+	
+	public void deleteParticipantIntf(MacVlanPair intf);
+	
+	public void clearAllParticipants();
+	
+    public void addListener(IMulticastListener listener);
+
+    public void removeListener(IMulticastListener listener);
+}

--- a/src/main/java/net/floodlightcontroller/multicasting/internal/MulticastManager.java
+++ b/src/main/java/net/floodlightcontroller/multicasting/internal/MulticastManager.java
@@ -1,0 +1,317 @@
+package net.floodlightcontroller.multicasting.internal;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.IPAddress;
+import org.projectfloodlight.openflow.types.MacAddress;
+import org.projectfloodlight.openflow.types.VlanVid;
+
+import net.floodlightcontroller.core.IFloodlightProviderService;
+import net.floodlightcontroller.core.module.FloodlightModuleContext;
+import net.floodlightcontroller.core.module.FloodlightModuleException;
+import net.floodlightcontroller.core.module.IFloodlightModule;
+import net.floodlightcontroller.core.module.IFloodlightService;
+import net.floodlightcontroller.core.types.MacVlanPair;
+import net.floodlightcontroller.core.types.NodePortTuple;
+import net.floodlightcontroller.devicemanager.IDevice;
+import net.floodlightcontroller.devicemanager.IDeviceListener;
+import net.floodlightcontroller.devicemanager.IDeviceService;
+import net.floodlightcontroller.multicasting.IMulticastListener;
+import net.floodlightcontroller.multicasting.IMulticastService;
+import net.floodlightcontroller.topology.ITopologyService;
+
+/**
+ * @author Souvik Das (souvikdas95@yahoo.co.in)
+ * 
+ * MulticastManager is only a service gateway between ParticipantTable
+ * in Multicast Service and the MulticastGroups & MulticastPaths in 
+ * Topology Service.
+ * 
+ */
+public class MulticastManager implements IFloodlightModule, IMulticastService, IDeviceListener {
+	
+    /**
+     * Table contains multicast group membership information
+     */
+    private static ParticipantTable participantTable = new ParticipantTable();
+	
+	private Set<IMulticastListener> multicastingListeners;
+	
+	// private IFloodlightProviderService floodlightProviderService;
+	private ITopologyService topologyService;
+	private IDeviceService deviceService;
+	
+	@Override
+	public Collection<Class<? extends IFloodlightService>> getModuleServices() {
+		Collection<Class<? extends IFloodlightService>> l =
+				new ArrayList<Class<? extends IFloodlightService>>();
+		l.add(IMulticastService.class);
+		return l;
+	}
+	
+	@Override
+	public Map<Class<? extends IFloodlightService>, IFloodlightService> getServiceImpls() {
+		Map<Class<? extends IFloodlightService>,  IFloodlightService> m = 
+				new HashMap<Class<? extends IFloodlightService>, IFloodlightService>();
+		m.put(IMulticastService.class, this);
+		return m;
+	}
+	
+	@Override
+	public Collection<Class<? extends IFloodlightService>> getModuleDependencies() {
+		Collection<Class<? extends IFloodlightService>> l =
+		        new ArrayList<Class<? extends IFloodlightService>>();
+	    l.add(IFloodlightProviderService.class);
+	    l.add(ITopologyService.class);
+	    l.add(IDeviceService.class);
+	    return l;
+	}
+	
+	@Override
+	public void init(FloodlightModuleContext context) throws FloodlightModuleException {
+		multicastingListeners = new HashSet<IMulticastListener>();
+		
+		// floodlightProviderService = context.getServiceImpl(IFloodlightProviderService.class);
+		topologyService = context.getServiceImpl(ITopologyService.class);
+		deviceService = context.getServiceImpl(IDeviceService.class);
+	}
+	
+	@Override
+	public void startUp(FloodlightModuleContext context) throws FloodlightModuleException {
+		deviceService.addListener(this);
+	}
+	
+	@Override
+	public void addParticipant(IPAddress<?> group, MacVlanPair intf, NodePortTuple ap) {
+		Set<NodePortTuple> attachmentPoints = participantTable.getAttachmentPoints(group, intf);
+		if (attachmentPoints.isEmpty() || !attachmentPoints.contains(ap)) {
+			for (IMulticastListener multicastingListener: multicastingListeners) {
+				multicastingListener.ParticipantAdded(group, intf, ap);
+			}
+			
+			participantTable.add(group, intf, ap);
+		}
+	}
+
+	@Override
+	public void removeParticipant(IPAddress<?> group, MacVlanPair intf, NodePortTuple ap) {
+		Set<NodePortTuple> attachmentPoints = participantTable.getAttachmentPoints(group, intf);
+		if (attachmentPoints.isEmpty() && attachmentPoints.contains(ap)) {
+			for (IMulticastListener multicastingListener: multicastingListeners) {
+				multicastingListener.ParticipantRemoved(group, intf, ap);
+			}
+			
+			participantTable.remove(group, intf, ap);
+		}
+	}
+	
+	@Override
+	public boolean hasParticipant(IPAddress<?> group, MacVlanPair intf) {
+		return participantTable.contains(group, intf);
+	}
+	
+	@Override
+	public Set<NodePortTuple> getParticipantAP(IPAddress<?> group, MacVlanPair intf) {
+		return participantTable.getAttachmentPoints(group, intf);
+	}
+	
+	@Override
+	public Set<MacVlanPair> getParticipantIntfs(IPAddress<?> group) {
+		return participantTable.getIntfs(group);
+	}
+
+	@Override
+	public Set<IPAddress<?>> getParticipantGroups(MacVlanPair intf) {
+		return participantTable.getGroups(intf);
+	}
+
+	@Override
+	public Set<MacVlanPair> getAllParticipantIntfs() {
+		return participantTable.getAllIntfs();
+	}
+
+	@Override
+	public Set<IPAddress<?>> getAllParticipantGroups() {
+		return participantTable.getAllGroups();
+	}
+
+	@Override
+	public boolean hasParticipantIntf(MacVlanPair intf) {
+		return participantTable.hasIntf(intf);
+	}
+
+	@Override
+	public boolean hasParticipantGroup(IPAddress<?> group) {
+		return participantTable.hasGroup(group);
+	}
+
+	@Override
+	public void deleteParticipantGroup(IPAddress<?> group) {
+		if (participantTable.hasGroup(group)) {
+			for (IMulticastListener multicastingListener: multicastingListeners) {
+				multicastingListener.ParticipantGroupRemoved(group);
+			}
+			
+			participantTable.deleteGroup(group);
+		}
+	}
+
+	@Override
+	public void deleteParticipantIntf(MacVlanPair intf) {
+		if (participantTable.hasIntf(intf)) {
+			for (IMulticastListener multicastingListener: multicastingListeners) {
+				multicastingListener.ParticipantIntfRemoved(intf);
+			}
+			
+			participantTable.deleteIntf(intf);
+		}
+	}
+
+	@Override
+	public void clearAllParticipants() {
+		for (IMulticastListener multicastingListener: multicastingListeners) {
+			multicastingListener.ParticipantsReset();
+		}
+		
+		participantTable.clearTable();
+	}
+	
+	@Override
+	public void addListener(IMulticastListener listener) {
+		multicastingListeners.add(listener);
+	}
+	
+	@Override
+	public void removeListener(IMulticastListener listener) {
+		multicastingListeners.remove(listener);
+	}
+
+	@Override
+	public String getName() {
+		return "multicasting";
+	}
+
+	@Override
+	public boolean isCallbackOrderingPrereq(String type, String name) {
+		return false;
+	}
+
+	@Override
+	public boolean isCallbackOrderingPostreq(String type, String name) {
+		return false;
+	}
+
+	@Override
+	public void deviceAdded(IDevice device) {
+		// nothing to do
+	}
+
+	@Override
+	public void deviceRemoved(IDevice device) {
+		MacAddress macAddress = device.getMACAddress();
+		VlanVid[] vlanIds = device.getVlanId();
+		for (VlanVid vlanId: vlanIds) {
+			MacVlanPair intf = new MacVlanPair(macAddress, vlanId);
+			Set<IPAddress<?>> groupSet = getParticipantGroups(intf);
+			for (IPAddress<?> group: groupSet) {
+				Set<NodePortTuple> memberAP = getParticipantAP(group, intf);
+				for (NodePortTuple ap: memberAP) {
+					removeParticipant(group, intf, ap);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void deviceMoved(IDevice device) {
+		/*
+		 * Use archipelago of participant switches to determine, changes
+		 * in attachmentPoints. The assumption is that a device can have 
+		 * only 1 attachmentPoint per archipelago.
+		 */
+		NodePortTuple[] deviceAP = device.getAttachmentPoints();
+		MacAddress macAddress = device.getMACAddress();
+		VlanVid[] vlanIds = device.getVlanId();
+		for (VlanVid vlanId: vlanIds) {
+			MacVlanPair intf = new MacVlanPair(macAddress, vlanId);
+			Set<IPAddress<?>> groupSet = getParticipantGroups(intf);
+			for (IPAddress<?> group: groupSet) {
+				// Reference attachmentPoints
+				Set<NodePortTuple> memberAP = getParticipantAP(group, intf);
+
+				// Classify Reference attachmentPoints based on Archipelago
+				Map<DatapathId, NodePortTuple> bucket = 
+						new HashMap<DatapathId, NodePortTuple>();
+				for (NodePortTuple ap: memberAP) {
+					DatapathId clusterId = topologyService.getClusterId(ap.getNodeId());
+					bucket.put(clusterId, ap);
+				}
+				
+				// Evaluate attachmentPoints based on Reference Archipelago and attachmentPoints
+				for (NodePortTuple ap: deviceAP) {
+					DatapathId clusterId = topologyService.getClusterId(ap.getNodeId());
+					NodePortTuple refAp = bucket.get(clusterId);
+					if (refAp != null) {
+						if (!ap.equals(refAp)) {
+							removeParticipant(group, intf, refAp);
+							addParticipant(group, intf, ap);
+						}
+						bucket.remove(clusterId);
+					}
+				}
+				
+				// Remove remaining attachmentPoints
+				for (NodePortTuple ap: bucket.values()) {
+					removeParticipant(group, intf, ap);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void deviceIPV4AddrChanged(IDevice device) {
+		// nothing to do
+	}
+
+	@Override
+	public void deviceIPV6AddrChanged(IDevice device) {
+		// nothing to do
+	}
+
+	@Override
+	public void deviceVlanChanged(IDevice device) {
+		/*
+		 * If any participant interface has the same Mac Address
+		 * as that of the changed device, then its vlanId must 
+		 * belong to that device. If not, then the corresponding
+		 * interface is no longer valid and must be removed.
+		 */
+		MacAddress macAddress = device.getMACAddress();
+		VlanVid[] vlanIds = device.getVlanId();
+		Set<MacVlanPair> intfSet = getAllParticipantIntfs();
+		for (MacVlanPair intf: intfSet) {
+			MacAddress refMacAddress = intf.getMac();
+			if (refMacAddress.equals(macAddress)) {
+				VlanVid refVlanVid = intf.getVlan();
+				boolean flag = false;
+				for (VlanVid vlanId: vlanIds) {
+					if (refVlanVid.equals(vlanId)) {
+						flag = true;
+						break;
+					}
+				}
+				if (!flag) {
+					deleteParticipantIntf(intf);
+				}
+			}
+		}
+		
+
+	}
+}

--- a/src/main/java/net/floodlightcontroller/multicasting/internal/ParticipantTable.java
+++ b/src/main/java/net/floodlightcontroller/multicasting/internal/ParticipantTable.java
@@ -1,0 +1,342 @@
+package net.floodlightcontroller.multicasting.internal;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashMap;
+
+import org.projectfloodlight.openflow.types.IPAddress;
+import org.python.google.common.collect.ImmutableSet;
+
+import net.floodlightcontroller.core.types.MacVlanPair;
+import net.floodlightcontroller.core.types.NodePortTuple;
+import net.floodlightcontroller.util.RWSync;
+
+/**
+ * @author Souvik Das (souvikdas95@yahoo.co.in)
+ * 
+ * Participant table that maps b/w Multicast IP, Device Intf & AttachmentPoints
+ * 
+ */
+public class ParticipantTable {
+	private class Member {
+		private final IPAddress<?> group;
+		private final MacVlanPair intf;
+		protected Member(IPAddress<?> group, MacVlanPair intf) {
+			this.group = group;
+			this.intf = intf;
+		}
+		protected IPAddress<?> getGroup() {
+			return group;
+		}
+		protected MacVlanPair getIntf() {
+			return intf;
+		}
+		@Override
+	    public boolean equals(Object o) {
+			if (this == o) {
+	        	return true;
+	        }
+	        if (o == null || getClass() != o.getClass()) {
+	        	return false;
+	        }
+	        Member that = (Member) o;
+	        if (group == null || that.group == null || 
+	        		!group.equals(that.group)) {
+	        	return false;
+	        }
+	        if (intf == null || that.intf == null || 
+	        		!intf.equals(that.intf)) {
+	        	return false;
+	        }
+	        return true;
+	    }
+	    @Override
+	    public int hashCode() {
+	        int result = group.hashCode();
+	        result = 31 * result + intf.hashCode();
+	        return result;
+	    }
+	}
+	
+	private final Map<IPAddress<?>, Set<MacVlanPair>> groupToIntfMap;
+	private final Map<MacVlanPair, Set<IPAddress<?>>> intfToGroupMap;
+	
+	private final Map<Member, Set<NodePortTuple>> memberToApMap;
+	
+	// Reader-Writer Synchronization Class & Object
+	private final RWSync rwSync;
+	
+	public ParticipantTable() {
+		groupToIntfMap = new HashMap<IPAddress<?>, Set<MacVlanPair>>();
+		intfToGroupMap = new HashMap<MacVlanPair, Set<IPAddress<?>>>();
+		
+		memberToApMap = new HashMap<Member, Set<NodePortTuple>>();
+		
+		rwSync = new RWSync();
+	}
+	
+	public void add(IPAddress<?> group, MacVlanPair intf, NodePortTuple ap) {
+		if (group == null || intf == null || ap == null) {
+			return;
+		}
+		
+		Set<MacVlanPair> intfSet;
+		Set<IPAddress<?>> groupSet;
+		Set<NodePortTuple> apSet;
+		Member member = new Member(group, intf);
+
+		rwSync.writeLock();
+		
+		intfSet = groupToIntfMap.get(group);
+		if (intfSet == null) {
+			intfSet = new HashSet<MacVlanPair>();
+			groupToIntfMap.put(group, intfSet);
+		}
+		intfSet.add(intf);
+		
+		groupSet = intfToGroupMap.get(intf);
+		if (groupSet == null) {
+			groupSet = new HashSet<IPAddress<?>>();
+			intfToGroupMap.put(intf, groupSet);
+		}
+		groupSet.add(group);
+		
+		apSet = memberToApMap.get(member);
+		if (apSet == null) {
+			apSet = new HashSet<NodePortTuple>();
+			memberToApMap.put(member, apSet);
+		}
+		apSet.add(ap);
+		
+		rwSync.writeUnlock();
+	}
+	
+	public void remove(IPAddress<?> group, MacVlanPair intf, NodePortTuple ap) {
+		if (group == null || intf == null || ap == null) {
+			return;
+		}
+		
+		Set<MacVlanPair> intfSet;
+		Set<IPAddress<?>> groupSet;
+		Set<NodePortTuple> apSet;
+		Member member = new Member(group, intf);
+
+		rwSync.writeLock();
+		
+		apSet = memberToApMap.get(member);
+		if (apSet != null) {
+			apSet.remove(ap);
+			if (apSet.isEmpty()) {
+				memberToApMap.remove(member);
+
+				intfSet = groupToIntfMap.get(group);
+				if (intfSet != null) {
+					intfSet.remove(intf);
+					if (intfSet.isEmpty()) {
+						groupToIntfMap.remove(group);
+					}
+				}
+
+				groupSet = intfToGroupMap.get(intf);
+				if (groupSet != null) {
+					groupSet.remove(group);
+					if (groupSet.isEmpty()) {
+						intfToGroupMap.remove(intf);
+					}
+				}
+			}
+		}
+		
+		rwSync.writeUnlock();
+	}
+	
+	public Boolean contains(IPAddress<?> group, MacVlanPair intf) {
+		if (group == null || intf == null) {
+			return false;
+		}
+		
+		Boolean result;
+		Member member = new Member(group, intf);
+		
+		rwSync.readLock();
+		
+		result = memberToApMap.containsKey(member);
+		
+		rwSync.readUnlock();
+
+		return result;
+	}
+	
+	public Set<NodePortTuple> getAttachmentPoints(IPAddress<?> group, MacVlanPair intf) {
+		Set<NodePortTuple> result;
+		Member member = new Member(group, intf);
+		
+		rwSync.readLock();
+		
+		result = memberToApMap.get(member);
+		result = (result == null) ? ImmutableSet.of() : new HashSet<NodePortTuple>(result);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<MacVlanPair> getIntfs(IPAddress<?> group) {
+		if (group == null) {
+			return ImmutableSet.of();
+		}
+		
+		Set<MacVlanPair> result;
+		
+		rwSync.readLock();
+		
+		result = groupToIntfMap.get(group);
+		result = (result == null) ? ImmutableSet.of() : new HashSet<MacVlanPair>(result);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<IPAddress<?>> getGroups(MacVlanPair intf) {
+		if (intf == null) {
+			return ImmutableSet.of();
+		}
+		
+		Set<IPAddress<?>> result;
+		
+		rwSync.readLock();
+		
+		result = intfToGroupMap.get(intf);
+		result = (result == null) ? ImmutableSet.of() : new HashSet<IPAddress<?>>(result);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<MacVlanPair> getAllIntfs() {
+		Set<MacVlanPair> result;
+		
+		rwSync.readLock();
+		
+		result = new HashSet<MacVlanPair>(intfToGroupMap.keySet());
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<IPAddress<?>> getAllGroups() {
+		Set<IPAddress<?>> result;
+		
+		rwSync.readLock();
+		
+		result = new HashSet<IPAddress<?>>(groupToIntfMap.keySet());
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Boolean hasIntf(MacVlanPair intf) {
+		if (intf == null) {
+			return false;
+		}
+		
+		Boolean result;
+		
+		rwSync.readLock();
+		
+		result = intfToGroupMap.containsKey(intf);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Boolean hasGroup(IPAddress<?> group) {
+		if (group == null) {
+			return false;
+		}
+		
+		Boolean result;
+		
+		rwSync.readLock();
+		
+		result = groupToIntfMap.containsKey(group);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public void deleteGroup(IPAddress<?> group) {
+		if (group == null) {
+			return;
+		}
+		
+		rwSync.writeLock();
+		
+		Set<MacVlanPair> intfSet = groupToIntfMap.get(group);
+		if (intfSet != null) {
+			for (MacVlanPair intf: intfSet) {
+				Set<IPAddress<?>> groupSet = intfToGroupMap.get(intf);
+				groupSet.remove(group);
+				if (groupSet.isEmpty()) {
+					intfToGroupMap.remove(intf);
+				}
+			}
+			groupToIntfMap.remove(group);
+			Set<Member> memberSet = new HashSet<Member>();
+			for (Member member: memberToApMap.keySet()) {
+				if (member.getGroup().equals(group)) {
+					memberSet.add(member);
+				}
+			}
+			memberToApMap.keySet().removeAll(memberSet);
+		}
+		
+		rwSync.writeUnlock();
+	}
+	
+	public void deleteIntf(MacVlanPair intf) {
+		if (intf == null) {
+			return;
+		}
+		
+		rwSync.writeLock();
+		
+		Set<IPAddress<?>> groupSet = intfToGroupMap.get(intf);
+		if (groupSet != null) {
+			for (IPAddress<?> group: groupSet) {
+				Set<MacVlanPair> intfSet = groupToIntfMap.get(group);
+				intfSet.remove(intf);
+				if (intfSet.isEmpty()) {
+					groupToIntfMap.remove(group);
+				}
+			}
+			intfToGroupMap.remove(intf);
+			Set<Member> memberSet = new HashSet<Member>();
+			for (Member member: memberToApMap.keySet()) {
+				if (member.getIntf().equals(intf)) {
+					memberSet.add(member);
+				}
+			}
+			memberToApMap.keySet().removeAll(memberSet);
+		}
+		
+		rwSync.writeUnlock();
+	}
+	
+	public void clearTable() {
+		rwSync.writeLock();
+		
+		groupToIntfMap.clear();
+		intfToGroupMap.clear();
+		memberToApMap.clear();
+		
+		rwSync.writeUnlock();
+	}
+}

--- a/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
+++ b/src/main/java/net/floodlightcontroller/routing/ForwardingBase.java
@@ -108,6 +108,7 @@ public abstract class ForwardingBase implements IOFMessageListener {
 
     protected void startUp() {
         floodlightProviderService.addOFMessageListener(OFType.PACKET_IN, this);
+        floodlightProviderService.addOFMessageListener(OFType.FLOW_REMOVED, this);
     }
 
     @Override
@@ -129,6 +130,18 @@ public abstract class ForwardingBase implements IOFMessageListener {
     public abstract Command processPacketInMessage(IOFSwitch sw, OFPacketIn pi, 
             IRoutingDecision decision, FloodlightContext cntx);
 
+    /**
+     * All subclasses must define this function if they want any specific
+     * action when a flow is removed
+     *
+     * @param sw
+     *            Switch that the packet came in from
+     * @param fr
+     *            The packet that came in
+     */
+    public abstract Command processFlowRemovedMessage(IOFSwitch sw, OFFlowRemoved fr, 
+            FloodlightContext cntx);
+
     @Override
     public Command receive(IOFSwitch sw, OFMessage msg, FloodlightContext cntx) {
         Ethernet eth = IFloodlightProviderService.bcStore.get(cntx, IFloodlightProviderService.CONTEXT_PI_PAYLOAD);
@@ -140,6 +153,8 @@ public abstract class ForwardingBase implements IOFMessageListener {
                 decision = RoutingDecision.rtStore.get(cntx, IRoutingDecision.CONTEXT_DECISION);
             }
             return this.processPacketInMessage(sw, (OFPacketIn) msg, decision, cntx);
+        case FLOW_REMOVED:
+            return this.processFlowRemovedMessage(sw, (OFFlowRemoved) msg, cntx);
         default:
             break;
         }

--- a/src/main/java/net/floodlightcontroller/routing/IRoutingService.java
+++ b/src/main/java/net/floodlightcontroller/routing/IRoutingService.java
@@ -17,6 +17,7 @@
 
 package net.floodlightcontroller.routing;
 
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -211,4 +212,17 @@ public interface IRoutingService extends IFloodlightService {
      * @return true upon success; false otherwise
      */
     boolean forceRecompute();
+    
+	/**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Retrieves end-to-end path b/w srcSwId
+     * at srcwPort and mgId
+     * 
+     * @param srcSwId
+     * @param mgId
+     * 
+     * @return MulticastPath
+     */
+    MulticastPath getMulticastPath(DatapathId srcSwId, BigInteger mgId);
 }

--- a/src/main/java/net/floodlightcontroller/routing/MulticastPath.java
+++ b/src/main/java/net/floodlightcontroller/routing/MulticastPath.java
@@ -1,0 +1,221 @@
+package net.floodlightcontroller.routing;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.OFPort;
+import org.projectfloodlight.openflow.types.U64;
+
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashMap;
+
+/**
+ * @author Souvik Das (souvikdas95@yahoo.co.in)
+ * 
+ * MulticastPath implementation
+ * 
+ */
+public class MulticastPath implements Comparable<MulticastPath> {
+    protected MulticastPathId id;
+    private final Map<DatapathId, Path> swIdToPathMap;	// Map of mgSwId and Path it belongs to
+    private final Map<DatapathId, Set<OFPort>> swIdToApPortMap;	// Map of mgSwId and Set of attachmentPointPorts
+    
+    protected int pathIndex;
+    
+    public MulticastPath(MulticastPathId id) {
+        super();
+        this.id = id;  
+        this.swIdToPathMap = new HashMap<DatapathId, Path>();
+        this.swIdToApPortMap = new HashMap<DatapathId, Set<OFPort>>();
+        this.pathIndex = 0; // useful if multipath multicast routing available
+    }
+    
+    public MulticastPath(DatapathId src, BigInteger mgId) {
+        super();
+        this.id = new MulticastPathId(src, mgId);
+        this.swIdToPathMap = new HashMap<DatapathId, Path>();
+        this.swIdToApPortMap = new HashMap<DatapathId, Set<OFPort>>();
+        this.pathIndex = 0; // useful if multipath multicast routing available
+    }
+    
+    public MulticastPathId getId() {
+        return id;
+    }
+    
+    public void setId(MulticastPathId id) {
+        this.id = id;
+    }
+    
+    public void add(DatapathId mgSwId, Set<OFPort> edgePorts, Path path) {
+    	if (mgSwId == null || edgePorts == null || path == null) {
+    		return;
+    	}
+    	
+    	swIdToPathMap.put(mgSwId, path);
+    	swIdToApPortMap.put(mgSwId, edgePorts);
+    }
+    
+    public void remove(DatapathId mgSwId) {
+    	if (mgSwId == null) {
+    		return;
+    	}
+    	
+    	swIdToPathMap.remove(mgSwId);
+    	swIdToApPortMap.remove(mgSwId);
+    }
+    
+    public void remove(Path path) {
+    	if (path == null) {
+    		return;
+    	}
+    	
+    	DatapathId mgSwId = path.getId().getDst();
+    	swIdToPathMap.remove(mgSwId);
+    	swIdToApPortMap.remove(mgSwId);
+    }
+    
+    public DatapathId getRoot() {
+    	return id.getSrc();
+    }
+    
+    public BigInteger getMgId() {
+    	return id.getMgId();
+    }
+    
+    public Collection<Path> getAllPaths() {
+        return Collections.unmodifiableCollection(swIdToPathMap.values());
+    }
+    
+    public Set<DatapathId> getAllMgSwIds() {
+    	 return Collections.unmodifiableSet(swIdToPathMap.keySet());
+    }
+    
+    public Path getPath(DatapathId mgSwId) {
+    	if (mgSwId == null) {
+    		return null;
+    	}
+    	
+    	return swIdToPathMap.get(mgSwId);
+    }
+    
+    public DatapathId getMgSwId(Path path) {
+    	if (path == null) {
+    		return null;
+    	}
+    	
+    	DatapathId mgSwId = path.getId().getDst();
+    	return mgSwId;
+    }
+    
+    public Set<OFPort> getApPorts(DatapathId mgSwId) {
+    	if (mgSwId == null) {
+    		return ImmutableSet.of();
+    	}
+    	
+    	Set<OFPort> result = swIdToApPortMap.get(mgSwId);
+    	return (result == null) ? ImmutableSet.of() : Collections.unmodifiableSet(result);
+    }
+    
+    public boolean hasPath(Path path) {
+    	if (path == null) {
+    		return false;
+    	}
+    	
+    	DatapathId mgSwId = path.getId().getDst();
+    	return swIdToPathMap.containsKey(mgSwId);
+    }
+    
+    public boolean hasMgSwId(DatapathId mgSwId) {
+    	if (mgSwId == null) {
+    		return false;
+    	}
+    	
+    	return swIdToPathMap.containsKey(mgSwId);
+    }
+    
+    public boolean isEmpty() {
+    	return swIdToPathMap.isEmpty();
+    }
+    
+    public void clear() {
+    	swIdToPathMap.clear();
+    }
+    
+    public int getMulticastPathIndex() {
+        return pathIndex;
+    }
+    
+    public void setMulticastPathIndex(int pathIndex) {
+        this.pathIndex = pathIndex;
+    }
+    
+    public int getHopCount() { 
+        int hopCount = 0;
+        for (Path path: swIdToPathMap.values()) {
+        	hopCount += path.getHopCount();
+        }
+        return hopCount;
+    }
+    
+    public U64 getLatency() { 
+    	U64 latency = U64.ZERO;
+        for (Path path:swIdToPathMap.values()) {
+        	latency.add(path.getLatency());
+        }
+        return latency;
+    }
+    
+    public int getCost() {
+        int cost = 0;
+        for (Path path: swIdToPathMap.values()) {
+        	cost += path.getCost();
+        }
+        return cost;
+    }
+    
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + pathIndex;
+        result = prime * result + swIdToPathMap.hashCode();
+        return result;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        MulticastPath other = (MulticastPath) obj;
+        if (id == null || other.id == null ||
+			!id.equals(other.id)) {
+        	return false;
+        }
+        if (pathIndex != other.pathIndex) {
+        	return false;
+        }
+        if (!swIdToPathMap.equals(other.swIdToPathMap)) {
+        	return false;
+        }
+        return true;
+    }
+    
+    @Override
+    public String toString() {
+        return "Route [id=" + id + ", paths=" + swIdToPathMap.values() + "]";
+    }
+    
+    @Override
+    public int compareTo(MulticastPath o) {
+        return ((Integer)swIdToPathMap.size()).compareTo(o.swIdToPathMap.size());
+    }
+}

--- a/src/main/java/net/floodlightcontroller/routing/MulticastPathId.java
+++ b/src/main/java/net/floodlightcontroller/routing/MulticastPathId.java
@@ -1,0 +1,88 @@
+package net.floodlightcontroller.routing;
+
+import java.math.BigInteger;
+
+import org.projectfloodlight.openflow.types.DatapathId;
+
+/**
+ * @author Souvik Das (souvikdas95@yahoo.co.in)
+ * 
+ * MulticastPathId implementation
+ * 
+ */
+public class MulticastPathId implements Cloneable, Comparable<MulticastPathId> {
+    protected DatapathId src;
+    protected BigInteger mgId;
+
+    public MulticastPathId(DatapathId src, BigInteger mgId) {
+        super();
+        this.src = src;
+        this.mgId = mgId;
+    }
+
+    public DatapathId getSrc() {
+        return src;
+    }
+
+    public void setSrc(DatapathId src) {
+        this.src = src;
+    }
+
+    public BigInteger getMgId() {
+        return mgId;
+    }
+
+    public void setMgId(BigInteger mgId) {
+        this.mgId = mgId;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 2417;
+        Long result = new Long(1);
+        result = prime * result + ((mgId == null) ? 0 : mgId.hashCode());
+        result = prime * result + ((src == null) ? 0 : src.hashCode());
+        return result.hashCode(); 
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        MulticastPathId other = (MulticastPathId) obj;
+        if (mgId == null) {
+            if (other.mgId != null)
+                return false;
+        } else if (!mgId.equals(other.mgId))
+            return false;
+        if (src == null) {
+            if (other.src != null)
+                return false;
+        } else if (!src.equals(other.src))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "RouteId [src=" + this.src.toString() + " mgId="
+                + this.mgId.toString() + "]";
+    }
+
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
+
+    @Override
+    public int compareTo(MulticastPathId o) {
+        int result = src.compareTo(o.getSrc());
+        if (result != 0)
+            return result;
+        return mgId.compareTo(o.getMgId());
+    }
+}

--- a/src/main/java/net/floodlightcontroller/routing/Path.java
+++ b/src/main/java/net/floodlightcontroller/routing/Path.java
@@ -40,6 +40,7 @@ public class Path implements Comparable<Path> {
     protected int pathIndex;
     protected int hopCount;
     protected U64 latency;
+    protected int cost;
 
     public Path(PathId id, List<NodePortTuple> switchPorts) {
         super();
@@ -111,6 +112,14 @@ public class Path implements Comparable<Path> {
 
     public U64 getLatency() { 
         return this.latency; 
+    }
+    
+    public void setCost(int cost) {
+    	this.cost = cost;
+    }
+    
+    public int getCost() {
+    	return this.cost;
     }
     
     @Override

--- a/src/main/java/net/floodlightcontroller/routing/RoutingManager.java
+++ b/src/main/java/net/floodlightcontroller/routing/RoutingManager.java
@@ -1,5 +1,6 @@
 package net.floodlightcontroller.routing;
 
+import java.math.BigInteger;
 import java.util.*;
 
 import net.floodlightcontroller.core.IOFSwitch;
@@ -175,4 +176,9 @@ public class RoutingManager implements IFloodlightModule, IRoutingService {
     public boolean isL3RoutingEnabled() {
         return enableL3RoutingService;
     }
+
+	@Override
+	public MulticastPath getMulticastPath(DatapathId srcSwId, BigInteger mgId) {
+		return tm.getCurrentTopologyInstance().getMulticastPath(srcSwId, mgId);
+	}
 }

--- a/src/main/java/net/floodlightcontroller/topology/Archipelago.java
+++ b/src/main/java/net/floodlightcontroller/topology/Archipelago.java
@@ -6,18 +6,25 @@ package net.floodlightcontroller.topology;
 import net.floodlightcontroller.routing.BroadcastTree;
 import org.projectfloodlight.openflow.types.DatapathId;
 
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class Archipelago {
     private DatapathId id; // the lowest id of the nodes
     private final Set<Cluster> clusters;
     private BroadcastTree destinationRootedFullTree;
+    private final Map<BigInteger, MulticastGroup> multicastGroups;
 
     public Archipelago() {
         id = DatapathId.NONE;
         clusters = new HashSet<Cluster>();
         destinationRootedFullTree = null;
+        multicastGroups = new HashMap<BigInteger, MulticastGroup>();
     }
 
     public DatapathId getId() {
@@ -73,6 +80,38 @@ public class Archipelago {
         destinationRootedFullTree = bt;
     }
 
+    void addMulticastGroup(MulticastGroup mg) {
+    	multicastGroups.put(mg.getId(), mg);
+    }
+    
+    void removeMulticastGroup(MulticastGroup mg) {
+    	removeMulticastGroup(mg.getId());
+    }
+    
+    void removeMulticastGroup(BigInteger mgId) {
+    	multicastGroups.remove(mgId);
+    }
+    
+    boolean hasMulticastGroup(MulticastGroup mg) {
+    	return hasMulticastGroup(mg.getId());
+    }
+    
+    boolean hasMulticastGroup(BigInteger mgId) {
+    	return multicastGroups.containsKey(mgId);
+    }
+    
+    MulticastGroup getMulticastGroup(BigInteger mgId) {
+    	return multicastGroups.get(mgId);
+    }
+    
+    Collection<MulticastGroup> getMulticastGroups() {
+    	return Collections.unmodifiableCollection(multicastGroups.values());
+    }
+    
+    void clearMulticastGroups() {
+    	multicastGroups.clear();
+    }
+    
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/net/floodlightcontroller/topology/MulticastGroup.java
+++ b/src/main/java/net/floodlightcontroller/topology/MulticastGroup.java
@@ -1,0 +1,336 @@
+package net.floodlightcontroller.topology;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashMap;
+
+import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.OFPort;
+import org.python.google.common.collect.ImmutableSet;
+
+import net.floodlightcontroller.core.types.MacVlanPair;
+import net.floodlightcontroller.core.types.NodePortTuple;
+import net.floodlightcontroller.util.RWSync;
+
+/**
+ * @author Souvik Das (souvikdas95@yahoo.co.in)
+ * 
+ * Group of Multicasting Device interfaces and their attachmentPoints
+ * in a given archipelago
+ * 
+ */
+public class MulticastGroup {
+	
+	// Multicast Group Id
+	private final BigInteger mgId;
+	
+	// Parent Archipelago Id (only used for reference & hashCode)
+	private final Archipelago arch;
+	
+	// Map of device interfaces and participant attachment points in archipelago
+	private final Map<MacVlanPair, Set<NodePortTuple>> intfApMap;
+	
+	// Map of attachment point and participant device interfaces in archipelago
+	private final Map<NodePortTuple, Set<MacVlanPair>> apIntfMap;
+	
+	// Map of switches and attachmentPoint ports connected to participant device interfaces
+	private final Map<DatapathId, Set<OFPort>> swApPorts;
+	
+	// Reader-Writer Sync
+	private final RWSync rwSync;
+	
+	public MulticastGroup(BigInteger mgId, Archipelago arch) {
+		this.mgId = mgId;
+		this.arch = arch;
+		
+		intfApMap = new HashMap<MacVlanPair, Set<NodePortTuple>>();
+		apIntfMap = new HashMap<NodePortTuple, Set<MacVlanPair>>();
+		swApPorts = new HashMap<DatapathId, Set<OFPort>>();
+		
+		rwSync = new RWSync();
+	}
+	
+	public BigInteger getId() {
+		return mgId;
+	}
+	
+	public Archipelago getArchipelago() {
+		return arch;
+	}
+	
+	public void add(MacVlanPair intf, NodePortTuple ap) {
+		if (intf == null || ap == null) {
+			return;
+		}
+		
+		rwSync.writeLock();
+		
+		Set<NodePortTuple> apSet = intfApMap.get(intf);
+		if (apSet == null) {
+			apSet = new HashSet<NodePortTuple>();
+			intfApMap.put(intf, apSet);
+		}
+		apSet.add(ap);
+		
+		Set<MacVlanPair> devSet = apIntfMap.get(ap);
+		if (devSet == null) {
+			devSet = new HashSet<MacVlanPair>();
+			apIntfMap.put(ap, devSet);
+		}
+		devSet.add(intf);
+		
+		DatapathId swId = ap.getNodeId();
+		OFPort port = ap.getPortId();
+		Set<OFPort> ports = swApPorts.get(swId);
+		if (ports == null) {
+			ports = new HashSet<OFPort>();
+			swApPorts.put(swId, ports);
+		}
+		ports.add(port);
+		
+		rwSync.writeUnlock();
+	}
+	
+	public void remove(MacVlanPair intf) {
+		if (intf == null) {
+			return;
+		}
+		
+		rwSync.writeLock();
+		
+		Set<NodePortTuple> apSet = intfApMap.get(intf);
+		if (apSet != null) {
+			for (NodePortTuple ap: apSet) {
+				Set<MacVlanPair> devSet = apIntfMap.get(ap);
+				devSet.remove(intf);
+				if (devSet.isEmpty()) {
+					apIntfMap.remove(ap);
+					DatapathId swId = ap.getNodeId();
+					OFPort port = ap.getPortId();
+					Set<OFPort> ports = swApPorts.get(swId);
+					ports.remove(port);
+					if (ports.isEmpty()) {
+						swApPorts.remove(swId);
+					}
+				}
+			}
+			intfApMap.remove(intf);
+		}
+		
+		rwSync.writeUnlock();
+	}
+	
+	public void remove(MacVlanPair intf, NodePortTuple ap) {
+		if (intf == null || ap == null) {
+			return;
+		}
+		
+		rwSync.writeLock();
+		
+		Set<NodePortTuple> apSet = intfApMap.get(intf);
+		if (apSet != null) {
+			if (apSet.contains(ap)) {
+				Set<MacVlanPair> devSet = apIntfMap.get(ap);
+				devSet.remove(intf);
+				if (devSet.isEmpty()) {
+					apIntfMap.remove(ap);
+					DatapathId swId = ap.getNodeId();
+					OFPort port = ap.getPortId();
+					Set<OFPort> ports = swApPorts.get(swId);
+					ports.remove(port);
+					if (ports.isEmpty()) {
+						swApPorts.remove(swId);
+					}
+				}
+				apSet.remove(ap);
+			}
+			if (apSet.isEmpty()) {
+				intfApMap.remove(intf);
+			}
+		}
+		
+		rwSync.writeUnlock();
+	}
+	
+	public boolean hasIntf(MacVlanPair intf) {
+		if (intf == null) {
+			return false;
+		}
+		
+		boolean result;
+		
+		rwSync.readLock();
+		
+		result = intfApMap.keySet().contains(intf);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public boolean hasAttachmentPoint(NodePortTuple ap) {
+		if (ap == null) {
+			return false;
+		}
+		
+		boolean result;
+		
+		rwSync.readLock();
+		
+		result = apIntfMap.keySet().contains(ap);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<MacVlanPair> getAllIntfs() {
+		Set<MacVlanPair> result;
+		
+		rwSync.readLock();
+		
+		result =  new HashSet<MacVlanPair>(intfApMap.keySet());
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<NodePortTuple> getAllAttachmentPoints() {
+		Set<NodePortTuple> result;
+		
+		rwSync.readLock();
+		
+		result = Collections.unmodifiableSet(apIntfMap.keySet());
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<MacVlanPair> getIntfs(NodePortTuple ap) {
+		if (ap == null) {
+			return ImmutableSet.of();
+		}
+		
+		Set<MacVlanPair> result;
+		
+		rwSync.readLock();
+		
+		result = apIntfMap.get(ap);
+		result = (result == null) ? ImmutableSet.of() : new HashSet<MacVlanPair>(result);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<NodePortTuple> getAttachmentPoints(MacVlanPair intf) {
+		if (intf == null) {
+			return ImmutableSet.of();
+		}
+		
+		Set<NodePortTuple> result;
+		
+		rwSync.readLock();
+		
+		result = intfApMap.get(intf);
+		result = (result == null) ? ImmutableSet.of() : new HashSet<NodePortTuple>(result);
+		
+		rwSync.readUnlock();
+		
+		return (result == null) ? ImmutableSet.of() : Collections.unmodifiableSet(result);
+	}
+	
+	public boolean hasSwitch(DatapathId swId) {
+		if (swId == null) {
+			return false;
+		}
+		
+		boolean result;
+		
+		rwSync.readLock();
+		
+		result = swApPorts.containsKey(swId);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<DatapathId> getSwitches() {
+		Set<DatapathId> result;
+		
+		rwSync.readLock();
+		
+		result =  new HashSet<DatapathId>(swApPorts.keySet());
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public Set<OFPort> getApPorts(DatapathId swId) {
+		if (swId == null) {
+			return ImmutableSet.of();
+		}
+		
+		Set<OFPort> result;
+		
+		rwSync.readLock();
+		
+		result = swApPorts.get(swId);
+		result = (result == null) ? ImmutableSet.of() : new HashSet<OFPort>(result);
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+	public boolean isEmpty() {
+		boolean result;
+		
+		rwSync.readLock();
+		
+		result = intfApMap.isEmpty();
+		
+		rwSync.readUnlock();
+		
+		return result;
+	}
+	
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+        	return true;
+        }
+        
+        if (o == null || getClass() != o.getClass()) {
+        	return false;
+        }
+
+        MulticastGroup that = (MulticastGroup) o;
+       
+        if (mgId == null || that.mgId == null || 
+        		!mgId.equals(that.mgId)) {
+        	return false;
+        }
+        
+        if (arch == null || that.arch == null || 
+        		!arch.getId().equals(that.arch.getId())) {
+        	return false;
+        }
+        
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mgId.hashCode();
+        result = 31 * result + arch.getId().hashCode();
+        return result;
+    }
+}

--- a/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
@@ -959,8 +959,12 @@ public class TopologyInstance {
     }
 
     private Archipelago getArchipelago(DatapathId d) {
-    	Cluster c = clusterFromSwitch.get(d);
-        return archipelagoFromCluster.get(c);
+        for (Archipelago a : archipelagos) {
+            if (a.getSwitches().contains(d)) {
+                return a;
+            }
+        }
+        return null;
     }
 
     public void setPathCosts(Path p, Map<Link, Integer> linkCost) {

--- a/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
+++ b/src/main/java/net/floodlightcontroller/topology/TopologyInstance.java
@@ -18,21 +18,28 @@ package net.floodlightcontroller.topology;
 
 import com.google.common.collect.ImmutableSet;
 import net.floodlightcontroller.core.IOFSwitch;
+import net.floodlightcontroller.core.types.MacVlanPair;
 import net.floodlightcontroller.core.types.NodePortTuple;
 import net.floodlightcontroller.linkdiscovery.Link;
 import net.floodlightcontroller.routing.BroadcastTree;
+import net.floodlightcontroller.routing.MulticastPath;
+import net.floodlightcontroller.routing.MulticastPathId;
 import net.floodlightcontroller.routing.Path;
 import net.floodlightcontroller.routing.PathId;
 import net.floodlightcontroller.statistics.SwitchPortBandwidth;
 import net.floodlightcontroller.util.ClusterDFS;
+import net.floodlightcontroller.util.MulticastUtils;
+
 import org.projectfloodlight.openflow.protocol.OFPortDesc;
 import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.IPAddress;
 import org.projectfloodlight.openflow.types.OFPort;
 import org.projectfloodlight.openflow.types.U64;
 import org.python.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigInteger;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -79,7 +86,9 @@ public class TopologyInstance {
     private List<Archipelago>                   archipelagos; /* connected clusters */
     private Map<Cluster, Archipelago>           archipelagoFromCluster;
     private Map<DatapathId, Set<NodePortTuple>> portsBroadcastPerArchipelago; /* broadcast ports in each archipelago ID */
+    
     private Map<PathId, List<Path>>             pathcache; /* contains computed paths ordered best to worst */
+    private Map<MulticastPathId, MulticastPath>	pathcacheMF; /* contains computed best multicast path */
 
     protected TopologyInstance(Map<DatapathId, Set<OFPort>> portsWithLinks,
             Set<NodePortTuple> portsBlocked,
@@ -131,6 +140,7 @@ public class TopologyInstance {
         this.portsBroadcastPerSwitch = new HashMap<DatapathId,Set<OFPort>>();
 
         this.pathcache = new HashMap<PathId, List<Path>>();
+        this.pathcacheMF = new HashMap<MulticastPathId, MulticastPath>();
 
         this.portsBroadcastPerArchipelago = new HashMap<DatapathId, Set<NodePortTuple>>();
 
@@ -175,6 +185,16 @@ public class TopologyInstance {
          */
         computeBroadcastPortsPerArchipelago();
 
+        /*
+         * Step 6: Identify multicast groups using existing Participant table
+         */
+        identifyMutlticastGroups();
+        
+        /*
+         * Step 7: Compute all multicast paths for all archipelagos
+         */
+        computeMulticastPaths(null);
+        
         /*
          * Step 6: Optionally, print topology to log for added verbosity or when debugging.
          */
@@ -939,16 +959,13 @@ public class TopologyInstance {
     }
 
     private Archipelago getArchipelago(DatapathId d) {
-        for (Archipelago a : archipelagos) {
-            if (a.getSwitches().contains(d)) {
-                return a;
-            }
-        }
-        return null;
+    	Cluster c = clusterFromSwitch.get(d);
+        return archipelagoFromCluster.get(c);
     }
 
-    public void setPathCosts(Path p) {
-        U64 cost = U64.ZERO;
+    public void setPathCosts(Path p, Map<Link, Integer> linkCost) {
+        U64 latency = U64.ZERO;
+        Integer cost = 0;
 
         // Set number of hops. Assuming the list of NPTs is always even.
         p.setHopCount(p.getPath().size()/2);
@@ -962,15 +979,24 @@ public class TopologyInstance {
                 if (l.getSrc().equals(src) && l.getDst().equals(dst) &&
                         l.getSrcPort().equals(srcPort) && l.getDstPort().equals(dstPort)) {
                     log.debug("Matching link found: {}", l);
-                    cost = cost.add(l.getLatency());
+                    // Add Latency
+                    U64 _latency = l.getLatency();
+                    latency = latency.add(_latency);
+                    
+                    // Add Cost
+                    Integer _cost = (linkCost == null) ? null : linkCost.get(l);
+                    if (_cost == null) {
+                    	_cost = 1;
+                    }
+                    cost += _cost;
                 }
             }
         }
 
-        p.setLatency(cost);
+        p.setLatency(latency);
+        p.setCost(cost);
         log.debug("Total cost is {}", cost);
         log.debug(p.toString());
-
     }
 
     private List<Path> yens(DatapathId src, DatapathId dst, Integer K, Archipelago aSrc, Archipelago aDst) {
@@ -1016,7 +1042,7 @@ public class TopologyInstance {
         Path newroute = buildPath(new PathId(src, dst), bt); /* guaranteed to be in same tree */
 
         if (newroute != null && !newroute.getPath().isEmpty()) { /* should never be null, but might be empty */
-            setPathCosts(newroute);
+            setPathCosts(newroute, linkCost);
             A.add(newroute);
             log.debug("Found shortest path in Yens {}", newroute);
         }
@@ -1076,7 +1102,7 @@ public class TopologyInstance {
                 totalNpt.addAll(rootPath.getPath());
                 totalNpt.addAll(spurPath.getPath());
                 Path totalPath = new Path(new PathId(src, dst), totalNpt);
-                setPathCosts(totalPath);
+                setPathCosts(totalPath, linkCost);
 
                 log.trace("Spur Node: {}", spurNode);
                 log.trace("Root Path: {}", rootPath);
@@ -1429,4 +1455,381 @@ public class TopologyInstance {
     public Set<DatapathId> getArchipelagoIds() {
         return archipelagos.stream().map(Archipelago::getId).collect(Collectors.toSet());
     }
+
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Creates multicast groups using multicasting participant table
+     * 
+     * @return
+     */
+    private void identifyMutlticastGroups() {
+		for (IPAddress<?> group: 
+			TopologyManager.multicastService.getAllParticipantGroups()) {
+			BigInteger mgId = MulticastUtils.MgIdFromMcastIP(group);
+			Set<MacVlanPair> intfSet = 
+					TopologyManager.multicastService.getParticipantIntfs(group);
+			for (MacVlanPair intf: intfSet) {
+				Set<NodePortTuple> attachmentPoints = 
+						TopologyManager.multicastService.getParticipantAP(group, intf);
+				for (NodePortTuple ap: attachmentPoints) {
+					addParticipant(mgId, intf, ap, false);
+				}
+			}
+		}
+    }
+    
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Computes multicast paths
+     * for a given collection of multicast groups
+     * Note: Each mg is unique in all archipelagos
+     * 
+     * @return
+     */
+    protected void computeMulticastPaths(Collection<MulticastGroup> mgs) {
+    	if (mgs == null) {
+    		// Select all multicast groups in all archipelagos
+    		pathcacheMF.clear();
+    		mgs = new HashSet<MulticastGroup>();
+    		for (Archipelago a: archipelagos) {
+    			mgs.addAll(a.getMulticastGroups());
+    		}
+    	}
+    	if (!mgs.isEmpty()) {
+    		for (MulticastGroup mg: mgs) {
+	    		Archipelago a = mg.getArchipelago();
+	    		for (DatapathId swId: a.getSwitches()) {
+					MulticastPathId mPathId = new MulticastPathId(swId, mg.getId());
+					MulticastPath mPath = computeMulticastPath(mPathId);
+					if (mPath != null) {
+						pathcacheMF.put(mPathId, mPath);
+					}
+	    		}
+	    	}
+    	}
+    }
+
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Computes multicast path for a given mPathId
+     * 
+     * @return MulticastPath
+     */
+    private MulticastPath computeMulticastPath(MulticastPathId mPathId) {
+        DatapathId srcSwId = mPathId.getSrc();
+        BigInteger mgId = mPathId.getMgId();
+        
+        /*
+         * Validate Requirements
+         */
+    	Archipelago a = getArchipelago(srcSwId);
+    	if (a == null) {
+    		if (log.isDebugEnabled()) {
+				log.debug(String.format("computeMulticastPath: srcSwId: {s%d}, mgId: {%s},"
+						+ "No suitable archipelago found, Exiting",
+						srcSwId.getLong(), mgId));
+    		}
+    		return null;
+    	}
+    	
+    	MulticastGroup mg = a.getMulticastGroup(mgId);
+    	if (mg == null) {
+    		if (log.isDebugEnabled()) {
+				log.debug(String.format("computeMulticastPath: srcSwId: {s%d}, mgId: {%s},"
+						+ "No suitable multicast group found, Exiting",
+						srcSwId.getLong(), mgId));
+    		}
+    		return null;
+    	}
+    	
+    	Set<DatapathId> swIds = mg.getSwitches();
+    	if (swIds.isEmpty()) {
+    		if (log.isDebugEnabled()) {
+				log.debug(String.format("computeMulticastPath: srcSwId: {s%d}, mgId: {%s},"
+						+ "Multicast group is not attached to any switch, Exiting",
+						srcSwId.getLong(), mgId));
+    		}
+    		return null;
+    	}
+    	
+    	/*
+    	 *  Create MulticastPath
+    	 */
+		MulticastPath result = new MulticastPath(srcSwId, mgId);
+		
+		Set<DatapathId> unselectedSwIds = new HashSet<DatapathId>(swIds);
+		List<DatapathId> selectedSwIds = new ArrayList<DatapathId>();
+		Map<DatapathId, Path> shortestPathSoFarMap = new HashMap<DatapathId, Path>();
+		Path shortestPath = null;
+		
+		// If unselectedSwIds contains the root, add an empty Path
+		// but with valid attachmentPoints to list of paths in result
+		if (unselectedSwIds.contains(srcSwId)) {
+			unselectedSwIds.remove(srcSwId);
+			Set<OFPort> edgePorts = mg.getApPorts(srcSwId);
+			result.add(srcSwId, edgePorts, 
+					new Path(new PathId(srcSwId, srcSwId), ImmutableList.of()));
+		}
+		
+		// Add tree root to selectedSwIds
+		selectedSwIds.add(srcSwId);
+		
+		do {
+			// Add sources into selelectedSwIds from shortestPath
+			// except path root as it is already taken into account
+			if (shortestPath != null) {
+				selectedSwIds = new ArrayList<DatapathId>();
+				List<NodePortTuple> nptList = shortestPath.getPath();
+				for (int index = 1; index < nptList.size(); index += 2) {
+					selectedSwIds.add(nptList.get(index).getNodeId());
+				}
+			}
+			
+			// Update shortestPathSoFarMap for every destination in unselectedSwIds
+			for (DatapathId _dstSwId: unselectedSwIds) {
+				for (DatapathId _srcSwId: selectedSwIds) {
+					PathId pathId = new PathId(_srcSwId, _dstSwId);
+					
+					// Get path (shortest) from _srcSwId to _dstSwId (O(1))
+					List<Path> paths = pathcache.get(pathId);
+					if (paths == null || paths.isEmpty()) {
+						continue;
+					}
+					Path path = paths.get(0);
+					
+					// Get shortestPathSoFar for _dstSwId (O(1))
+					Path shortestPathSoFar = shortestPathSoFarMap.get(_dstSwId);
+					
+					// Compare and update (O(1))
+					// Note: Ensure exclusive paths by using fallback to HopCount
+					if ((shortestPathSoFar == null) || /*first run*/
+							(path.getCost() < shortestPathSoFar.getCost()) ||
+								(path.getCost() == shortestPathSoFar.getCost() && 
+								path.getHopCount() < shortestPathSoFar.getHopCount())) {
+						shortestPathSoFarMap.put(_dstSwId, path);
+					}
+				}
+			}
+			
+			// Exit if shortestPathSoFarMap is empty (after first run)
+			if (shortestPathSoFarMap.isEmpty()) {
+				break;
+			}
+			
+			// Select shortestPath from shortestPathSoFarMap
+			shortestPath = null;
+			for (Path path: shortestPathSoFarMap.values()) {
+				if (shortestPath == null ||
+						path.getCost() < shortestPath.getCost()) {
+					shortestPath = path;
+				}
+			}
+			
+			// Remove from unselectedSwIds & shortestPathSoFarMap
+			DatapathId dstSwId = shortestPath.getId().getDst();
+			unselectedSwIds.remove(dstSwId);
+			shortestPathSoFarMap.remove(dstSwId);
+			
+			// Add to result
+			Set<OFPort> edgePorts = mg.getApPorts(dstSwId);
+			result.add(dstSwId, edgePorts, shortestPath);
+			
+		} while (shortestPathSoFarMap.size() > 0);
+		
+    	if (result.isEmpty())
+    	{
+    		if (log.isDebugEnabled()) {
+				log.debug(String.format("computeMulticastPath: srcSwId: {s%d}, mgId: {%s}, "
+						+ "No path could be formed, Exiting",
+						srcSwId.getLong(), mgId));
+	    	}
+	    	return null;
+    	}
+
+    	return result;
+	}
+    
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Clear multicast paths
+     * for a given collection of multicast groups
+     * 
+     * Notes:
+     * 1. Each mg is unique in all archipelagos
+     * 2. Each mg may no longer be a part of the archipelago 
+     *    but reference remains valid until the end of scope.   
+     * 
+     * @return
+     */
+	protected void clearMulticastPaths(Collection<MulticastGroup> mgs) {
+    	if (mgs != null && !mgs.isEmpty()) {
+    		for (MulticastGroup mg: mgs) {
+	    		Archipelago a = mg.getArchipelago();
+	    		for (DatapathId swId: a.getSwitches()) {
+					MulticastPathId mPathId = new MulticastPathId(swId, mg.getId());
+					pathcacheMF.remove(mPathId);
+	    		}
+	    	}
+    	}
+    }
+	
+	/**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Retrieves Multicast path b/w srcSwId and mgId
+     * 
+     * @param srcSwId
+     * @param mgId
+     * 
+     * @return MulticastPath
+     */
+	public MulticastPath getMulticastPath(DatapathId srcSwId, BigInteger mgId) {
+    	MulticastPathId mPathId = new MulticastPathId(srcSwId, mgId);
+    	MulticastPath mPath = pathcacheMF.get(mPathId);
+
+        return (mPath == null) ? new MulticastPath(mPathId) : mPath;
+    }
+    
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Adds a list of participants to multicast groups
+     * 
+     * @param mgId
+     * @param intf
+     * @param ap
+     * 
+     * @return
+     */
+    protected void addParticipant(BigInteger mgId, MacVlanPair intf, NodePortTuple ap, boolean recomputePaths) {
+		Set<MulticastGroup> updated = new HashSet<MulticastGroup>();
+		DatapathId swId = ap.getNodeId();
+		OFPort port = ap.getPortId();
+		if (!isEdge(swId, port)) {
+			return;
+		}
+		Archipelago a = getArchipelago(swId);
+		if (a == null) {
+			if (log.isErrorEnabled()) {
+				log.error(String.format("addParticipants: mgId: {%s}, attachmentPoint: {%s},"
+						+ "No suitable archipelago found!",
+						mgId, ap));
+			}
+			return;
+		}
+		MulticastGroup mg = a.getMulticastGroup(mgId);
+		if (mg == null) {
+			mg = new MulticastGroup(mgId, a);
+			a.addMulticastGroup(mg);
+			mg.add(intf, ap);
+			updated.add(mg);
+		}
+		else {
+			Set<NodePortTuple> storedAp = mg.getAttachmentPoints(intf);
+			if (storedAp == null || !storedAp.contains(ap)) {
+				mg.add(intf, ap);
+				updated.add(mg);
+			}
+		}
+		if (recomputePaths) {
+			computeMulticastPaths(updated);
+		}
+	}
+
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Remove participants from multicast group
+     * 
+     * @param mgId
+     * @param intf
+     * @param ap
+     * 
+     * @return
+     */
+	protected void removeParticipant(BigInteger mgId, MacVlanPair intf, NodePortTuple ap) {
+		Set<MulticastGroup> updated = new HashSet<MulticastGroup>();
+		Set<MulticastGroup> removed = new HashSet<MulticastGroup>();
+		DatapathId swId = ap.getNodeId();
+		OFPort port = ap.getPortId();
+		if (!isEdge(swId, port)) {
+			return;
+		}
+		Archipelago a = getArchipelago(swId);
+		if (a == null) {
+			if (log.isErrorEnabled()) {
+				log.error(String.format("addParticipants: mgId: {%s}, attachmentPoint: {%s},"
+						+ "No suitable archipelago found!",
+						mgId, ap));
+			}
+			return;
+		}
+		MulticastGroup mg = a.getMulticastGroup(mgId);
+		if (mg != null) {
+			Set<NodePortTuple> storedAp = mg.getAttachmentPoints(intf);
+			if (storedAp != null && storedAp.contains(ap)) {
+				mg.remove(intf, ap);
+				if (mg.isEmpty()) {
+					a.removeMulticastGroup(mg);
+					removed.add(mg);
+				}
+				else {
+					updated.add(mg);
+				}
+			}
+		}
+		clearMulticastPaths(removed);
+		computeMulticastPaths(updated);
+	}
+	
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Remove participants from multicast group
+     * 
+     * @param mgId
+     * @param intf
+     * 
+     * @return
+     */
+	protected void removeParticipant(BigInteger mgId, MacVlanPair intf) {
+		Set<MulticastGroup> updated = new HashSet<MulticastGroup>();
+		Set<MulticastGroup> removed = new HashSet<MulticastGroup>();
+		for (Archipelago a: archipelagos) {
+			MulticastGroup mg = a.getMulticastGroup(mgId);
+			if (mg != null) {
+				if (mg.hasIntf(intf)) {
+					mg.remove(intf);
+					if (mg.isEmpty()) {
+						a.removeMulticastGroup(mg);
+						removed.add(mg);
+					}
+					else {
+						updated.add(mg);
+					}
+				}
+			}
+		}
+		updated.removeAll(removed);
+		clearMulticastPaths(removed);
+		computeMulticastPaths(updated);
+	}
+	
+    /**
+     * @author Souvik Das (souvikdas95@yahoo.co.in)
+     * 
+     * Removes all participants from all multicast groups
+     * 
+     * @return
+     */
+	protected void clearParticipants() {
+		for (Archipelago a: archipelagos) {
+			a.clearMulticastGroups();
+		}
+		pathcacheMF.clear();
+	}
 } 

--- a/src/main/java/net/floodlightcontroller/util/MulticastUtils.java
+++ b/src/main/java/net/floodlightcontroller/util/MulticastUtils.java
@@ -1,0 +1,38 @@
+package net.floodlightcontroller.util;
+
+import java.math.BigInteger;
+
+import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.IPAddress;
+import org.projectfloodlight.openflow.types.IPv4Address;
+import org.projectfloodlight.openflow.types.IPv6Address;
+
+/**
+ * @author Souvik Das (souvikdas95@yahoo.co.in)
+ * 
+ * Utility methods for Multicasting
+ * 
+ */ 
+public class MulticastUtils {
+    /*
+     * Generates MgId from Mcast IPAddress (For internal use only)
+     */
+	public static BigInteger MgIdFromMcastIP(IPAddress<?> mcastIp) {
+		return new BigInteger(mcastIp.getBytes());
+	}
+	
+	/*
+	 * Generates Mcast IPAddress from MgId (For internal use only)
+	 */
+	public static IPAddress<?> McastIPFromMgId(BigInteger mgId) {
+		byte[] bMgId = mgId.toByteArray();
+		byte[] bIp = new byte[bMgId.length];
+		if (bIp.length == 4) {	/* IPv4 Multicast */
+			return IPv4Address.of(bIp);
+		}
+		if (bIp.length == 16) { /* IPv6 Multicast */
+			return IPv6Address.of(bIp);
+		}
+		return null;
+	}
+}

--- a/src/main/java/net/floodlightcontroller/util/RWSync.java
+++ b/src/main/java/net/floodlightcontroller/util/RWSync.java
@@ -1,0 +1,85 @@
+package net.floodlightcontroller.util;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * @author Souvik Das (souvikdas95@yahoo.co.in)
+ * 
+ * Reader-Writer Synchronization Class
+ * 
+ */
+public class RWSync {
+	private final Semaphore in;
+	private final Semaphore out;
+	private final Semaphore wrt;
+	private int ctrin;
+	private int ctrout;
+	private boolean wait;
+	
+	public RWSync() {
+		in = new Semaphore(1);
+		out = new Semaphore(1);
+		wrt = new Semaphore(0);
+		ctrin = 0;
+		ctrout = 0;
+		wait = false;
+	}
+	
+	public void reset() {
+		in.release();
+		out.release();
+		wrt.tryAcquire();
+		ctrin = 0;
+		ctrout = 0;
+		wait = false;
+	}
+	
+	public void readLock() {
+		try {
+			in.acquire();
+			ctrin++;
+			in.release();
+		}
+		catch (InterruptedException e) {
+			reset();
+		}
+	}
+	
+	public void readUnlock() {
+		try {
+			out.acquire();
+			ctrout++;
+			if (wait && ctrin == ctrout) {
+				wrt.release();
+			}
+			out.release();
+		}
+		catch (InterruptedException e) {
+			reset();
+		}
+	}
+	
+	public void writeLock() {
+		try {
+			in.acquire();
+			out.acquire();
+			if (ctrin == ctrout) {
+				out.release();
+			}
+			else {
+				wait = true;
+				out.release();
+				wrt.acquire();
+				wait = false;
+			}
+		}
+		catch (InterruptedException e) {
+			reset();
+		}
+	}
+	
+	public void writeUnlock() {
+		in.release();
+	}
+};
+

--- a/src/main/resources/META-INF/services/net.floodlightcontroller.core.module.IFloodlightModule
+++ b/src/main/resources/META-INF/services/net.floodlightcontroller.core.module.IFloodlightModule
@@ -17,6 +17,7 @@ org.sdnplatform.sync.internal.SyncManager
 org.sdnplatform.sync.internal.SyncTorture
 net.floodlightcontroller.simpleft.FT
 net.floodlightcontroller.staticentry.StaticEntryPusher
+net.floodlightcontroller.multicasting.internal.MulticastManager
 net.floodlightcontroller.topology.TopologyManager
 net.floodlightcontroller.forwarding.Forwarding
 net.floodlightcontroller.loadbalancer.LoadBalancer

--- a/src/main/resources/floodlightdefault.properties
+++ b/src/main/resources/floodlightdefault.properties
@@ -7,6 +7,7 @@ net.floodlightcontroller.debugcounter.DebugCounterServiceImpl,\
 net.floodlightcontroller.perfmon.PktInProcessingTime,\
 net.floodlightcontroller.staticentry.StaticEntryPusher,\
 net.floodlightcontroller.restserver.RestApiServer,\
+net.floodlightcontroller.multicasting.internal.MulticastManager,\
 net.floodlightcontroller.topology.TopologyManager,\
 net.floodlightcontroller.routing.RoutingManager,\
 net.floodlightcontroller.forwarding.Forwarding,\

--- a/src/main/resources/neutron.properties
+++ b/src/main/resources/neutron.properties
@@ -8,6 +8,7 @@ net.floodlightcontroller.debugcounter.DebugCounterServiceImpl,\
 net.floodlightcontroller.perfmon.PktInProcessingTime,\
 net.floodlightcontroller.staticentry.StaticEntryPusher,\
 net.floodlightcontroller.restserver.RestApiServer,\
+net.floodlightcontroller.multicasting.internal.MulticastManager,\
 net.floodlightcontroller.topology.TopologyManager,\
 net.floodlightcontroller.forwarding.Forwarding,\
 net.floodlightcontroller.virtualnetwork.VirtualNetworkFilter,\


### PR DESCRIPTION
This PR includes a generic Multicasting Module.

## Description
A Multicasting module is supposed to be able to form paths from any source to any set of destinations. This module does the same. Here, a destination primary is denoted by a Multicast Address and represents a set of devices. It could contain any device attached to any port of any switch. Hence, it's denoted by a **MacVlanPair** and a set of **attachmentPoints**. While attachmentPoints are enough to determine destinations, we also require to make sure when the attachmentPoints become no longer valid. For this, we have a provisioning in DeviceManager's service that can tell when a device is moved (change in attachmentPoints) or removed (either attachmentPoint switch goes down, or port goes down). Hence, we require a way to uniquely identify devices and as per documentation, a pair of MacAddress and VlanId (MacVlanPair) is perfect for that purpose. Additionally, it also checks if when a Vlan changes for a device.

It provides 2 interfaces: 
1. **IMulticastListener**: This provides the callback methods for when a Participant is/are added/removed.
2. **IMulticastService**: This provides basic functionality to manage the Participants as well as register listeners for IMulticastListener.

For **deviceMoved** scenario, it has the ability to determine, if the moved attachmentPoint is valid or not (belongs to the same OpenFlow Island). It does so by using TopologyManager's service to map attachmentPoints based on their OpenFlow Island (Strong connected component of switches or Clusters). That way, it updates the table entry.

For **deviceRemoved** scenario, it simply removes every entry for each MacVlanPair associated with the device from the table.

For **deviceVlanChanged** changed scenario, it checks if a VlanId associated with the device is a participant and if it is no longer present, then prunes each matching entry accordingly from the table.

It create a ParticipantTable to register devices. Each participant comprises of a **group** _(Multicast IPAddress)_, a **set of devices** _(MacVlanPair)_ in that group and a **set of attachmentPoints** _(SwitchPort/NodePortTuple)_ for each device in the group.

## Module Dependencies:
1. IDeviceService
2. ITopologyService

## Module Services:
1. IMulticastService

### At Topology:

1. Implements **IMulticastListener** and uses **IMulticastService** to add itself as a listener to monitor changes in Participants and propagate them to current **TopologyInstance**.
2. **TopologyInstance** uses **MulticastGroup** to form **MulticastPath** and caches them for use by other modules.
3. A **MulticastGroup** holds participant device _(MacVlanPair)_ to attachmentPoints and Switches mappings per Archipelago. This gets updated in real-time for the same **TopologyInstance** and is used for:
	1. Building **MulticastPaths** in real-time by listening to participant changes over a given set of archipelagos for current **TopologyInstance**.
	2. Re-building **MulticastPaths** when new **TopologyInstance** is created and archipelagos are re-identified. 
	**Note:** This could have been put outside the **TopologyInstance**, only if key **archipelagoId** had remained persistent after Topology update i.e. Changes in archipelago are hard to manage from outside **TopologyInstance**. Also, the reason why it had to be kept inside the Archipelago structure and not in **TopologyInstance** is because it is strongly bound to an archipelago and resolving it directly from **TopologyInstance**, would require another hash-able structure that holds 2 keys - **mgId** and **archipelagoId**. So, instead of going through that trouble, it's better to keep it inside the **Archipelago** class and to avoid serialization later, its Set is made "_transient_".

4. A **MulticastPath** holds paths, that form the trunks and branches of a tree that is rooted at source switch and edges out at destination switches. It's made using **MulticastGroup** but is not affected in real-time and is used for exporting to other modules, such as Forwarding via **getMulticastPath()** method.
5. **IRoutingService** for **TopologyManager** provides **getMulticastPath()** method, which is used by **Forwarding** module for making Multicast forwarding decisions.

### At Forwarding:

1. Reduce **FLOWSET_BITS** from 28 to 24 to match usable bits from **OFPG_MAX** in Forwarding for matching 1-to-1, **flowSetId** of cookies in **OFFlowMods** with **groupId** in **OFGroupMods** during **FLOW_REMOVED**. _This needs to be done because Groups in GroupTable don't expire unlike Flows in FlowTable._ 
**Note:** We can't keep a map between them inside the controller because, in case the controller fails, HA can help remove the Groups even without a map. Also, we can't save Groups inside the switches permanently because flowSetId will keep changing for every packet received at the controller that needs to be forwarded and each flow is temporary, with limited idle_timeout.
2. **doMulticast()** method is called upon receiving a Multicast packet, both for L2/L3 and IPv4/IPv6 and others.
3. **pushMulticastFlow()** method uses **MulticastPath** to generate an inPort and outPorts for every switch in path, leading to attachmentPoints in O(n) time complexity. Then for each switch in path:
	a. A **PacketOut** message to only attachmentPoint ports that leads to destination devices is created.
	b. An **OFGroupMod** message with groupId set to flowSetId and bucket actions, each leading to an outPort of the switch is created.
	c. An **OFFlowMod** message switch input match, priority, timeout, SEND_FLOW_REM enabled and actionGroup pointing to groupId is created.
	d. All 3 messages are sent together to the switch.
4. **IOFMessageListener** interface provides **FLOW_REMOVED** callback to help remove associated Groups from GroupTable using flowSetId/groupId from cookie.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This solves the missing generic Multicasting feature. Sure, a flow could be manually pushed to implement the same but that would be static and won't reflect actual topology and changes. Moreover, that won't do On-The-Go multicasting or support any dynamic multicasting protocol like IGMP or DVMRP. This, module however can.
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. I created a simple IGMP Manager module that can listen to IGMPv3 group membership messages and accordingly, create and remove participants in the table.
2. I created a verbose Multicast VideoStreaming application over Mininet that can create various topologies and parallely stream various media over various sources and destinations. Its details and test environment used, can be found here: https://github.com/souvikdas95/SDN_VideoStreaming
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
