### PR TITLE
Topology Bug Fixes & Optimizations

### DIFF
--- a/src/main/java/net/floodlightcontroller/topology/Archipelago.java
+++ b/src/main/java/net/floodlightcontroller/topology/Archipelago.java
@@ -81,14 +81,13 @@ public class Archipelago {
         Archipelago that = (Archipelago) o;
 
         if (!id.equals(that.id)) return false;
-        return clusters.equals(that.clusters);
 
+        return true;
     }
 
     @Override
     public int hashCode() {
         int result = id.hashCode();
-        result = 31 * result + clusters.hashCode();
         return result;
     }
 


### PR DESCRIPTION
1. Fixed a bug in **identifyArchipelagos()** where in the base case, **archipelagoFromCluster** wasn't getting updated. (It is a requirement for the applied optimization)
2. Optimized **isInSameArchipelago(DatapathId, DatapathId)** and **getArchipelago(DatapathId)** method (O(n<sup>2</sup>) to O(1)).
3. Changed hashCode and equals methods in Archipelago to not include clusters as 2 archipelagos can't have the same or in fact any common cluster(s) at any state of the current **TopologyInstance** of **TopologyManager**. Even in the method **identifyArchipelagos()**, where it attempts to merge the 2 sets, each of them is bipartite already.
4. Reverted **archipelagos** to use Set instead of List because when we need to change a key in HashSet, we are supposed to remove the key, change it and add it back. All that can happen in O(1). We don't need to use a List in that case.
5. Fixed a major bug with **computeBroadcastPortsPerArchipelago()** in getting archipelago Id of a switch that is not connected to any other switch. Since such a switch is not part of any archipelago, retrieving its **Archipelago** Object and calling its **getId()** method results in _NullPointerException_, breaking the topology completely.

Note: No additional tests are required for this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All existing tests passed.
